### PR TITLE
Bugfix for paren placement around (local_ E)

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1958,7 +1958,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_apply
       ( {pexp_desc= Pexp_extension ({txt= "extension.local"; _}, PStr []); _}
       , [(Nolabel, sbody)] ) ->
-      fmt "local_@ " $ fmt_expression c (sub_exp ~ctx sbody)
+      Params.parens_if parens c.conf
+        (fmt "local_@ " $ fmt_expression c (sub_exp ~ctx sbody))
   | Pexp_apply (e0, [(Nolabel, e1)]) when Exp.is_prefix e0 ->
       hvbox 2
         (Params.Exp.wrap c.conf c.source ~loc:pexp_loc ~parens

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -9,6 +9,7 @@ let f () = local_
   let local_ r = 1 in
   let local_ f : 'a. 'a -> 'a = fun x -> local_ x in
   let local_ g a b c : int = 1 in
+  let () = g (local_ fun () -> ()) in
   local_ "asdfasdfasdfasdfasdfasdfasdf"
 
 type 'a r = {mutable a: 'a; nonlocal_ b: 'a; global_ c: 'a}


### PR DESCRIPTION
Sometimes the expression `local_ ...` needs surrounding parenthesis (e.g. when used as an argument), but these were not correctly inserted by ocamlformat.

Signed-off-by: Stephen Dolan <sdolan@janestreet.com>