### PR TITLE
Don't desugar `let _ = local_ x`

### DIFF
--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -14,7 +14,8 @@ module Extensions = Extensions
 include Parsetree
 
 (* Enable all language extensions *)
-let () = List.iter ~f:Language_extension.enable Language_extension.all
+let () =
+  List.iter ~f:Language_extension.enable Language_extension.max_compatible
 
 let equal_core_type : core_type -> core_type -> bool = Poly.equal
 

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -550,6 +550,15 @@ let split_global_flags_from_attrs atrs =
   | [`Global], atrs -> (false, true, atrs)
   | _ -> (false, false, atrs)
 
+let is_layout attr =
+  match attr.attr_name.txt with
+  | "any" -> true
+  | "value" -> true
+  | "void" -> true
+  | "immediate" -> true
+  | "immediate64" -> true
+  | _ -> false
+
 let rec fmt_extension_aux c ctx ~key (ext, pld) =
   match (ext.txt, pld, ctx) with
   (* Quoted extensions (since ocaml 4.11). *)
@@ -754,8 +763,15 @@ and fmt_arrow_param c ctx
    [xtyp] should be parenthesized. [constraint_ctx] gives the higher context
    of the expression, i.e. if the expression is part of a `fun`
    expression. *)
+(* I think instead of having a [tydecl_param] argument here, the right thing
+   would be for [xtyp] to provide enough information to determine whether we
+   are printing a type parameter in a typedecl. But it doesn't, and that
+   change would be a much bigger diff and make rebasing on upstream harder in
+   the future. When layouts are upstreamed and upstream ocamlformat gets
+   support for them, we should remove tydecl_param and go with whatever their
+   solution is. *)
 and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
-    ({ast= typ; ctx} as xtyp) =
+    ?(tydecl_param = false) ({ast= typ; ctx} as xtyp) =
   protect c (Typ typ)
   @@
   let {ptyp_desc; ptyp_attributes; ptyp_loc; _} = typ in
@@ -780,12 +796,20 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   let doc, atrs = doc_atrs ptyp_attributes in
   Cmts.fmt c ptyp_loc
   @@ (fun k -> k $ fmt_docstring c ~pro:(fmt "@ ") doc)
-  @@ ( if List.is_empty atrs then Fn.id
-       else fun k ->
-         hvbox 0 (Params.parens c.conf (k $ fmt_attributes c ~pre:Cut atrs))
-     )
+  @@ ( match atrs with
+     | [] -> Fn.id
+     | [attr] when is_layout attr ->
+         Fn.id
+         (* layout annotations on type params are printed by the type
+            parameter printer. Revisit when we have support for pretty layout
+            annotations in more places. *)
+     | _ ->
+         fun k ->
+           hvbox 0
+             (Params.parens_if (not tydecl_param) c.conf
+                (k $ fmt_attributes c ~pre:Cut atrs) ) )
   @@
-  let parens = parenze_typ xtyp in
+  let parens = (not tydecl_param) && parenze_typ xtyp in
   hvbox_if box 0
   @@ Params.parens_if
        (match typ.ptyp_desc with Ptyp_tuple _ -> false | _ -> parens)
@@ -3271,15 +3295,28 @@ and fmt_value_description ?ext c ctx vd =
     $ fmt_item_attributes c ~pre:(Break (1, 2)) atrs
     $ doc_after )
 
+and fmt_tydcl_param c ctx ty =
+  fmt_core_type ~tydecl_param:true c (sub_typ ~ctx ty)
+  $
+  match ty.ptyp_attributes with
+  | [] | _ :: _ :: _ -> noop
+  | [attr] -> fmt_if_k (is_layout attr) (fmt "@ :@ " $ str attr.attr_name.txt)
+
 and fmt_tydcl_params c ctx params =
-  fmt_if_k
-    (not (List.is_empty params))
-    ( wrap_fits_breaks_if ~space:false c.conf
-        (List.length params > 1)
-        "(" ")"
+  let empty, parenize =
+    match params with
+    | [] -> (true, false)
+    | [(p, _)] -> (
+        ( false
+        , match p.ptyp_attributes with
+          | [] | _ :: _ :: _ -> false
+          | [attr] -> is_layout attr ) )
+    | _ :: _ :: _ -> (false, true)
+  in
+  fmt_if_k (not empty)
+    ( wrap_fits_breaks_if ~space:false c.conf parenize "(" ")"
         (list params (Params.comma_sep c.conf) (fun (ty, vc) ->
-             fmt_variance_injectivity c vc
-             $ fmt_core_type c (sub_typ ~ctx ty) ) )
+             fmt_variance_injectivity c vc $ fmt_tydcl_param c ctx ty ) )
     $ fmt "@ " )
 
 and fmt_class_params c ctx params =

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -763,13 +763,13 @@ and fmt_arrow_param c ctx
    [xtyp] should be parenthesized. [constraint_ctx] gives the higher context
    of the expression, i.e. if the expression is part of a `fun`
    expression. *)
-(* I think instead of having a [tydecl_param] argument here, the right thing
-   would be for [xtyp] to provide enough information to determine whether we
-   are printing a type parameter in a typedecl. But it doesn't, and that
-   change would be a much bigger diff and make rebasing on upstream harder in
-   the future. When layouts are upstreamed and upstream ocamlformat gets
-   support for them, we should remove tydecl_param and go with whatever their
-   solution is. *)
+(* CR layouts: Instead of having a [tydecl_param] argument here, the right thing
+   would be for [xtyp] to provide enough information to determine whether we are
+   printing a type parameter in a typedecl. But it doesn't, and that change
+   would be a much bigger diff and make rebasing on upstream harder in the
+   future. When layouts are upstreamed and upstream ocamlformat gets support for
+   them, we should remove tydecl_param and go with whatever their solution
+   is. *)
 and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
     ?(tydecl_param = false) ({ast= typ; ctx} as xtyp) =
   protect c (Typ typ)
@@ -800,9 +800,9 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
      | [] -> Fn.id
      | [attr] when is_layout attr ->
          Fn.id
-         (* layout annotations on type params are printed by the type
-            parameter printer. Revisit when we have support for pretty layout
-            annotations in more places. *)
+         (* CR layouts v1.5: layout annotations on type params are printed by
+            the type parameter printer. Revisit when we have support for pretty
+            layout annotations in more places. *)
      | _ ->
          fun k ->
            hvbox 0
@@ -3298,6 +3298,19 @@ and fmt_value_description ?ext c ctx vd =
 and fmt_tydcl_param c ctx ty =
   fmt_core_type ~tydecl_param:true c (sub_typ ~ctx ty)
   $
+  (* CR layouts v1.5: When we added the syntax for layout annotations on type
+     parameters to the parser, we also made it possible for people to put
+     arbitrary attributes on type parameters.  Previously, the parser didn't
+     accept attributes at all here, though there has always been a place in the
+     parse tree.
+
+     The parser currently allows you to have either a pretty layout annotation
+     or arbitrary attributes, but not both.  A pretty layout annotation only
+     parses if it's the only attribute, so we only print the pretty syntax in
+     that case. Probably we'll change this in v1.5.
+
+     In the case of multiple attributes, which may include layouts, they'll be
+     printed as normal attributes by [fmt_core_type]. So we do nothing here.  *)
   match ty.ptyp_attributes with
   | [] | _ :: _ :: _ -> noop
   | [attr] -> fmt_if_k (is_layout attr) (fmt "@ :@ " $ str attr.attr_name.txt)

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -326,8 +326,17 @@ module Let_binding = struct
           ( { pexp_desc= Pexp_extension ({txt= "extension.local"; _}, PStr [])
             ; _ }
           , [(Nolabel, sbody)] ) ->
-          let sattrs, _ = check_local_attr sbody.pexp_attributes in
-          let sbody = {sbody with pexp_attributes= sattrs} in
+          let islocal, sbody =
+            (* The desugaring is only valid for some patterns. The pattern
+               part must still be rewritten as the parser duplicated the type
+               annotations and extensions into the pattern and the
+               expression. *)
+            match lb_pat.ppat_desc with
+            | Ppat_any -> (false, lb_exp)
+            | _ ->
+                let sattrs, _ = check_local_attr sbody.pexp_attributes in
+                (true, {sbody with pexp_attributes= sattrs})
+          in
           let pattrs, _ = check_local_attr lb_pat.ppat_attributes in
           let pat = {lb_pat with ppat_attributes= pattrs} in
           let fake_ctx =
@@ -338,7 +347,7 @@ module Let_binding = struct
               ; lb_attributes= []
               ; lb_loc= Location.none }
           in
-          ( true
+          ( islocal
           , fake_ctx
           , sub_pat ~ctx:fake_ctx pat
           , sub_exp ~ctx:fake_ctx sbody )

--- a/test/passing/layouts.ml
+++ b/test/passing/layouts.ml
@@ -1,0 +1,17 @@
+(* Layout annotations work on type params, including when there are multiple
+   type params. *)
+type ('a : void) t1 = 'a
+
+type ('b, 'a : immediate) t2 = 'a
+
+type ('b, 'a : immediate64, 'c) t3 = 'a
+
+type ('b, 'a : immediate, 'c : any) t4 = 'a
+
+(* We don't reformat attributes on type parameters to layout annotations
+   unless there is just one attribute and it's a layout. *)
+type 'a[@immediate] [@foo] t5
+
+type 'a[@foo] [@immediate] t6
+
+type 'a[@baz] t7

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -25,3 +25,5 @@ type ('a, 'b) cfn =
   a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
 
 type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+let _ = local_ ()

--- a/vendor/diff-parsers-ext-parsewyc.patch
+++ b/vendor/diff-parsers-ext-parsewyc.patch
@@ -1,5 +1,5 @@
---- ocaml-4.13-extended/lexer.mll
-+++ parse-wyc/lib/lexer.mll
+--- parser-extended/lexer.mll
++++ parser-recovery/lib/lexer.mll
 @@@@
  let is_keyword name = Hashtbl.mem keyword_table name
  
@@ -148,15 +148,15 @@
          string lexbuf
        }
    | eof
---- ocaml-4.13-extended/parser.mly
-+++ parse-wyc/lib/parser.mly
+--- parser-extended/parser.mly
++++ parser-recovery/lib/parser.mly
 @@@@
     text comprised between the markers [BEGIN AVOID] and -----------
     [END AVOID] has been removed. This file should be formatted in
     such a way that this results in a clean removal of certain
     symbols, productions, or declarations. */
  
-+/* parse-wyc:
++/* parser-recovery:
 +   Compared to upstream, rules with errors on the RHS (between [BEGIN AVOID]
 +   and [END AVOID]) are commented. Some rules definition are kept to minimize
 +   the diff as long as the call sites are commented. This is necessary to
@@ -168,15 +168,6 @@
  open Asttypes
  open Longident
  open Parsetree
- open Ast_helper
- open Docstrings
- open Docstrings.WithMenhir
-+open Let_binding
- 
- let mkloc = Location.mkloc
- let mknoloc = Location.mknoloc
- 
- let make_loc (startpos, endpos) = {
 @@@@
    Attr.mk ~loc:Location.none local_ext_loc (PStr [])
  
@@ -195,21 +186,34 @@
    {pat with ppat_attributes = local_attr :: pat.ppat_attributes}
 @@@@
  
- let mkpat_opt_constraint ~loc p = function
-   | None -> p
-   | Some typ -> mkpat ~loc (Ppat_constraint(p, typ))
+ let nonlocal_attr loc =
+   Attr.mk ~loc:Location.none (nonlocal_loc loc) (PStr [])
+ 
+ let mkld_global ld loc =
+-  { ld with pld_attributes = global_attr loc :: ld.pld_attributes }
++  { ld with pld_attributes = (global_attr loc) :: ld.pld_attributes }
+ 
+ let mkld_nonlocal ld loc =
+-  { ld with pld_attributes = nonlocal_attr loc :: ld.pld_attributes }
++  { ld with pld_attributes = (nonlocal_attr loc) :: ld.pld_attributes }
+ 
+ let mkld_global_maybe gbl ld loc =
+   match gbl with
+   | Global -> mkld_global ld loc
+   | Nonlocal -> mkld_nonlocal ld loc
+@@@@
+   match t1, t2 with
+   | Some t, None -> mkexp ~loc (Pexp_constraint(e, t))
+   | _, Some t -> mkexp ~loc (Pexp_coerce(e, t1, t))
+   | None, None -> assert false
  
 -let syntax_error () =
 -  raise Syntaxerr.Escape_error
-+(*let syntax_error () =
-+  raise Syntaxerr.Escape_error*)
- 
+-
 -let unclosed opening_name opening_loc closing_name closing_loc =
-+(*let unclosed opening_name opening_loc closing_name closing_loc =
-   raise(Syntaxerr.Error(Syntaxerr.Unclosed(make_loc opening_loc, opening_name,
+-  raise(Syntaxerr.Error(Syntaxerr.Unclosed(make_loc opening_loc, opening_name,
 -                                           make_loc closing_loc, closing_name)))
 -
-+                                           make_loc closing_loc, closing_name)))*)
  (* Normal mutable arrays and immutable arrays are parsed identically, just with
     different delimiters.  The parsing is done by the [array_exprs] rule, and the
     [Generic_array] module provides (1) a type representing the possible results,
@@ -254,14 +258,12 @@
  
 -let expecting loc nonterm =
 -    raise Syntaxerr.(Error(Expecting(make_loc loc, nonterm)))
-+
-+(*let expecting loc nonterm =
-+    raise Syntaxerr.(Error(Expecting(make_loc loc, nonterm)))*)
- 
+-
  (* Using the function [not_expecting] in a semantic action means that this
     syntactic form is recognized by the parser but is in fact incorrect. This
     idiom is used in a few places to produce ad hoc syntax error messages. *)
  
+ (* This idiom should be used as little as possible, because it confuses the
 @@@@
     (unexpected) syntax error and do not achieve the desired effect. This could
     also lead a completion system to propose completions which in fact are
@@ -270,29 +272,31 @@
  
 -let not_expecting loc nonterm =
 -    raise Syntaxerr.(Error(Not_expecting(make_loc loc, nonterm)))
-+(*let not_expecting loc nonterm =
-+    raise Syntaxerr.(Error(Not_expecting(make_loc loc, nonterm)))*)
+-
+ let mk_builtin_indexop_expr ~loc (pia_lhs, _dot, pia_paren, idx, pia_rhs) =
+   mkexp ~loc
+     (Pexp_indexop_access
+        { pia_lhs; pia_kind= Builtin idx; pia_paren; pia_rhs })
  
- (* Helper functions for desugaring array indexing operators *)
- type paren_kind = Paren | Brace | Bracket
+ let mk_dotop_indexop_expr ~loc (pia_lhs, (path, op), pia_paren, idx, pia_rhs) =
+   mkexp ~loc
+     (Pexp_indexop_access
+        { pia_lhs; pia_kind= Dotop (path, op, idx); pia_paren; pia_rhs })
  
- (* We classify the dimension of indices: Bigarray distinguishes
-@@@@
-     | None -> []
-     | Some expr -> [Nolabel, expr] in
-   let args = (Nolabel,array) :: index @ set_arg in
-   mkexp ~loc (Pexp_apply(ghexp ~loc (Pexp_ident fn), args))
- 
+-let paren_to_strings = function
+-  | Paren -> "(", ")"
+-  | Bracket -> "[", "]"
+-  | Brace -> "{", "}"
+-
 -let indexop_unclosed_error loc_s s loc_e =
-+(*let indexop_unclosed_error loc_s s loc_e =
-   let left, right = paren_to_strings s in
+-  let left, right = paren_to_strings s in
 -  unclosed left loc_s right loc_e
-+  unclosed left loc_s right loc_e*)
- 
+-
  let lapply ~loc p1 p2 =
    if !Clflags.applicative_functors
    then Lapply(p1, p2)
    else raise (Syntaxerr.Error(
+                   Syntaxerr.Applicative_path (make_loc loc)))
 @@@@
  let text_str pos = Str.text (rhs_text pos)
  let text_sig pos = Sig.text (rhs_text pos)
@@ -300,7 +304,7 @@
  let text_csig pos = Ctf.text (rhs_text pos)
  let text_def pos =
 -  List.map (fun def -> Ptop_def [def]) (Str.text (rhs_text pos))
-+  (* Change required for parse-wyc *)
++  (* Change required for parser-recovery *)
 +  [Ptop_def (Str.text (rhs_text pos))]
 +  (*List.map (fun def -> Ptop_def [def]) (Str.text (rhs_text pos))*)
  
@@ -309,32 +313,7 @@
    | [] ->
        let post = rhs_post_text endpos in
 @@@@
- 
- let extra_rhs_core_type ct ~pos =
-   let docs = rhs_info pos in
-   { ct with ptyp_attributes = add_info_attrs docs ct.ptyp_attributes }
- 
--type let_binding =
--  { lb_pattern: pattern;
--    lb_expression: expression;
--    lb_is_pun: bool;
--    lb_attributes: attributes;
--    lb_docs: docs Lazy.t;
--    lb_text: text Lazy.t;
--    lb_loc: Location.t; }
--
--type let_bindings =
--  { lbs_bindings: let_binding list;
--    lbs_rec: rec_flag;
--    lbs_extension: string Asttypes.loc option }
--
- let mklb first ~loc (p, e, is_pun) attrs =
-   {
-     lb_pattern = p;
-     lb_expression = e;
-     lb_is_pun = is_pun;
-@@@@
-                else symbol_text_lazy (fst loc));
+     lb_attributes = add_text_attrs text (add_docs_attrs docs attrs);
      lb_loc = make_loc loc;
    }
  
@@ -346,6 +325,26 @@
  let mklbs ext rf lb =
    let lbs = {
      lbs_bindings = [];
+@@@@
+       pdir_name = name;
+       pdir_arg = arg;
+       pdir_loc = make_loc loc;
+     }
+ 
+-let check_layout loc id =
+-  begin
+-    match id with
+-    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
+-    | _ -> expecting loc "layout"
+-  end;
+-  let loc = make_loc loc in
+-  Attr.mk ~loc (mkloc id loc) (PStr [])
+-
+ %}
+ 
+ /* Tokens */
+ 
+ /* The alias that follows each token is used by Menhir when it needs to
 @@@@
  %token BAR                    "|"
  %token BARBAR                 "||"
@@ -409,12 +408,8 @@
  %token RBRACE                 "}"
  %token RBRACKET               "]"
 @@@@
- %token SEMI                   ";"
- %token SEMISEMI               ";;"
- %token HASH                   "#"
- %token <string> HASHOP        "##" (* just an example *)
  %token SIG                    "sig"
--%token SLASH                  "/"
+ %token SLASH                  "/"
  %token STAR                   "*"
  %token <string * Location.t * string option>
         STRING                 "\"hello\"" (* just an example *)
@@ -437,19 +432,6 @@
  %token WHEN                   "when"
  %token WHILE                  "while"
 @@@@
- %token <string * Location.t> COMMENT    "(* comment *)"
- %token <Docstrings.docstring> DOCSTRING "(** documentation *)"
- 
- %token EOL                    "\\n"      (* not great, but EOL is unused *)
- 
--%token <string> TYPE_DISAMBIGUATOR "2" (* just an example *)
--
- /* Precedences and associativities.
- 
- Tokens and rules have precedences.  A reduce/reduce conflict is resolved
- in favor of the first rule (in source file order).  A shift/reduce conflict
- is resolved by comparing the precedence and associativity of the token to
-@@@@
  %right    COLONEQUAL                    /* expr (e := e := e) */
  %nonassoc AS
  %left     BAR                           /* pattern (p|p|p) */
@@ -462,18 +444,6 @@
  %right    AMPERSAND AMPERAMPER          /* expr (e && e && e) */
  %nonassoc below_EQUAL
  %left     INFIXOP0 EQUAL LESS GREATER   /* expr (e OP e OP e) */
- %right    INFIXOP1                      /* expr (e OP e OP e) */
- %nonassoc below_LBRACKETAT
- %nonassoc LBRACKETAT
- %right    COLONCOLON                    /* expr (e :: e :: e) */
- %left     INFIXOP2 PLUS PLUSDOT MINUS MINUSDOT PLUSEQ /* expr (e OP e OP e) */
--%left     PERCENT SLASH INFIXOP3 STAR                 /* expr (e OP e OP e) */
-+%left     PERCENT INFIXOP3 STAR                 /* expr (e OP e OP e) */
- %right    INFIXOP4                      /* expr (e OP e OP e) */
- %nonassoc prec_unary_minus prec_unary_plus /* unary - */
- %nonassoc prec_constant_constructor     /* cf. simple_expr (C versus C x) */
- %nonassoc prec_constr_appl              /* above AS BAR COLONCOLON COMMA */
- %nonassoc below_HASH
 @@@@
  (* The syntax of module expressions is not properly stratified. The cases of
     functors, functor applications, and attributes interact and cause conflicts,
@@ -486,8 +456,8 @@
        { mkmod ~loc:$sloc ~attrs (Pmod_structure s) }
 -  | STRUCT attributes structure error
 -      { unclosed "struct" $loc($1) "end" $loc($4) }
-+  (*| STRUCT attributes structure error
-+      { unclosed "struct" $loc($1) "end" $loc($4) }*)
+-  | SIG error
+-      { expecting $loc($1) "struct" }
    | FUNCTOR attrs = attributes args = functor_args MINUSGREATER me = module_expr
        { wrap_mod_attrs ~loc:$sloc attrs (
            List.fold_left (fun acc (startpos, arg) ->
@@ -501,36 +471,40 @@
        { mkmod ~loc:$sloc (Pmod_constraint(me, mty)) }
 -  | LPAREN module_expr COLON module_type error
 -      { unclosed "(" $loc($1) ")" $loc($5) }
-+  (*| LPAREN module_expr COLON module_type error
-+      { unclosed "(" $loc($1) ")" $loc($5) }*)
    | (* A module expression within parentheses. *)
      LPAREN me = module_expr RPAREN
        { me (* TODO consider reloc *) }
 -  | LPAREN module_expr error
 -      { unclosed "(" $loc($1) ")" $loc($3) }
-+  (*| LPAREN module_expr error
-+      { unclosed "(" $loc($1) ")" $loc($3) }*)
    | (* A core language expression that produces a first-class module.
         This expression can be annotated in various ways. *)
      LPAREN VAL attrs = attributes e = expr_colon_package_type RPAREN
-       { mkmod ~loc:$sloc ~attrs (Pmod_unpack e) }
+       { let (e, ty1, ty2) = e in
+         mkmod ~loc:$sloc ~attrs (Pmod_unpack (e, ty1, ty2)) }
 -  | LPAREN VAL attributes expr COLON error
 -      { unclosed "(" $loc($1) ")" $loc($6) }
 -  | LPAREN VAL attributes expr COLONGREATER error
 -      { unclosed "(" $loc($1) ")" $loc($6) }
 -  | LPAREN VAL attributes expr error
 -      { unclosed "(" $loc($1) ")" $loc($5) }
-+  (*| LPAREN VAL attributes expr COLON error
-+      { unclosed "(" $loc($1) ")" $loc($6) }*)
-+  (*| LPAREN VAL attributes expr COLONGREATER error
-+      { unclosed "(" $loc($1) ")" $loc($6) }*)
-+  (*| LPAREN VAL attributes expr error
-+      { unclosed "(" $loc($1) ")" $loc($5) }*)
  ;
  
  (* The various ways of annotating a core language expression that
     produces a first-class module that we wish to unpack. *)
  %inline expr_colon_package_type:
+@@@@
+ 
+ (* The body (right-hand side) of a module binding. *)
+ module_binding_body:
+     EQUAL me = module_expr
+       { me }
+-  | COLON error
+-      { expecting $loc($1) "=" }
+   | mkmod(
+       COLON mty = module_type EQUAL me = module_expr
+         { Pmod_constraint(me, mty) }
+     | arg_and_pos = functor_arg body = module_binding_body
+         { let (_, arg) = arg_and_pos in
 @@@@
  
  (* -------------------------------------------------------------------------- *)
@@ -573,8 +547,8 @@
        { mkmty ~loc:$sloc ~attrs (Pmty_signature s) }
 -  | SIG attributes signature error
 -      { unclosed "sig" $loc($1) "end" $loc($4) }
-+  (*| SIG attributes signature error
-+      { unclosed "sig" $loc($1) "end" $loc($4) }*)
+-  | STRUCT error
+-      { expecting $loc($1) "sig" }
    | FUNCTOR attrs = attributes args = functor_args
      MINUSGREATER mty = module_type
        %prec below_WITH
@@ -588,13 +562,31 @@
        { $2 }
 -  | LPAREN module_type error
 -      { unclosed "(" $loc($1) ")" $loc($3) }
-+  (*| LPAREN module_type error
-+      { unclosed "(" $loc($1) ")" $loc($3) }*)
    | module_type attribute
        { Mty.attr $1 $2 }
    | mkmty(
        mkrhs(mty_longident)
          { Pmty_ident $1 }
+-    | LPAREN RPAREN MINUSGREATER module_type
+-        { Pmty_functor(Unit, $4) }
+     | module_type MINUSGREATER module_type
+         %prec below_WITH
+         { Pmty_functor(Named (mknoloc None, $1), $3) }
+     | module_type WITH separated_nonempty_llist(AND, with_constraint)
+         { Pmty_with($1, $3) }
+@@@@
+ 
+ (* The body (right-hand side) of a module declaration. *)
+ module_declaration_body:
+     COLON mty = module_type
+       { mty }
+-  | EQUAL error
+-      { expecting $loc($1) ":" }
+   | mkmty(
+       arg_and_pos = functor_arg body = module_declaration_body
+         { let (_, arg) = arg_and_pos in
+           Pmty_functor(arg, body) }
+     )
 @@@@
      let attrs = attrs1 @ attrs2 in
      let loc = make_loc $sloc in
@@ -603,8 +595,6 @@
    }
 -| MODULE ext attributes mkrhs(UIDENT) COLONEQUAL error
 -    { expecting $loc($6) "module path" }
-+(*| MODULE ext attributes mkrhs(UIDENT) COLONEQUAL error
-+    { expecting $loc($6) "module path" }*)
  ;
  
  (* A group of recursive module declarations. *)
@@ -631,21 +621,15 @@
        { $2 }
 -  | LPAREN class_expr error
 -      { unclosed "(" $loc($1) ")" $loc($3) }
-+  (*| LPAREN class_expr error
-+      { unclosed "(" $loc($1) ")" $loc($3) }*)
    | mkclass(
        tys = actual_class_parameters cid = mkrhs(class_longident)
          { Pcl_constr(cid, tys) }
 -    | OBJECT attributes class_structure error
 -        { unclosed "object" $loc($1) "end" $loc($4) }
-+    (*| OBJECT attributes class_structure error
-+        { unclosed "object" $loc($1) "end" $loc($4) }*)
      | LPAREN class_expr COLON class_type RPAREN
          { Pcl_constraint($2, $4) }
 -    | LPAREN class_expr COLON class_type error
 -        { unclosed "(" $loc($1) ")" $loc($5) }
-+    (*| LPAREN class_expr COLON class_type error
-+        { unclosed "(" $loc($1) ")" $loc($5) }*)
      ) { $1 }
    | OBJECT attributes class_structure END
      { mkclass ~loc:$sloc ~attrs:$2 (Pcl_structure $3) }
@@ -672,8 +656,6 @@
        { mkcty ~loc:$sloc ~attrs:$2 (Pcty_signature $3) }
 -  | OBJECT attributes class_sig_body error
 -      { unclosed "object" $loc($1) "end" $loc($4) }
-+  (*| OBJECT attributes class_sig_body error
-+      { unclosed "object" $loc($1) "end" $loc($4) }*)
    | class_signature attribute
        { Cty.attr $1 $2 }
    | LET OPEN override_flag attributes mkrhs(mod_longident) IN class_signature
@@ -701,17 +683,15 @@
  ;
  
 -%inline indexop_error(dot, index):
-+(*%inline indexop_error(dot, index):
-   | simple_expr dot _p=LPAREN index  _e=error
-     { indexop_unclosed_error $loc(_p)  Paren $loc(_e) }
-   | simple_expr dot _p=LBRACE index  _e=error
-     { indexop_unclosed_error $loc(_p) Brace $loc(_e) }
-   | simple_expr dot _p=LBRACKET index  _e=error
-     { indexop_unclosed_error $loc(_p) Bracket $loc(_e) }
+-  | simple_expr dot _p=LPAREN index  _e=error
+-    { indexop_unclosed_error $loc(_p)  Paren $loc(_e) }
+-  | simple_expr dot _p=LBRACE index  _e=error
+-    { indexop_unclosed_error $loc(_p) Brace $loc(_e) }
+-  | simple_expr dot _p=LBRACKET index  _e=error
+-    { indexop_unclosed_error $loc(_p) Bracket $loc(_e) }
 -;
-+;*)
- 
- %inline qualified_dotop: ioption(DOT mod_longident {$2}) DOTOP { $1, $2 };
+-
+ %inline qualified_dotop: ioption(DOT mkrhs(mod_longident) {$2}) DOTOP { $1, $2 };
  
 -expr:
 +expr [@recover.expr Annot.Exp.mk ()]:
@@ -721,23 +701,6 @@
        { let desc, attrs = $1 in
          mkexp_attrs ~loc:$sloc desc attrs }
 @@@@
-   | indexop_expr(qualified_dotop, expr_semi_list, LESSMINUS v=expr {Some v})
-     { mk_indexop_expr user_indexing_operators ~loc:$sloc $1 }
-   | expr attribute
-       { Exp.attr $1 $2 }
- /* BEGIN AVOID */
--  (*
--  | UNDERSCORE
--     { not_expecting $loc($1) "wildcard \"_\"" }
--  *)
-+  (*| UNDERSCORE
-+     { not_expecting $loc($1) "wildcard \"_\"" }*)
- /* END AVOID */
-   | LOCAL seq_expr
-      { mkexp_stack ~loc:$sloc $2 }
- ;
- %inline expr_attrs:
-@@@@
          (mk_newtypes ~loc:$sloc $5 $7).pexp_desc, (ext, attrs) }
    | MATCH ext_attributes seq_expr WITH match_cases
        { Pexp_match($3, $5), $2 }
@@ -745,35 +708,42 @@
        { Pexp_try($3, $5), $2 }
 -  | TRY ext_attributes seq_expr WITH error
 -      { syntax_error() }
-+  (*| TRY ext_attributes seq_expr WITH error
-+      { syntax_error() }*)
-   | IF ext_attributes seq_expr THEN expr ELSE expr
-       { Pexp_ifthenelse($3, $5, Some $7), $2 }
-   | IF ext_attributes seq_expr THEN expr
-       { Pexp_ifthenelse($3, $5, None), $2 }
-   | WHILE ext_attributes seq_expr DO seq_expr DONE
+   | IF ext_attributes seq_expr THEN expr ELSE else_=expr
+       { let ext, attrs = $2 in
+         let br = { if_cond = $3; if_body = $5; if_attrs = attrs } in
+         let ite =
+           match else_.pexp_desc with
 @@@@
+       { Pexp_lazy $3, $2 }
  ;
- 
- simple_expr:
-   | LPAREN seq_expr RPAREN
-       { reloc_exp ~loc:$sloc $2 }
+ %inline do_done_expr:
+   | DO e = seq_expr DONE
+       { e }
+-  | DO seq_expr error
+-      { unclosed "do" $loc($1) "done" $loc($2) }
+ ;
+ %inline expr_:
+   | simple_expr nonempty_llist(labeled_simple_expr)
+       { Pexp_apply($1, $2) }
+   | expr_comma_list %prec below_COMMA
+@@@@
+   | LPAREN e = seq_expr RPAREN
+       { match e.pexp_desc with
+         | Pexp_pack _ ->
+             mkexp ~loc:$sloc (Pexp_parens e)
+         | _ -> reloc_exp ~loc:$sloc e }
 -  | LPAREN seq_expr error
 -      { unclosed "(" $loc($1) ")" $loc($3) }
-+  (*| LPAREN seq_expr error
-+      { unclosed "(" $loc($1) ")" $loc($3) }*)
    | LPAREN seq_expr type_constraint RPAREN
        { mkexp_constraint ~loc:$sloc $2 $3 }
    | indexop_expr(DOT, seq_expr, { None })
-       { mk_indexop_expr builtin_indexing_operators ~loc:$sloc $1 }
+       { mk_builtin_indexop_expr ~loc:$sloc $1 }
    (* Immutable array indexing is a regular operator, so it doesn't need its own
       rule and is handled by the next case *)
    | indexop_expr(qualified_dotop, expr_semi_list, { None })
-       { mk_indexop_expr user_indexing_operators ~loc:$sloc $1 }
+       { mk_dotop_indexop_expr ~loc:$sloc $1 }
 -  | indexop_error (DOT, seq_expr) { $1 }
 -  | indexop_error (qualified_dotop, expr_semi_list) { $1 }
-+  (*| indexop_error (DOT, seq_expr) { $1 }*)
-+  (*| indexop_error (qualified_dotop, expr_semi_list) { $1 }*)
    | simple_expr_attrs
      { let desc, attrs = $1 in
        mkexp_attrs ~loc:$sloc desc attrs }
@@ -781,30 +751,24 @@
        { $1 }
 @@@@
  %inline simple_expr_attrs:
-   | BEGIN ext = ext attrs = attributes e = seq_expr END
-       { e.pexp_desc, (ext, attrs @ e.pexp_attributes) }
+   | BEGIN ext_attributes seq_expr END
+       { Pexp_beginend $3, $2 }
    | BEGIN ext_attributes END
        { Pexp_construct (mkloc (Lident "()") (make_loc $sloc), None), $2 }
 -  | BEGIN ext_attributes seq_expr error
 -      { unclosed "begin" $loc($1) "end" $loc($4) }
-+  (*| BEGIN ext_attributes seq_expr error
-+      { unclosed "begin" $loc($1) "end" $loc($4) }*)
    | NEW ext_attributes mkrhs(class_longident)
        { Pexp_new($3), $2 }
    | LPAREN MODULE ext_attributes module_expr RPAREN
-       { Pexp_pack $4, $3 }
+       { Pexp_pack ($4, None), $3 }
    | LPAREN MODULE ext_attributes module_expr COLON package_type RPAREN
-       { Pexp_constraint (ghexp ~loc:$sloc (Pexp_pack $4), $6), $3 }
+       { Pexp_pack ($4, Some $6), $3 }
 -  | LPAREN MODULE ext_attributes module_expr COLON error
 -      { unclosed "(" $loc($1) ")" $loc($6) }
-+  (*| LPAREN MODULE ext_attributes module_expr COLON error
-+      { unclosed "(" $loc($1) ")" $loc($6) }*)
    | OBJECT ext_attributes class_structure END
        { Pexp_object $3, $2 }
 -  | OBJECT ext_attributes class_structure error
 -      { unclosed "object" $loc($1) "end" $loc($4) }
-+  (*| OBJECT ext_attributes class_structure error
-+      { unclosed "object" $loc($1) "end" $loc($4) }*)
  ;
  
  comprehension_iterator:
@@ -818,8 +782,6 @@
        { Generic_array.Literal $2 }
 -  | ARR_OPEN contents_semi_list error
 -      { Generic_array.Unclosed($loc($1),$loc($3)) }
-+  (*| ARR_OPEN contents_semi_list error
-+      { Generic_array.Unclosed($loc($1),$loc($3)) }*)
    | ARR_OPEN ARR_CLOSE
        { Generic_array.Literal [] }
  ;
@@ -832,25 +794,21 @@
        { (* TODO: review the location of Pexp_array *)
          Generic_array.Opened_literal(od, $startpos($3), $endpos, []) }
 -  | mod_longident DOT
-+  (*| mod_longident DOT
-     ARR_OPEN expr_semi_list error
+-    ARR_OPEN expr_semi_list error
 -      { Generic_array.Unclosed($loc($3), $loc($5)) }
-+      { Generic_array.Unclosed($loc($3), $loc($5)) }*)
  ;
  
  %inline array_patterns(ARR_OPEN, ARR_CLOSE):
    | array_simple(ARR_OPEN, ARR_CLOSE, pattern_semi_list)
        { $1 }
 @@@@
-       { Pexp_apply($1, [Nolabel,$2]) }
+       { Pexp_prefix($1, $2) }
    | op(BANG {"!"}) simple_expr
-       { Pexp_apply($1, [Nolabel,$2]) }
+       { Pexp_prefix($1, $2) }
    | LBRACELESS object_expr_content GREATERRBRACE
        { Pexp_override $2 }
 -  | LBRACELESS object_expr_content error
 -      { unclosed "{<" $loc($1) ">}" $loc($3) }
-+  (*| LBRACELESS object_expr_content error
-+      { unclosed "{<" $loc($1) ">}" $loc($3) }*)
    | LBRACELESS GREATERRBRACE
        { Pexp_override [] }
    | simple_expr DOT mkrhs(label_longident)
@@ -862,8 +820,6 @@
          Pexp_open(od, mkexp ~loc:$sloc (Pexp_override $4)) }
 -  | mod_longident DOT LBRACELESS object_expr_content error
 -      { unclosed "{<" $loc($3) ">}" $loc($5) }
-+  (*| mod_longident DOT LBRACELESS object_expr_content error
-+      { unclosed "{<" $loc($3) ">}" $loc($5) }*)
    | simple_expr HASH mkrhs(label)
        { Pexp_send($1, $3) }
    | simple_expr op(HASHOP) simple_expr
@@ -876,23 +832,17 @@
        { Pexp_open(od, mkexp ~loc:($loc($3)) (Pexp_construct($3, None))) }
 -  | mod_longident DOT LPAREN seq_expr error
 -      { unclosed "(" $loc($3) ")" $loc($5) }
-+  (*| mod_longident DOT LPAREN seq_expr error
-+      { unclosed "(" $loc($3) ")" $loc($5) }*)
    | LBRACE record_expr_content RBRACE
        { let (exten, fields) = $2 in
          Pexp_record(fields, exten) }
 -  | LBRACE record_expr_content error
 -      { unclosed "{" $loc($1) "}" $loc($3) }
-+  (*| LBRACE record_expr_content error
-+      { unclosed "{" $loc($1) "}" $loc($3) }*)
    | od=open_dot_declaration DOT LBRACE record_expr_content RBRACE
        { let (exten, fields) = $4 in
          Pexp_open(od, mkexp ~loc:($startpos($3), $endpos)
                          (Pexp_record(fields, exten))) }
 -  | mod_longident DOT LBRACE record_expr_content error
 -      { unclosed "{" $loc($3) "}" $loc($5) }
-+  (*| mod_longident DOT LBRACE record_expr_content error
-+      { unclosed "{" $loc($3) "}" $loc($5) }*)
    | array_exprs(LBRACKETBAR, BARRBRACKET)
        { Generic_array.expression
            "[|" "|]"
@@ -906,8 +856,6 @@
        { Pexp_list $2 }
 -  | LBRACKET expr_semi_list error
 -      { unclosed "[" $loc($1) "]" $loc($3) }
-+  (*| LBRACKET expr_semi_list error
-+      { unclosed "[" $loc($1) "]" $loc($3) }*)
    | comprehension_expr { $1 }
    | od=open_dot_declaration DOT comprehension_expr
        { Pexp_open(od, mkexp ~loc:($loc($3)) $3) }
@@ -917,21 +865,17 @@
    | od=open_dot_declaration DOT mkrhs(LBRACKET RBRACKET {Lident "[]"})
        { Pexp_open(od, mkexp ~loc:$loc($3) (Pexp_construct($3, None))) }
 -  | mod_longident DOT
-+  (*| mod_longident DOT
-     LBRACKET expr_semi_list error
+-    LBRACKET expr_semi_list error
 -      { unclosed "[" $loc($3) "]" $loc($5) }
-+      { unclosed "[" $loc($3) "]" $loc($5) }*)
    | od=open_dot_declaration DOT LPAREN MODULE ext_attributes module_expr COLON
      package_type RPAREN
        { let modexp =
            mkexp_attrs ~loc:($startpos($3), $endpos)
-             (Pexp_constraint (ghexp ~loc:$sloc (Pexp_pack $6), $8)) $5 in
+             (Pexp_pack ($6, Some $8)) $5 in
          Pexp_open(od, modexp) }
 -  | mod_longident DOT
-+  (*| mod_longident DOT
-     LPAREN MODULE ext_attributes module_expr COLON error
+-    LPAREN MODULE ext_attributes module_expr COLON error
 -      { unclosed "(" $loc($3) ")" $loc($8) }
-+      { unclosed "(" $loc($3) ")" $loc($8) }*)
  ;
  labeled_simple_expr:
      simple_expr %prec below_HASH
@@ -945,8 +889,6 @@
  /* BEGIN AVOID */
 -  | val_ident %prec below_HASH
 -      { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, true) }
-+  (*| val_ident %prec below_HASH
-+      { (mkpatvar ~loc:$loc $1, mkexpvar ~loc:$loc $1, true) }*)
    (* The production that allows puns is marked so that [make list-parse-errors]
       does not attempt to exploit it. That would be problematic because it
       would then generate bindings such as [let x], which are rejected by the
@@ -960,8 +902,6 @@
    | COLONGREATER core_type                      { (None, Some $2) }
 -  | COLON error                                 { syntax_error() }
 -  | COLONGREATER error                          { syntax_error() }
-+  (*| COLON error                                 { syntax_error() }*)
-+  (*| COLONGREATER error                          { syntax_error() }*)
  ;
  
  /* Patterns */
@@ -988,20 +928,19 @@
          { Ppat_alias($1, $3) }
 -    | self AS error
 -        { expecting $loc($3) "identifier" }
-+    (*| self AS error
-+        { expecting $loc($3) "identifier" }*)
      | pattern_comma_list(self) %prec below_COMMA
          { Ppat_tuple(List.rev $1) }
 -    | self COLONCOLON error
 -        { expecting $loc($3) "pattern" }
-+    (*| self COLONCOLON error
-+        { expecting $loc($3) "pattern" }*)
      | self BAR pattern
-         { Ppat_or($1, $3) }
+         { let rec or_ p =
+             match p with
+             | {ppat_desc= Ppat_or (x :: t); ppat_attributes= []; _} -> or_ x @ t
+             | _ -> [p]
+           in
+           Ppat_or (or_ $1 @ or_ $3) }
 -    | self BAR error
 -        { expecting $loc($3) "pattern" }
-+    (*| self BAR error
-+        { expecting $loc($3) "pattern" }*)
    ) { $1 }
  ;
  
@@ -1019,27 +958,15 @@
 -      { expecting $loc($4) "pattern" }
 -  | LPAREN pattern error
 -      { unclosed "(" $loc($1) ")" $loc($3) }
-+  (*| mod_longident DOT LPAREN pattern error
-+      { unclosed "(" $loc($3) ")" $loc($5)  }*)
-+  (*| mod_longident DOT LPAREN error
-+      { expecting $loc($4) "pattern" }*)
-+  (*| LPAREN pattern error
-+      { unclosed "(" $loc($1) ")" $loc($3) }*)
    | LPAREN pattern COLON core_type RPAREN
        { Ppat_constraint($2, $4) }
 -  | LPAREN pattern COLON core_type error
 -      { unclosed "(" $loc($1) ")" $loc($5) }
 -  | LPAREN pattern COLON error
 -      { expecting $loc($4) "type" }
--  | LPAREN MODULE ext_attributes module_name COLON package_type
-+  (*| LPAREN pattern COLON core_type error
-+      { unclosed "(" $loc($1) ")" $loc($5) }*)
-+  (*| LPAREN pattern COLON error
-+      { expecting $loc($4) "type" }*)
-+  (*| LPAREN MODULE ext_attributes module_name COLON package_type
-     error
+-  | LPAREN MODULE ext_attributes module_name COLON package_core_type
+-    error
 -      { unclosed "(" $loc($1) ")" $loc($7) }
-+      { unclosed "(" $loc($1) ")" $loc($7) }*)
    | extension
        { Ppat_extension $1 }
  ;
@@ -1051,14 +978,10 @@
          Ppat_record(fields, closed) }
 -    | LBRACE record_pat_content error
 -      { unclosed "{" $loc($1) "}" $loc($3) }
-+    (*| LBRACE record_pat_content error
-+      { unclosed "{" $loc($1) "}" $loc($3) }*)
      | LBRACKET pattern_semi_list RBRACKET
        { Ppat_list $2 }
 -    | LBRACKET pattern_semi_list error
 -      { unclosed "[" $loc($1) "]" $loc($3) }
-+    (*| LBRACKET pattern_semi_list error
-+      { unclosed "[" $loc($1) "]" $loc($3) }*)
      | array_patterns(LBRACKETBAR, BARRBRACKET)
          { Generic_array.pattern
              "[|" "|]"
@@ -1071,48 +994,57 @@
      pattern_comma_list(self) COMMA pattern      { $3 :: $1 }
    | self COMMA pattern                          { [$3; $1] }
 -  | self COMMA error                            { expecting $loc($3) "pattern" }
-+  (*| self COMMA error                            { expecting $loc($3) "pattern" }*)
  ;
  %inline pattern_semi_list:
    ps = separated_or_terminated_nonempty_list(SEMI, pattern)
      { ps }
  ;
 @@@@
-   | PLUS                                    { Covariant, NoInjectivity }
-   | MINUS                                   { Contravariant, NoInjectivity }
-   | BANG                                    { NoVariance, Injective }
-   | PLUS BANG | BANG PLUS                   { Covariant, Injective }
-   | MINUS BANG | BANG MINUS                 { Contravariant, Injective }
+ type_parameters:
+     /* empty */
+       { [] }
+   | p = type_parameter
+       { [p] }
+-  | LPAREN ps = separated_nonempty_llist(COMMA, type_parameter) RPAREN
++  | LPAREN
+     ps = separated_nonempty_llist(COMMA, parenthesized_type_parameter)
+     RPAREN
+       { ps }
+ ;
+ 
+@@@@
+   | BANG                                    { [ mkvarinj "!" $sloc ] }
+   | PLUS BANG   { [ mkvarinj "+" $loc($1); mkvarinj "!" $loc($2) ] }
+   | BANG PLUS   { [ mkvarinj "!" $loc($1); mkvarinj "+" $loc($2) ] }
+   | MINUS BANG  { [ mkvarinj "-" $loc($1); mkvarinj "!" $loc($2) ] }
+   | BANG MINUS  { [ mkvarinj "!" $loc($1); mkvarinj "-" $loc($2) ] }
 -  | INFIXOP2
-+  (*| INFIXOP2
-       { if $1 = "+!" then Covariant, Injective else
-         if $1 = "-!" then Contravariant, Injective else
--        expecting $loc($1) "type_variance" }
+-      { if ($1 = "+!") || ($1 = "-!") then [ mkvarinj $1 $sloc ]
+-        else expecting $loc($1) "type_variance" }
 -  | PREFIXOP
-+        expecting $loc($1) "type_variance" }*)
-+  (*| PREFIXOP
-       { if $1 = "!+" then Covariant, Injective else
-         if $1 = "!-" then Contravariant, Injective else
--        expecting $loc($1) "type_variance" }
-+        expecting $loc($1) "type_variance" }*)
+-      { if ($1 = "!+") || ($1 = "!-") then [ mkvarinj $1 $sloc ]
+-        else expecting $loc($1) "type_variance" }
  ;
  
  (* A sequence of constructor declarations is either a single BAR, which
     means that the list is empty, or a nonempty BAR-separated list of
     declarations, with an optional leading BAR. *)
 @@@@
-       { [head], Closed }
-   | head = field
-   | head = inherit_field
-       { [head], Closed }
-   | DOTDOT
--      { [], Open }
-+      { [], (Open : closed_flag) }
+                                           ?foo: int -> int
+  *)
+ function_type:
+   | ty = tuple_type
+     %prec MINUSGREATER
+-      { ty }
++     { ty }
+   | ty = strict_function_type
+-      { ty }
++     { ty }
  ;
- %inline field:
-   mkrhs(label) COLON poly_type_no_attr attributes
-     { let info = symbol_info $endpos in
-       let attrs = add_info_attrs info $4 in
+ strict_function_type:
+   | mktyp(
+       label = arg_label
+       local = optional_local
 @@@@
      UIDENT                    { $1 }
    | LIDENT                    { $1 }
@@ -1122,51 +1054,19 @@
 -  | LPAREN operator error     { unclosed "(" $loc($1) ")" $loc($3) }
 -  | LPAREN error              { expecting $loc($2) "operator" }
 -  | LPAREN MODULE error       { expecting $loc($3) "module-expr" }
-+  (*| LPAREN operator error     { unclosed "(" $loc($1) ")" $loc($3) }*)
-+  (*| LPAREN error              { expecting $loc($2) "operator" }*)
-+  (*| LPAREN MODULE error       { expecting $loc($3) "module-expr" }*)
  ;
  val_ident:
      LIDENT                    { $1 }
    | val_extra_ident           { $1 }
  ;
 @@@@
-   | PLUS           {"+"}
-   | PLUSDOT       {"+."}
-   | PLUSEQ        {"+="}
-   | MINUS          {"-"}
-   | MINUSDOT      {"-."}
--  | SLASH          {"/"}
-   | STAR           {"*"}
-   | PERCENT        {"%"}
-   | EQUAL          {"="}
-   | LESS           {"<"}
-   | GREATER        {">"}
-@@@@
- label_longident:
-     mk_longident(mod_longident, LIDENT) { $1 }
  ;
- type_longident:
-     mk_longident(mod_ext_longident, LIDENT)  { $1 }
--  | LIDENT SLASH TYPE_DISAMBIGUATOR          { Lident ($1 ^ "/" ^ $3) }
- ;
- mod_longident:
-     mk_longident(mod_longident, UIDENT)  { $1 }
- ;
--mod_ext_longident_:
--    UIDENT                          { Lident $1 }
--  | UIDENT SLASH TYPE_DISAMBIGUATOR { Lident ($1 ^ "/" ^ $3) }
--  | mod_ext_longident DOT UIDENT    { Ldot($1,$3) }
--;
  mod_ext_longident:
--    mod_ext_longident_ { $1 }
-+    mk_longident(mod_ext_longident, UIDENT) { $1 }
+     mod_ext_longident_ { $1 }
    | mod_ext_longident LPAREN mod_ext_longident RPAREN
        { lapply ~loc:$sloc $1 $3 }
 -  | mod_ext_longident LPAREN error
 -      { expecting $loc($3) "module path" }
-+  (*| mod_ext_longident LPAREN error
-+      { expecting $loc($3) "module path" }*)
  ;
  mty_longident:
      mk_longident(mod_ext_longident,ident) { $1 }
@@ -1179,7 +1079,6 @@
      /* empty */ { Recursive }
  /* BEGIN AVOID */
 -  | NONREC      { not_expecting $loc "nonrec flag" }
-+  (*| NONREC      { not_expecting $loc "nonrec flag" }*)
  /* END AVOID */
  ;
  direction_flag:
@@ -1192,7 +1091,6 @@
    | /* empty */     { None }
  /* BEGIN AVOID */
 -  | PERCENT attr_id { not_expecting $loc "extension" }
-+  (*| PERCENT attr_id { not_expecting $loc "extension" }*)
  /* END AVOID */
  ;
  %inline ext_attributes:

--- a/vendor/diff-parsers-upstream-std.patch
+++ b/vendor/diff-parsers-upstream-std.patch
@@ -1,5 +1,5 @@
---- ocaml-4.13-upstream/ast_helper.ml
-+++ ocaml-4.13/ast_helper.ml
+--- parser-upstream/ast_helper.ml
++++ parser-standard/ast_helper.ml
 @@@@
    let open_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_open (a, b))
    let letop ?loc ?attrs let_ ands body =
@@ -24,8 +24,8 @@
  module Sig = struct
    let mk ?(loc = !default_loc) d = {psig_desc = d; psig_loc = loc}
  
---- ocaml-4.13-upstream/ast_helper.mli
-+++ ocaml-4.13/ast_helper.mli
+--- parser-upstream/ast_helper.mli
++++ parser-standard/ast_helper.mli
 @@@@
      val extension: ?loc:loc -> ?attrs:attrs -> extension -> expression
      val unreachable: ?loc:loc -> ?attrs:attrs -> unit -> expression
@@ -50,8 +50,8 @@
  (** Signature items *)
  module Sig:
    sig
---- ocaml-4.13-upstream/ast_mapper.ml
-+++ ocaml-4.13/ast_mapper.ml
+--- parser-upstream/ast_mapper.ml
++++ parser-standard/ast_mapper.ml
 @@@@
    type_exception: mapper -> type_exception -> type_exception;
    type_kind: mapper -> type_kind -> type_kind;
@@ -117,8 +117,30 @@
  let extension_of_error {kind; main; sub} =
    if kind <> Location.Report_error then
      raise (Invalid_argument "extension_of_error: expected kind Report_error");
---- ocaml-4.13-upstream/ast_mapper.mli
-+++ ocaml-4.13/ast_mapper.mli
+@@@@
+       | "tool_name" ->
+           tool_name_ref := get_string payload
+       | "include_dirs" ->
+           Clflags.include_dirs := get_list get_string payload
+       | "load_path" ->
+-          (* Duplicates Compmisc.auto_include, since we can't reference Compmisc
+-             from this module. *)
+-          let auto_include find_in_dir fn =
+-            if !Clflags.no_std_include then
+-              raise Not_found
+-            else
+-              let alert = Location.auto_include_alert in
+-              Load_path.auto_include_otherlibs alert find_in_dir fn
+-          in
+-          Load_path.init ~auto_include (get_list get_string payload)
++          ()
+       | "open_modules" ->
+           Clflags.open_modules := get_list get_string payload
+       | "for_package" ->
+           Clflags.for_package := get_option get_string payload
+       | "debug" ->
+--- parser-upstream/ast_mapper.mli
++++ parser-standard/ast_mapper.mli
 @@@@
    type_exception: mapper -> type_exception -> type_exception;
    type_kind: mapper -> type_kind -> type_kind;
@@ -133,8 +155,8 @@
      using an open recursion style: each method takes as its first
      argument the mapper to be applied to children in the syntax
      tree. *)
---- ocaml-4.13-upstream/asttypes.mli
-+++ ocaml-4.13/asttypes.mli
+--- parser-upstream/asttypes.mli
++++ parser-standard/asttypes.mli
 @@@@
  
  type override_flag = Override | Fresh
@@ -146,13 +168,22 @@
 +  | Nonlocal
 +  | Nothing
 +
++(* constant layouts are parsed as layout annotations, and also used
++   in the type checker as already-inferred (i.e. non-variable) layouts *)
++type const_layout =
++  | Any
++  | Value
++  | Void
++  | Immediate64
++  | Immediate
++
  type label = string
  
  type arg_label =
      Nolabel
-   | Labelled of string (*  label:T -> ... *)
---- ocaml-4.13-upstream/lexer.mll
-+++ ocaml-4.13/lexer.mll
+   | Labelled of string (** [label:T -> ...] *)
+--- parser-upstream/lexer.mll
++++ parser-standard/lexer.mll
 @@@@
      "false", FALSE;
      "for", FOR;
@@ -285,8 +316,8 @@
      "(*"
        { comment_start_loc := (Location.curr lexbuf) :: !comment_start_loc;
          store_lexeme lexbuf;
---- ocaml-4.13-upstream/parse.ml
-+++ ocaml-4.13/parse.ml
+--- parser-upstream/parse.ml
++++ parser-standard/parse.ml
 @@@@
  let maybe_skip_phrase lexbuf =
    match !last_token with
@@ -382,8 +413,8 @@
  (* The code has been moved here so that one can reuse Pprintast.tyvar *)
  
  let prepare_error err =
---- ocaml-4.13-upstream/parser.mly
-+++ ocaml-4.13/parser.mly
+--- parser-upstream/parser.mly
++++ parser-standard/parser.mly
 @@@@
    | "+", Pexp_constant(Pconst_integer _)
    | ("+" | "+."), Pexp_constant(Pconst_float _) -> desc
@@ -444,27 +475,39 @@
 +      else mktyp_curry typ
 +  | _ -> typ
 +
-+let global_loc = mknoloc "extension.global"
++let global_loc loc = mkloc "extension.global" loc
 +
-+let global_attr =
-+  Attr.mk ~loc:Location.none global_loc (PStr [])
++let global_attr loc =
++  Attr.mk ~loc:Location.none (global_loc loc) (PStr [])
 +
-+let nonlocal_loc = mknoloc "extension.nonlocal"
++let nonlocal_loc loc = mkloc "extension.nonlocal" loc
 +
-+let nonlocal_attr =
-+  Attr.mk ~loc:Location.none nonlocal_loc (PStr [])
++let nonlocal_attr loc =
++  Attr.mk ~loc:Location.none (nonlocal_loc loc) (PStr [])
 +
-+let mkld_global ld =
-+  { ld with pld_attributes = global_attr :: ld.pld_attributes }
++let mkld_global ld loc =
++  { ld with pld_attributes = global_attr loc :: ld.pld_attributes }
 +
-+let mkld_nonlocal ld =
-+  { ld with pld_attributes = nonlocal_attr :: ld.pld_attributes }
++let mkld_nonlocal ld loc =
++  { ld with pld_attributes = nonlocal_attr loc :: ld.pld_attributes }
 +
-+let mkld_global_maybe gbl ld =
++let mkld_global_maybe gbl ld loc =
 +  match gbl with
-+  | Global -> mkld_global ld
-+  | Nonlocal -> mkld_nonlocal ld
++  | Global -> mkld_global ld loc
++  | Nonlocal -> mkld_nonlocal ld loc
 +  | Nothing -> ld
++
++let mkcty_global cty loc =
++  { cty with ptyp_attributes = global_attr loc :: cty.ptyp_attributes }
++
++let mkcty_nonlocal cty loc =
++  { cty with ptyp_attributes = nonlocal_attr loc :: cty.ptyp_attributes }
++
++let mkcty_global_maybe gbl cty loc =
++  match gbl with
++  | Global -> mkcty_global cty loc
++  | Nonlocal -> mkcty_nonlocal cty loc
++  | Nothing -> cty
 +
  (* TODO define an abstraction boundary between locations-as-pairs
     and locations-as-Location.t; it should be clear when we move from
@@ -524,8 +567,14 @@
  let expecting loc nonterm =
      raise Syntaxerr.(Error(Expecting(make_loc loc, nonterm)))
  
+-let removed_string_set loc =
+-  raise(Syntaxerr.Error(Syntaxerr.Removed_string_set(make_loc loc)))
+-
  (* Using the function [not_expecting] in a semantic action means that this
     syntactic form is recognized by the parser but is in fact incorrect. This
+    idiom is used in a few places to produce ad hoc syntax error messages. *)
+ 
+ (* This idiom should be used as little as possible, because it confuses the
 @@@@
  
  let bigarray_untuplify = function
@@ -539,6 +588,44 @@
    let opname = if !Clflags.unsafe then "unsafe_" ^ opname else opname in
    let prefix = match paren_kind with
      | Paren -> Lident "Array"
+-    | Bracket ->
+-        if assign then removed_string_set loc
+-        else Lident "String"
++    | Bracket -> Lident "String"
+     | Brace ->
+        let submodule_name = match n with
+          | One -> "Array1"
+          | Two -> "Array2"
+          | Three -> "Array3"
+@@@@
+       pdir_name = name;
+       pdir_arg = arg;
+       pdir_loc = make_loc loc;
+     }
+ 
++let check_layout loc id =
++  begin
++    match id with
++    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
++    | _ -> expecting loc "layout"
++  end;
++  let loc = make_loc loc in
++  Attr.mk ~loc (mkloc id loc) (PStr [])
++
++let check_layout loc id =
++  begin
++    match id with
++    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
++    | _ -> expecting loc "layout"
++  end;
++  let loc = make_loc loc in
++  Attr.mk ~loc (mkloc id loc) (PStr [])
++
+ %}
+ 
+ /* Tokens */
+ 
+ /* The alias that follows each token is used by Menhir when it needs to
 @@@@
  %token CLASS                  "class"
  %token COLON                  ":"
@@ -1111,6 +1198,60 @@
      pattern_comma_list(self) COMMA pattern      { $3 :: $1 }
    | self COMMA pattern                          { [$3; $1] }
 @@@@
+ type_parameters:
+     /* empty */
+       { [] }
+   | p = type_parameter
+       { [p] }
+-  | LPAREN ps = separated_nonempty_llist(COMMA, type_parameter) RPAREN
++  | LPAREN
++    ps = separated_nonempty_llist(COMMA, parenthesized_type_parameter)
++    RPAREN
+       { ps }
+ ;
++
++layout:
++  ident { check_layout $loc($1) $1 }
++;
++
++parenthesized_type_parameter:
++    type_parameter { $1 }
++  | type_variance type_variable COLON layout
++      { {$2 with ptyp_attributes = [$4]}, $1 }
++;
++
+ type_parameter:
+-    type_variance type_variable        { $2, $1 }
++    type_variance type_variable attributes
++      { {$2 with ptyp_attributes = $3}, $1 }
+ ;
++
+ type_variable:
+   mktyp(
+     QUOTE tyvar = ident
+       { Ptyp_var tyvar }
+   | UNDERSCORE
+@@@@
+                                   { ([],Pcstr_tuple [],Some $2) }
+   | COLON typevar_list DOT atomic_type %prec below_HASH
+                                   { ($2,Pcstr_tuple [],Some $4) }
+ ;
+ 
++%inline atomic_type_gbl:
++  gbl = global_flag cty = atomic_type {
++  mkcty_global_maybe gbl cty (make_loc $loc(gbl))
++}
++;
++
+ constructor_arguments:
+-  | tys = inline_separated_nonempty_llist(STAR, atomic_type)
++  | tys = inline_separated_nonempty_llist(STAR, atomic_type_gbl)
+     %prec below_HASH
+       { Pcstr_tuple tys }
+   | LBRACE label_declarations RBRACE
+       { Pcstr_record $2 }
+ ;
+@@@@
      label_declaration                           { [$1] }
    | label_declaration_semi                      { [$1] }
    | label_declaration_semi label_declarations   { $1 :: $2 }
@@ -1122,7 +1263,8 @@
 -        Type.field $2 $4 ~mut:$1 ~attrs:$5 ~loc:(make_loc $sloc) ~info }
 +        let mut, gbl = $1 in
 +        mkld_global_maybe gbl
-+          (Type.field $2 $4 ~mut ~attrs:$5 ~loc:(make_loc $sloc) ~info) }
++          (Type.field $2 $4 ~mut ~attrs:$5 ~loc:(make_loc $sloc) ~info)
++          (make_loc $loc($1)) }
  ;
  label_declaration_semi:
 -    mutable_flag mkrhs(label) COLON poly_type_no_attr attributes SEMI attributes
@@ -1136,7 +1278,8 @@
 -       Type.field $2 $4 ~mut:$1 ~attrs:($5 @ $7) ~loc:(make_loc $sloc) ~info }
 +       let mut, gbl = $1 in
 +       mkld_global_maybe gbl
-+         (Type.field $2 $4 ~mut ~attrs:($5 @ $7) ~loc:(make_loc $sloc) ~info) }
++         (Type.field $2 $4 ~mut ~attrs:($5 @ $7) ~loc:(make_loc $sloc) ~info)
++         (make_loc $loc($1)) }
  ;
  
  /* Type Extensions */
@@ -1153,41 +1296,41 @@
 +;
 +
 +strict_function_type:
-+  | mktyp(
-+      label = arg_label
-+      local = optional_local
-+      domain = extra_rhs(param_type)
-+      MINUSGREATER
-+      codomain = strict_function_type
-+        { Ptyp_arrow(label, mktyp_local_if local domain, codomain) }
-+    )
-+    { $1 }
    | mktyp(
        label = arg_label
 -      domain = extra_rhs(tuple_type)
-+      arg_local = optional_local
++      local = optional_local
 +      domain = extra_rhs(param_type)
        MINUSGREATER
 -      codomain = function_type
 -        { Ptyp_arrow(label, domain, codomain) }
++      codomain = strict_function_type
++        { Ptyp_arrow(label, mktyp_local_if local domain, codomain) }
++    )
++    { $1 }
++  | mktyp(
++      label = arg_label
++      arg_local = optional_local
++      domain = extra_rhs(param_type)
++      MINUSGREATER
 +      ret_local = optional_local
 +      codomain = tuple_type
 +      %prec MINUSGREATER
 +        { Ptyp_arrow(label,
 +            mktyp_local_if arg_local domain,
 +            mktyp_local_if ret_local (maybe_curry_typ codomain)) }
-+    )
-+    { $1 }
-+;
+     )
+     { $1 }
+ ;
 +%inline param_type:
 +  | mktyp(
 +    LPAREN vars = typevar_list DOT ty = core_type RPAREN
 +      { Ptyp_poly(vars, ty) }
-     )
-     { $1 }
++    )
++    { $1 }
 +  | ty = tuple_type
 +    { ty }
- ;
++;
  %inline arg_label:
    | label = optlabel
        { Optional label }
@@ -1255,6 +1398,11 @@
 +  | GLOBAL                                      { Immutable, Global }
 +  | NONLOCAL                                    { Immutable, Nonlocal }
 +;
++%inline global_flag:
++          { Nothing }
++  | GLOBAL { Global }
++  | NONLOCAL { Nonlocal }
++;
  virtual_flag:
      /* empty */                                 { Concrete }
    | VIRTUAL                                     { Virtual }
@@ -1280,36 +1428,34 @@
    | MODULE { "module" }
    | MUTABLE { "mutable" }
    | NEW { "new" }
---- ocaml-4.13-upstream/parsetree.mli
-+++ ocaml-4.13/parsetree.mli
+--- parser-upstream/parsetree.mli
++++ parser-standard/parsetree.mli
 @@@@
-            let* P = E and* P = E in E *)
-   | Pexp_extension of extension
-         (* [%id] *)
-   | Pexp_unreachable
-         (* . *)
-+  | Pexp_hole
-+        (* _ *)
+   | Pexp_letop of letop
+       (** - [let* P = E0 in E1]
+             - [let* P0 = E00 and* P1 = E01 in E1] *)
+   | Pexp_extension of extension  (** [[%id]] *)
+   | Pexp_unreachable  (** [.] *)
++  | Pexp_hole  (** [_] *)
  
- and case =   (* (P -> E) or (P when E0 -> E) *)
+ and case =
      {
       pc_lhs: pattern;
       pc_guard: expression option;
 @@@@
-         (* (ME : MT) *)
-   | Pmod_unpack of expression
-         (* (val E) *)
-   | Pmod_extension of extension
-         (* [%id] *)
-+  | Pmod_hole
-+        (* _ *)
+       (** [functor(X : MT1) -> ME] *)
+   | Pmod_apply of module_expr * module_expr  (** [ME1(ME2)] *)
+   | Pmod_constraint of module_expr * module_type  (** [(ME : MT)] *)
+   | Pmod_unpack of expression  (** [(val E)] *)
+   | Pmod_extension of extension  (** [[%id]] *)
++  | Pmod_hole  (** [_] *)
  
  and structure = structure_item list
  
  and structure_item =
      {
---- ocaml-4.13-upstream/printast.ml
-+++ ocaml-4.13/printast.ml
+--- parser-upstream/printast.ml
++++ parser-standard/printast.ml
 @@@@
    | Pexp_extension (s, arg) ->
        line i ppf "Pexp_extension \"%s\"\n" s.txt;
@@ -1336,51 +1482,13 @@
  
  and structure_item i ppf x =
    line i ppf "structure_item %a\n" fmt_location x.pstr_loc;
---- ocaml-4.13-upstream/pprintast.ml
-+++ ocaml-4.13/pprintast.ml
+--- parser-upstream/printast.mli
++++ parser-standard/printast.mli
 @@@@
-         let fmt:(_,_,_)format =
-           "@[<hv0>@[<hv2>@[<2>for %a =@;%a@;%a%a@;do@]@;%a@]@;done@]" in
-         let expression = expression ctxt in
-         pp f fmt (pattern ctxt) s expression e1 direction_flag
-           df expression e2 expression e3
-+    | Pexp_hole ->
-+        pp f "_"
-     | _ ->  paren true (expression ctxt) f x
+ val top_phrase : formatter -> toplevel_phrase -> unit
  
- and attributes ctxt f l =
-   List.iter (attribute ctxt f) l
- 
-@@@@
-         pp f "(%a)(%a)" (module_expr ctxt) me1 (module_expr ctxt) me2
-         (* Cf: #7200 *)
-     | Pmod_unpack e ->
-         pp f "(val@ %a)" (expression ctxt) e
-     | Pmod_extension e -> extension ctxt f e
-+    | Pmod_hole ->
-+        pp f "_"
- 
- and structure ctxt f x = list ~sep:"@\n" (structure_item ctxt) f x
- 
- and payload ctxt f = function
-   | PStr [{pstr_desc = Pstr_eval (e, attrs)}] ->
-@@@@
- let class_type = class_type reset_ctxt
- let structure_item = structure_item reset_ctxt
- let signature_item = signature_item reset_ctxt
- let binding = binding reset_ctxt
- let payload = payload reset_ctxt
-+let type_declaration = type_declaration reset_ctxt
---- ocaml-4.13-upstream/pprintast.mli
-+++ ocaml-4.13/pprintast.mli
-@@@@
- val module_type: Format.formatter -> Parsetree.module_type -> unit
- val structure_item: Format.formatter -> Parsetree.structure_item -> unit
- val signature_item: Format.formatter -> Parsetree.signature_item -> unit
- val binding: Format.formatter -> Parsetree.value_binding -> unit
- val payload: Format.formatter -> Parsetree.payload -> unit
-+val type_declaration: Format.formatter -> Parsetree.type_declaration -> unit
- 
- val tyvar: Format.formatter -> string -> unit
-   (** Print a type variable name, taking care of the special treatment
-       required for the single quote character in second position. *)
+ val expression: int -> formatter -> expression -> unit
+ val structure: int -> formatter -> structure -> unit
+ val payload: int -> formatter -> payload -> unit
++val core_type: int -> formatter -> core_type -> unit
++val module_type: int -> formatter -> module_type -> unit

--- a/vendor/ocaml-common/language_extension.mli
+++ b/vendor/ocaml-common/language_extension.mli
@@ -1,5 +1,7 @@
 (** Language extensions provided by ocaml-jst *)
 
+type maturity = Stable | Beta | Alpha
+
 (** The type of language extensions *)
 type t =
   | Comprehensions
@@ -7,12 +9,18 @@ type t =
   | Include_functor
   | Polymorphic_parameters
   | Immutable_arrays
+  | Module_strengthening
+  | Layouts of maturity
 
 (** Equality on language extensions *)
 val equal : t -> t -> bool
 
 (** A list of all possible language extensions *)
 val all : t list
+
+(** A maximal list of compatible language extensions (of the layouts extensions,
+    "layouts_alpha" is selected). *)
+val max_compatible : t list
 
 (** Check if a language extension is "erasable", i.e. whether it can be
     harmlessly translated to attributes and compiled with the upstream

--- a/vendor/parser-extended/asttypes.mli
+++ b/vendor/parser-extended/asttypes.mli
@@ -57,6 +57,15 @@ type global_flag =
   | Nonlocal
   | Nothing
 
+(* constant layouts are parsed as layout annotations, and also used
+   in the type checker as already-inferred (i.e. non-variable) layouts *)
+type const_layout =
+  | Any
+  | Value
+  | Void
+  | Immediate64
+  | Immediate
+
 type label = string
 
 type arg_label =

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -570,6 +570,15 @@ let mk_directive ~loc name arg =
       pdir_loc = make_loc loc;
     }
 
+let check_layout loc id =
+  begin
+    match id with
+    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
+    | _ -> expecting loc "layout"
+  end;
+  let loc = make_loc loc in
+  Attr.mk ~loc (mkloc id loc) (PStr [])
+
 %}
 
 /* Tokens */
@@ -3158,12 +3167,27 @@ type_parameters:
       { [] }
   | p = type_parameter
       { [p] }
-  | LPAREN ps = separated_nonempty_llist(COMMA, type_parameter) RPAREN
+  | LPAREN
+    ps = separated_nonempty_llist(COMMA, parenthesized_type_parameter)
+    RPAREN
       { ps }
 ;
-type_parameter:
-    type_variance type_variable        { $2, $1 }
+
+layout:
+  ident { check_layout $loc($1) $1 }
 ;
+
+parenthesized_type_parameter:
+    type_parameter { $1 }
+  | type_variance type_variable COLON layout
+      { {$2 with ptyp_attributes = [$4]}, $1 }
+;
+
+type_parameter:
+    type_variance type_variable attributes
+      { {$2 with ptyp_attributes = $3}, $1 }
+;
+
 type_variable:
   mktyp(
     QUOTE tyvar = ident

--- a/vendor/parser-recovery/lib/parser.mly
+++ b/vendor/parser-recovery/lib/parser.mly
@@ -552,6 +552,15 @@ let mk_directive ~loc name arg =
       pdir_loc = make_loc loc;
     }
 
+let check_layout loc id =
+  begin
+    match id with
+    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
+    | _ -> raise Syntaxerr.(Error(Expecting(make_loc loc, "layout")))
+  end;
+  let loc = make_loc loc in
+  Attr.mk ~loc (mkloc id loc) (PStr [])
+
 %}
 
 /* Tokens */
@@ -3029,12 +3038,27 @@ type_parameters:
       { [] }
   | p = type_parameter
       { [p] }
-  | LPAREN ps = separated_nonempty_llist(COMMA, type_parameter) RPAREN
+  | LPAREN
+    ps = separated_nonempty_llist(COMMA, parenthesized_type_parameter)
+    RPAREN
       { ps }
 ;
-type_parameter:
-    type_variance type_variable        { $2, $1 }
+
+layout:
+  ident { check_layout $loc($1) $1 }
 ;
+
+parenthesized_type_parameter:
+    type_parameter { $1 }
+  | type_variance type_variable COLON layout
+      { {$2 with ptyp_attributes = [$4]}, $1 }
+;
+
+type_parameter:
+    type_variance type_variable attributes
+      { {$2 with ptyp_attributes = $3}, $1 }
+;
+
 type_variable:
   mktyp(
     QUOTE tyvar = ident

--- a/vendor/parser-recovery/lib/recovery_parser.log
+++ b/vendor/parser-recovery/lib/recovery_parser.log
@@ -1,662 +1,23 @@
 Not enough annotation to recover from state 115:
 mod_ext_longident_ ::= UIDENT SLASH . TYPE_DISAMBIGUATOR
 
-Not enough annotation to recover from state 168:
+Not enough annotation to recover from state 177:
 type_longident ::= LIDENT SLASH . TYPE_DISAMBIGUATOR
 
-# State 1858 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL LPAREN              (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             . (codomain = tuple_type)
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)  
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 166 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL  LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL  LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | LOCAL  LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-atomic_type          ::= LPAREN . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    HASH            clty_longident  
-                       | LPAREN . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    type_longident 
-                       | LPAREN . MODULE                                                      ext                                       list(attribute) module_type      RPAREN
-                       | LPAREN . core_type                                                   RPAREN                                   
-
-
-# State 376 is preventing recovery from 2 states:
-tag_field ::= name_tag OF opt_ampersand . (xs = reversed_separated_nonempty_llist(AMPERSAND,core_type_no_attr)) list(attribute)
-
-
-# State 1815 is preventing recovery from 2 states:
-meth_list   ::= (ty = atomic_type) .
-              | (ty = atomic_type)   . SEMI          
-              | (ty = atomic_type)   . SEMI           (tail = meth_list)
-atomic_type ::= (ty = atomic_type)   . HASH           clty_longident    
-              | (ty = atomic_type)   . type_longident
-
-
-# State 302 is preventing recovery from 2 states:
-reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (xs = reversed_separated_nontrivial_llist(STAR,atomic_type)) STAR             (x = atomic_type) .
-atomic_type                                           ::= (ty = atomic_type)                                           . HASH           clty_longident     
-                                                        | (ty = atomic_type)                                           . type_longident
-
-
-# State 371 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(BAR,row_field) ::= (xs = reversed_separated_nonempty_llist(BAR,row_field)) BAR . (x = row_field)
-
-
-# State 354 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LOCAL (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LOCAL (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 988 is preventing recovery from 2 states:
-fun_def     ::= COLON              atomic_type      . MINUSGREATER seq_expr
-atomic_type ::= (ty = atomic_type) . HASH           clty_longident
-              | (ty = atomic_type) . type_longident
-
-
-# State 1169 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . NONLOCAL            (cty = atomic_type)
-                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . GLOBAL              (cty = atomic_type)
-                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . (cty = atomic_type)
-constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . NONLOCAL            (cty = atomic_type)
-                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . GLOBAL              (cty = atomic_type)
-                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . (cty = atomic_type)
-
-
-# State 1426 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(COMMA,core_type) ::= (xs = reversed_separated_nonempty_llist(COMMA,core_type)) COMMA . (x = core_type)
-
-
-# State 1848 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
-                       | (label = LIDENT) COLON (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 1884 is preventing recovery from 2 states:
-generic_type_declaration(no_nonrec_flag,type_subst_kind) ::= TYPE (ext = ext) list(attribute) (params = type_parameters) LIDENT COLONEQUAL . nonempty_type_kind (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)
-
-
-# State 333 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
-                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 272 is preventing recovery from 2 states:
-atomic_type ::= LBRACKET . row_field BAR                                                     (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
-              | LBRACKET . BAR       (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET                                               
-              | LBRACKET . tag_field RBRACKET                                               
-
-
-# State 1174 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             (cty = atomic_type) .
-constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type)                                             . HASH           clty_longident       
-                                                          | (ty = atomic_type)                                             . type_longident
-
-
-# State 378 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(AMPERSAND,core_type_no_attr) ::= (xs = reversed_separated_nonempty_llist(AMPERSAND,core_type_no_attr)) AMPERSAND . alias_type
-
-
-# State 789 is preventing recovery from 2 states:
-labeled_simple_pattern ::= LABEL LPAREN LOCAL (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN
-
-
-# State 1481 is preventing recovery from 2 states:
-class_type ::= (label = optlabel) (domain = tuple_type) MINUSGREATER . (codomain = class_type)
-
-
-# State 1882 is preventing recovery from 2 states:
-signature_item                                           ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . type_longident PLUSEQ                           (priv = private_flag)                                 (xs = reversed_bar_llist(extension_constructor_declaration)) list(post_item_attribute)
-generic_type_declaration(nonrec_flag,type_kind)          ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . LIDENT         (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)                                   
-generic_type_declaration(no_nonrec_flag,type_subst_kind) ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . LIDENT         COLONEQUAL                       nonempty_type_kind                                    (xs = reversed_llist(preceded(CONSTRAINT,constrain)))        list(post_item_attribute)
-
-
-# State 1854 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 291 is preventing recovery from 2 states:
-strict_function_type ::= (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
-                       | (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 1179 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= COLON (xs = reversed_nonempty_llist(typevar)) DOT . atomic_type          
-                                    | COLON (xs = reversed_nonempty_llist(typevar)) DOT . constructor_arguments MINUSGREATER atomic_type
-
-
-# State 1843 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER              LOCAL                             (codomain = tuple_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER              (codomain = tuple_type)          
-                       | (label = LIDENT) COLON               LOCAL                                   (ty = tuple_type)                 MINUSGREATER            LOCAL  . (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER              (codomain = strict_function_type)
-
-
-# State 534 is preventing recovery from 2 states:
-with_constraint ::= TYPE type_parameters label_longident COLONEQUAL . alias_type
-
-
-# State 818 is preventing recovery from 2 states:
-type_constraint             ::= COLON . core_type COLONGREATER core_type                                
-                              | COLON . core_type
-let_binding_body_no_punning ::= LOCAL val_ident   COLON        . (xs = reversed_nonempty_llist(typevar)) DOT core_type EQUAL seq_expr
-
-
-# State 1842 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON LOCAL (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON LOCAL (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
-                       | (label = LIDENT) COLON LOCAL (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 1708 is preventing recovery from 2 states:
-class_field ::= CONSTRAINT list(attribute) . constrain_field list(post_item_attribute)
-
-
-# State 1182 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= COLON              (xs = reversed_nonempty_llist(typevar)) DOT            constructor_arguments MINUSGREATER atomic_type .
-atomic_type                       ::= (ty = atomic_type) . HASH                                  clty_longident
-                                    | (ty = atomic_type) . type_longident                       
-
-
-# State 1830 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | (label = LIDENT) COLON LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | (label = LIDENT) COLON LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 1167 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= GLOBAL             (cty = atomic_type) .
-constructor_arguments                                   ::= GLOBAL             (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type) . HASH                clty_longident
-                                                          | (ty = atomic_type) . type_longident     
-
-
-# State 1177 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= COLON . (xs = reversed_nonempty_llist(typevar)) DOT          atomic_type          
-                                    | COLON . atomic_type                            
-                                    | COLON . (xs = reversed_nonempty_llist(typevar)) DOT          constructor_arguments MINUSGREATER atomic_type
-                                    | COLON . constructor_arguments                   MINUSGREATER atomic_type          
-
-
-# State 1837 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)                
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)                        RPAREN MINUSGREATER     LOCAL                             (codomain = tuple_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)                        RPAREN MINUSGREATER     (codomain = tuple_type)          
-                       | (label = LIDENT) COLON               LOCAL                                   LPAREN                            (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN                            MINUSGREATER            LOCAL . (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)                        RPAREN MINUSGREATER     (codomain = strict_function_type)
-
-
-# State 1812 is preventing recovery from 2 states:
-meth_list ::= LIDENT COLON possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute) .
-            | LIDENT COLON possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute)   . (tail = meth_list)
-
-
-# State 343 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LOCAL                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LOCAL                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-atomic_type          ::= LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH                                      clty_longident
-                       | LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident                           
-                       | LPAREN             . MODULE                                                      ext    list(attribute)                           module_type    RPAREN          
-                       | LPAREN             . core_type                                                   RPAREN
-
-
-# State 1600 is preventing recovery from 2 states:
-value ::= list(attribute) (mutable_ = virtual_with_mutable_flag) LIDENT COLON . (ty = core_type)
-
-
-# State 541 is preventing recovery from 2 states:
-reversed_llist(preceded(CONSTRAINT,constrain)) ::= (xs = reversed_llist(preceded(CONSTRAINT,constrain))) CONSTRAINT core_type EQUAL . core_type
-
-
-# State 1822 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 1831 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON                                                         LOCAL  LPAREN          . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON                                                         LOCAL  LPAREN          . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON                                                         LOCAL  LPAREN          . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-atomic_type          ::= LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH            clty_longident                           
-                       | LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident 
-                       | LPAREN           . MODULE                                                      ext    list(attribute) module_type                               RPAREN
-                       | LPAREN           . core_type                                                   RPAREN
-
-
-# State 1172 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR GLOBAL . (cty = atomic_type)
-constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR GLOBAL . (cty = atomic_type)
-
-
-# State 1442 is preventing recovery from 2 states:
-constrain_field ::= core_type EQUAL . core_type
-
-
-# State 1411 is preventing recovery from 2 states:
-class_sig_field ::= METHOD list(attribute) private_virtual_flags LIDENT COLON . possibly_poly(core_type) list(post_item_attribute)
-
-
-# State 1695 is preventing recovery from 2 states:
-class_simple_expr ::= LPAREN class_expr COLON . class_type RPAREN
-
-
-# State 1475 is preventing recovery from 2 states:
-class_signature ::= LBRACKET . (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET                                                clty_longident                                         
-atomic_type     ::= LBRACKET . row_field                                                 BAR                                                     (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
-                  | LBRACKET . BAR                                                       (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET                                               
-                  | LBRACKET . tag_field                                                 RBRACKET                                               
-
-
-# State 1833 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 181 is preventing recovery from 2 states:
-structure_item                                  ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . type_longident PLUSEQ                           (priv = private_flag)                                 (xs = reversed_bar_llist(extension_constructor)) list(post_item_attribute)
-generic_type_declaration(nonrec_flag,type_kind) ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . LIDENT         (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)                       
-
-
-# State 306 is preventing recovery from 2 states:
-tuple_type                                            ::= (ty = atomic_type) .
-reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (x1 = atomic_type)   . STAR           (x2 = atomic_type)
-atomic_type                                           ::= (ty = atomic_type)   . HASH           clty_longident    
-                                                        | (ty = atomic_type)   . type_longident
-
-
-# State 360 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
-                       | (label = optlabel) (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 1154 is preventing recovery from 2 states:
-possibly_poly(core_type_no_attr) ::= (xs = reversed_nonempty_llist(typevar)) DOT . alias_type
-
-
-# State 299 is preventing recovery from 2 states:
-reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (xs = reversed_separated_nontrivial_llist(STAR,atomic_type)) STAR . (x = atomic_type)
-
-
-# State 1173 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             GLOBAL         (cty = atomic_type) .
-constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             GLOBAL         (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type)                                             . HASH           clty_longident
-                                                          | (ty = atomic_type)                                             . type_longident
-
-
-# State 1849 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON               (ty = tuple_type)                       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = strict_function_type)
-
-
-# State 1143 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= OF . constructor_arguments
-
-
-# State 296 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL (ty = tuple_type)   MINUSGREATER                            LOCAL                             . (codomain = tuple_type)
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)  
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 1388 is preventing recovery from 2 states:
-class_self_type ::= LPAREN . core_type RPAREN
-
-
-# State 1422 is preventing recovery from 2 states:
-class_signature ::= LBRACKET . (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET clty_longident
-
-
-# State 1527 is preventing recovery from 2 states:
-constr_extra_nonprefix_ident ::= LBRACKET . RBRACKET 
-atomic_type                  ::= LBRACKET . row_field BAR                                                     (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
-                               | LBRACKET . BAR       (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET                                               
-                               | LBRACKET . tag_field RBRACKET                                               
-
-
-# State 1639 is preventing recovery from 2 states:
-method_ ::= list(attribute) private_flag LIDENT COLON . TYPE                     (xs = nonempty_list(mkrhs(LIDENT))) DOT      core_type EQUAL seq_expr
-          | list(attribute) private_flag LIDENT COLON . possibly_poly(core_type) EQUAL                               seq_expr
-
-
-# State 307 is preventing recovery from 2 states:
-reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (x1 = atomic_type) STAR . (x2 = atomic_type)
-
-
-# State 850 is preventing recovery from 2 states:
-let_binding_body_no_punning ::= val_ident COLON (xs = reversed_nonempty_llist(typevar)) DOT . core_type EQUAL seq_expr
-
-
-# State 1719 is preventing recovery from 2 states:
-class_fun_binding ::= COLON . class_type EQUAL class_expr
-
-
-# State 312 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-atomic_type          ::= LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    HASH            clty_longident  
-                       | LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    type_longident 
-                       | LPAREN             . MODULE                                                      ext                                       list(attribute) module_type      RPAREN
-                       | LPAREN             . core_type                                                   RPAREN                                   
-
-
-# State 793 is preventing recovery from 2 states:
-simple_pattern_not_ident ::= LPAREN pattern COLON           . core_type RPAREN                                   
-labeled_simple_pattern   ::= LABEL  LPAREN  (pat = pattern) COLON       . (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN
-
-
-# State 1183 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (cty = atomic_type) .
-generalized_constructor_arguments                       ::= COLON                 (xs = reversed_nonempty_llist(typevar)) DOT            atomic_type .
-constructor_arguments                                   ::= (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type)    . HASH                                  clty_longident
-                                                          | (ty = atomic_type)    . type_longident                       
-
-
-# State 1187 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (cty = atomic_type) .
-generalized_constructor_arguments                       ::= COLON                 atomic_type .   
-constructor_arguments                                   ::= (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type)    . HASH           clty_longident
-                                                          | (ty = atomic_type)    . type_longident
-
-
-# State 1478 is preventing recovery from 2 states:
-class_type ::= (domain = tuple_type) MINUSGREATER . (codomain = class_type)
-
-
-# State 271 is preventing recovery from 2 states:
-atomic_type ::= LBRACKETGREATER option(BAR) . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
-
-
-# State 1185 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= COLON constructor_arguments MINUSGREATER . atomic_type
-
-
-# State 172 is preventing recovery from 2 states:
-atomic_type ::= LESS . GREATER  
-              | LESS . meth_list GREATER
-
-
-# State 349 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                                   (codomain = tuple_type)
-                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)                
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL               LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                     (ty = core_type) RPAREN       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
-                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)      
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = strict_function_type)
-
-
-# State 497 is preventing recovery from 2 states:
-label_let_pattern ::= LIDENT COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type)
-
-
-# State 268 is preventing recovery from 2 states:
-atomic_type ::= LBRACKETLESS option(BAR) . (xs = reversed_separated_nonempty_llist(BAR,row_field)) GREATER  (xs_inlined1 = reversed_nonempty_llist(name_tag)) RBRACKET
-              | LBRACKETLESS option(BAR) . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
-
-
-# State 1171 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             NONLOCAL       (cty = atomic_type) .
-constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             NONLOCAL       (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type)                                             . HASH           clty_longident
-                                                          | (ty = atomic_type)                                             . type_longident
-
-
-# State 1474 is preventing recovery from 2 states:
-class_type ::= (label = LIDENT) COLON (domain = tuple_type) MINUSGREATER . (codomain = class_type)
-
-
-# State 295 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | LOCAL (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
-                       | LOCAL (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 1618 is preventing recovery from 2 states:
-method_ ::= BANG list(attribute) private_flag LIDENT COLON TYPE (xs = nonempty_list(mkrhs(LIDENT))) DOT . core_type EQUAL seq_expr
-
-
-# State 685 is preventing recovery from 2 states:
-type_constraint ::= COLONGREATER . core_type
-
-
-# State 345 is preventing recovery from 2 states:
+# State 352 is preventing recovery from 2 states:
 strict_function_type ::= (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
                        | (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
                        | (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
 
 
-# State 1526 is preventing recovery from 2 states:
-list(generic_and_type_declaration(type_subst_kind)) ::= AND list(attribute) (params = type_parameters) LIDENT COLONEQUAL . nonempty_type_kind (xs_inlined1 = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute) (xs = list(generic_and_type_declaration(type_subst_kind)))
-
-
-# State 165 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 308 is preventing recovery from 2 states:
-reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (x1 = atomic_type) STAR             (x2 = atomic_type) .
-atomic_type                                           ::= (ty = atomic_type) . HASH           clty_longident      
-                                                        | (ty = atomic_type) . type_longident
-
-
-# State 157 is preventing recovery from 2 states:
-type_kind ::= EQUAL . nonempty_type_kind
-
-
-# State 334 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)  
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LPAREN              (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             . (codomain = tuple_type)
-                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 342 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | (label = optlabel) LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 348 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 406 is preventing recovery from 2 states:
-simple_pattern_not_ident ::= HASH . type_longident
-
-
-# State 629 is preventing recovery from 2 states:
-letop_binding_body ::= (pat = simple_pattern) COLON . (typ = core_type) EQUAL (exp = seq_expr)
-
-
-# State 1816 is preventing recovery from 2 states:
-meth_list ::= (ty = atomic_type) SEMI .
-            | (ty = atomic_type) SEMI   . (tail = meth_list)
-
-
-# State 319 is preventing recovery from 2 states:
-reversed_separated_nontrivial_llist(COMMA,core_type) ::= (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) COMMA . (x = core_type)
-
-
-# State 1470 is preventing recovery from 2 states:
-signature_item ::= CLASS (ext = ext) list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT COLON . (cty = class_type) list(post_item_attribute) (bs = list(and_class_description))
-
-
-# State 1186 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= COLON              constructor_arguments MINUSGREATER   atomic_type .
-atomic_type                       ::= (ty = atomic_type) . HASH                clty_longident
-                                    | (ty = atomic_type) . type_longident     
-
-
-# State 815 is preventing recovery from 2 states:
-labeled_simple_pattern ::= LPAREN (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN
-
-
-# State 1170 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR NONLOCAL . (cty = atomic_type)
-constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR NONLOCAL . (cty = atomic_type)
-
-
-# State 170 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON . LOCAL             (ty = tuple_type)                       MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON . LOCAL             (ty = tuple_type)                       MINUSGREATER                            (codomain = tuple_type)          
-                       | (label = LIDENT) COLON . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      (codomain = tuple_type)          
-                       | (label = LIDENT) COLON . (ty = tuple_type) MINUSGREATER                            LOCAL                                   (codomain = tuple_type)          
-                       | (label = LIDENT) COLON . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)                
-                       | (label = LIDENT) COLON . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER LOCAL                             (codomain = tuple_type)          
-                       | (label = LIDENT) COLON . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON . LOCAL             (ty = tuple_type)                       MINUSGREATER                            (codomain = strict_function_type)
-                       | (label = LIDENT) COLON . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      (codomain = strict_function_type)
-                       | (label = LIDENT) COLON . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)      
-                       | (label = LIDENT) COLON . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER (codomain = strict_function_type)
-
-
-# State 495 is preventing recovery from 2 states:
-label_let_pattern ::= LIDENT COLON . (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type)
-                    | LIDENT COLON . (cty = core_type)                      
-
-
-# State 171 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-atomic_type          ::= LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH                                      clty_longident
-                       | LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident                           
-                       | LPAREN           . MODULE                                                      ext    list(attribute)                           module_type    RPAREN          
-                       | LPAREN           . core_type                                                   RPAREN
-
-
-# State 112 is preventing recovery from 2 states:
-value_description ::= VAL (ext = ext) list(attribute) val_ident COLON . (ty = possibly_poly(core_type)) list(post_item_attribute)
-
-
-# State 1400 is preventing recovery from 2 states:
-class_sig_field ::= VAL list(attribute) (flags = mutable_virtual_flags) LIDENT COLON . (ty = core_type) list(post_item_attribute)
-
-
-# State 330 is preventing recovery from 2 states:
-strict_function_type ::= (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
-
-
-# State 1166 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= GLOBAL . (cty = atomic_type)
-constructor_arguments                                   ::= GLOBAL . (cty = atomic_type)
-
-
-# State 1472 is preventing recovery from 2 states:
-class_type ::= (label = LIDENT) COLON . (domain = tuple_type) MINUSGREATER (codomain = class_type)
-
-
-# State 536 is preventing recovery from 2 states:
-with_constraint ::= TYPE type_parameters label_longident with_type_binder . alias_type (xs = reversed_llist(preceded(CONSTRAINT,constrain)))
-
-
-# State 987 is preventing recovery from 2 states:
-fun_def ::= COLON . atomic_type MINUSGREATER seq_expr
-
-
-# State 173 is preventing recovery from 2 states:
+# State 182 is preventing recovery from 2 states:
 atomic_type ::= LPAREN . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH            clty_longident
               | LPAREN . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident 
               | LPAREN . MODULE                                                      ext    list(attribute) module_type    RPAREN
               | LPAREN . core_type                                                   RPAREN
 
 
-# State 286 is preventing recovery from 2 states:
-atomic_type ::= LBRACKET BAR . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
-
-
-# State 355 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = tuple_type)          
-                       | (label = optlabel) LOCAL               (ty = tuple_type)                       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
-                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = strict_function_type)
-
-
-# State 649 is preventing recovery from 2 states:
-let_pattern ::= (pat = pattern) COLON . (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type)
-              | pattern         COLON . core_type                              
-
-
-# State 813 is preventing recovery from 2 states:
-simple_pattern_not_ident ::= LPAREN pattern         COLON . core_type                               RPAREN
-labeled_simple_pattern   ::= LPAREN (pat = pattern) COLON . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN
-
-
-# State 1867 is preventing recovery from 2 states:
-strict_function_type ::= LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
-                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 820 is preventing recovery from 2 states:
-let_binding_body_no_punning ::= LOCAL val_ident COLON (xs = reversed_nonempty_llist(typevar)) DOT . core_type EQUAL seq_expr
-
-
-# State 859 is preventing recovery from 2 states:
-let_binding_body_no_punning ::= simple_pattern_not_ident COLON . core_type EQUAL seq_expr
-
-
-# State 1825 is preventing recovery from 2 states:
-strict_function_type ::= (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
-                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
-
-
-# State 311 is preventing recovery from 2 states:
+# State 318 is preventing recovery from 2 states:
 strict_function_type ::= (label = optlabel) . LOCAL             (ty = tuple_type)                       MINUSGREATER                            LOCAL                             (codomain = tuple_type)
                        | (label = optlabel) . LOCAL             (ty = tuple_type)                       MINUSGREATER                            (codomain = tuple_type)          
                        | (label = optlabel) . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      LOCAL                             (codomain = tuple_type)
@@ -671,34 +32,406 @@ strict_function_type ::= (label = optlabel) . LOCAL             (ty = tuple_type
                        | (label = optlabel) . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER (codomain = strict_function_type)
 
 
-# State 1144 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= NONLOCAL . (cty = atomic_type)
-constructor_arguments                                   ::= NONLOCAL . (cty = atomic_type)
+# State 1858 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
+                       | (label = LIDENT) COLON (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
 
 
-# State 1857 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
-                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
-                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
+# State 1705 is preventing recovery from 2 states:
+class_simple_expr ::= LPAREN class_expr COLON . class_type RPAREN
 
 
-# State 1181 is preventing recovery from 2 states:
-generalized_constructor_arguments ::= COLON (xs = reversed_nonempty_llist(typevar)) DOT constructor_arguments MINUSGREATER . atomic_type
+# State 166 is preventing recovery from 2 states:
+type_kind ::= EQUAL . nonempty_type_kind
 
 
-# State 1615 is preventing recovery from 2 states:
-method_ ::= BANG list(attribute) private_flag LIDENT COLON . TYPE                     (xs = nonempty_list(mkrhs(LIDENT))) DOT      core_type EQUAL seq_expr
-          | BANG list(attribute) private_flag LIDENT COLON . possibly_poly(core_type) EQUAL                               seq_expr
+# State 302 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | LOCAL (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
+                       | LOCAL (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
 
 
-# State 162 is preventing recovery from 2 states:
-nonempty_type_kind ::= PRIVATE . LBRACE                          (ls = label_declarations) RBRACE
-                     | PRIVATE . DOTDOT                         
-                     | PRIVATE . (cs = constructor_declarations)
-                     | PRIVATE . (ty = core_type)               
+# State 1491 is preventing recovery from 2 states:
+class_type ::= (label = optlabel) (domain = tuple_type) MINUSGREATER . (codomain = class_type)
 
 
-# State 163 is preventing recovery from 2 states:
+# State 1178 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             NONLOCAL       (cty = atomic_type) .
+constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             NONLOCAL       (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type)                                             . HASH           clty_longident
+                                                          | (ty = atomic_type)                                             . type_longident
+
+
+# State 1190 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (cty = atomic_type) .
+generalized_constructor_arguments                       ::= COLON                 (xs = reversed_nonempty_llist(typevar)) DOT            atomic_type .
+constructor_arguments                                   ::= (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type)    . HASH                                  clty_longident
+                                                          | (ty = atomic_type)    . type_longident                       
+
+
+# State 694 is preventing recovery from 2 states:
+type_constraint ::= COLON . core_type COLONGREATER core_type
+                  | COLON . core_type
+
+
+# State 272 is preventing recovery from 2 states:
+option(preceded(COLON,core_type)) ::= COLON . (x = core_type)
+
+
+# State 1174 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= GLOBAL             (cty = atomic_type) .
+constructor_arguments                                   ::= GLOBAL             (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type) . HASH                clty_longident
+                                                          | (ty = atomic_type) . type_longident     
+
+
+# State 378 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(BAR,row_field) ::= (xs = reversed_separated_nonempty_llist(BAR,row_field)) BAR . (x = row_field)
+
+
+# State 1482 is preventing recovery from 2 states:
+class_type ::= (label = LIDENT) COLON . (domain = tuple_type) MINUSGREATER (codomain = class_type)
+
+
+# State 796 is preventing recovery from 2 states:
+labeled_simple_pattern ::= LABEL LPAREN LOCAL (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN
+
+
+# State 825 is preventing recovery from 2 states:
+type_constraint             ::= COLON . core_type COLONGREATER core_type                                
+                              | COLON . core_type
+let_binding_body_no_punning ::= LOCAL val_ident   COLON        . (xs = reversed_nonempty_llist(typevar)) DOT core_type EQUAL seq_expr
+
+
+# State 180 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+atomic_type          ::= LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH                                      clty_longident
+                       | LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident                           
+                       | LPAREN           . MODULE                                                      ext    list(attribute)                           module_type    RPAREN          
+                       | LPAREN           . core_type                                                   RPAREN
+
+
+# State 275 is preventing recovery from 2 states:
+atomic_type ::= LBRACKETLESS option(BAR) . (xs = reversed_separated_nonempty_llist(BAR,row_field)) GREATER  (xs_inlined1 = reversed_nonempty_llist(name_tag)) RBRACKET
+              | LBRACKETLESS option(BAR) . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+
+
+# State 1179 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR GLOBAL . (cty = atomic_type)
+constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR GLOBAL . (cty = atomic_type)
+
+
+# State 1843 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 866 is preventing recovery from 2 states:
+let_binding_body_no_punning ::= simple_pattern_not_ident COLON . core_type EQUAL seq_expr
+
+
+# State 1161 is preventing recovery from 2 states:
+possibly_poly(core_type_no_attr) ::= (xs = reversed_nonempty_llist(typevar)) DOT . alias_type
+
+
+# State 857 is preventing recovery from 2 states:
+let_binding_body_no_punning ::= val_ident COLON (xs = reversed_nonempty_llist(typevar)) DOT . core_type EQUAL seq_expr
+
+
+# State 1832 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 341 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)  
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LPAREN              (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             . (codomain = tuple_type)
+                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 1299 is preventing recovery from 2 states:
+possibly_poly(core_type) ::= (xs = reversed_nonempty_llist(typevar)) DOT . core_type
+
+
+# State 1674 is preventing recovery from 2 states:
+class_simple_expr ::= LBRACKET . (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET class_longident
+
+
+# State 1323 is preventing recovery from 2 states:
+payload ::= COLON . core_type
+          | COLON . signature
+
+
+# State 548 is preventing recovery from 2 states:
+reversed_llist(preceded(CONSTRAINT,constrain)) ::= (xs = reversed_llist(preceded(CONSTRAINT,constrain))) CONSTRAINT core_type EQUAL . core_type
+
+
+# State 1718 is preventing recovery from 2 states:
+class_field ::= CONSTRAINT list(attribute) . constrain_field list(post_item_attribute)
+
+
+# State 1536 is preventing recovery from 2 states:
+list(generic_and_type_declaration(type_subst_kind)) ::= AND list(attribute) (params = type_parameters) LIDENT COLONEQUAL . nonempty_type_kind (xs_inlined1 = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute) (xs = list(generic_and_type_declaration(type_subst_kind)))
+
+
+# State 385 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(AMPERSAND,core_type_no_attr) ::= (xs = reversed_separated_nonempty_llist(AMPERSAND,core_type_no_attr)) AMPERSAND . alias_type
+
+
+# State 849 is preventing recovery from 2 states:
+type_constraint             ::= COLON     . core_type COLONGREATER                              core_type                          
+                              | COLON     . core_type
+let_binding_body_no_punning ::= val_ident COLON       . TYPE                                    (xs = nonempty_list(mkrhs(LIDENT))) DOT       core_type EQUAL    seq_expr
+                              | val_ident COLON       . (xs = reversed_nonempty_llist(typevar)) DOT                                 core_type EQUAL     seq_expr
+
+
+# State 1948 is preventing recovery from 2 states:
+parse_core_type' ::= . parse_core_type
+
+
+# State 502 is preventing recovery from 2 states:
+label_let_pattern ::= LIDENT COLON . (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type)
+                    | LIDENT COLON . (cty = core_type)                      
+
+
+# State 1452 is preventing recovery from 2 states:
+constrain_field ::= core_type EQUAL . core_type
+
+
+# State 1729 is preventing recovery from 2 states:
+class_fun_binding ::= COLON . class_type EQUAL class_expr
+
+
+# State 1841 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON                                                         LOCAL  LPAREN          . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON                                                         LOCAL  LPAREN          . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON                                                         LOCAL  LPAREN          . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+atomic_type          ::= LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH            clty_longident                           
+                       | LPAREN           . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident 
+                       | LPAREN           . MODULE                                                      ext    list(attribute) module_type                               RPAREN
+                       | LPAREN           . core_type                                                   RPAREN
+
+
+# State 1436 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(COMMA,core_type) ::= (xs = reversed_separated_nonempty_llist(COMMA,core_type)) COMMA . (x = core_type)
+
+
+# State 1488 is preventing recovery from 2 states:
+class_type ::= (domain = tuple_type) MINUSGREATER . (codomain = class_type)
+
+
+# State 1177 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR NONLOCAL . (cty = atomic_type)
+constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR NONLOCAL . (cty = atomic_type)
+
+
+# State 504 is preventing recovery from 2 states:
+label_let_pattern ::= LIDENT COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type)
+
+
+# State 1894 is preventing recovery from 2 states:
+generic_type_declaration(no_nonrec_flag,type_subst_kind) ::= TYPE (ext = ext) list(attribute) (params = type_parameters) LIDENT COLONEQUAL . nonempty_type_kind (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)
+
+
+# State 303 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL (ty = tuple_type)   MINUSGREATER                            LOCAL                             . (codomain = tuple_type)
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)  
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 356 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                                   (codomain = tuple_type)
+                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)                
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL               LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                     (ty = core_type) RPAREN       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
+                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)      
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = strict_function_type)
+
+
+# State 656 is preventing recovery from 2 states:
+let_pattern ::= (pat = pattern) COLON . (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type)
+              | pattern         COLON . core_type                              
+
+
+# State 995 is preventing recovery from 2 states:
+fun_def     ::= COLON              atomic_type      . MINUSGREATER seq_expr
+atomic_type ::= (ty = atomic_type) . HASH           clty_longident
+              | (ty = atomic_type) . type_longident
+
+
+# State 1432 is preventing recovery from 2 states:
+class_signature ::= LBRACKET . (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET clty_longident
+
+
+# State 696 is preventing recovery from 2 states:
+type_constraint ::= COLON core_type COLONGREATER . core_type
+
+
+# State 337 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 541 is preventing recovery from 2 states:
+with_constraint ::= TYPE type_parameters label_longident COLONEQUAL . alias_type
+
+
+# State 1822 is preventing recovery from 2 states:
+meth_list ::= LIDENT COLON possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute) .
+            | LIDENT COLON possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute)   . (tail = meth_list)
+
+
+# State 190 is preventing recovery from 2 states:
+structure_item                                  ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . type_longident PLUSEQ                           (priv = private_flag)                                 (xs = reversed_bar_llist(extension_constructor)) list(post_item_attribute)
+generic_type_declaration(nonrec_flag,type_kind) ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . LIDENT         (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)                       
+
+
+# State 1159 is preventing recovery from 2 states:
+label_declaration_semi ::= mutable_or_global_flag LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute)
+label_declaration      ::= mutable_or_global_flag LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute)
+
+
+# State 543 is preventing recovery from 2 states:
+with_constraint ::= TYPE type_parameters label_longident with_type_binder . alias_type (xs = reversed_llist(preceded(CONSTRAINT,constrain)))
+
+
+# State 1537 is preventing recovery from 2 states:
+constr_extra_nonprefix_ident ::= LBRACKET . RBRACKET 
+atomic_type                  ::= LBRACKET . row_field BAR                                                     (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+                               | LBRACKET . BAR       (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET                                               
+                               | LBRACKET . tag_field RBRACKET                                               
+
+
+# State 1398 is preventing recovery from 2 states:
+class_self_type ::= LPAREN . core_type RPAREN
+
+
+# State 181 is preventing recovery from 2 states:
+atomic_type ::= LESS . GREATER  
+              | LESS . meth_list GREATER
+
+
+# State 306 is preventing recovery from 2 states:
+reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (xs = reversed_separated_nontrivial_llist(STAR,atomic_type)) STAR . (x = atomic_type)
+
+
+# State 1835 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
+                       | (label = LIDENT) COLON LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 299 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL             . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL             . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL             . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL             . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (ty = tuple_type) MINUSGREATER        LOCAL                                   . (codomain = tuple_type)        
+                       | LOCAL             . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL             . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 1173 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= GLOBAL . (cty = atomic_type)
+constructor_arguments                                   ::= GLOBAL . (cty = atomic_type)
+
+
+# State 1194 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (cty = atomic_type) .
+generalized_constructor_arguments                       ::= COLON                 atomic_type .   
+constructor_arguments                                   ::= (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type)    . HASH           clty_longident
+                                                          | (ty = atomic_type)    . type_longident
+
+
+# State 1421 is preventing recovery from 2 states:
+class_sig_field ::= METHOD list(attribute) private_virtual_flags LIDENT COLON . possibly_poly(core_type) list(post_item_attribute)
+
+
+# State 1184 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= COLON . (xs = reversed_nonempty_llist(typevar)) DOT          atomic_type          
+                                    | COLON . atomic_type                            
+                                    | COLON . (xs = reversed_nonempty_llist(typevar)) DOT          constructor_arguments MINUSGREATER atomic_type
+                                    | COLON . constructor_arguments                   MINUSGREATER atomic_type          
+
+
+# State 1297 is preventing recovery from 2 states:
+primitive_declaration ::= EXTERNAL (ext = ext) list(attribute) val_ident COLON . (ty = possibly_poly(core_type)) EQUAL (prim = nonempty_list(mkrhs(raw_string))) list(post_item_attribute)
+
+
+# State 1892 is preventing recovery from 2 states:
+signature_item                                           ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . type_longident PLUSEQ                           (priv = private_flag)                                 (xs = reversed_bar_llist(extension_constructor_declaration)) list(post_item_attribute)
+generic_type_declaration(nonrec_flag,type_kind)          ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . LIDENT         (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)                                   
+generic_type_declaration(no_nonrec_flag,type_subst_kind) ::= TYPE (ext = ext) list(attribute) (params = type_parameters) . LIDENT         COLONEQUAL                       nonempty_type_kind                                    (xs = reversed_llist(preceded(CONSTRAINT,constrain)))        list(post_item_attribute)
+
+
+# State 658 is preventing recovery from 2 states:
+let_pattern ::= (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type)
+
+
+# State 279 is preventing recovery from 2 states:
+atomic_type ::= LBRACKET . row_field BAR                                                     (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+              | LBRACKET . BAR       (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET                                               
+              | LBRACKET . tag_field RBRACKET                                               
+
+
+# State 1628 is preventing recovery from 2 states:
+method_ ::= BANG list(attribute) private_flag LIDENT COLON TYPE (xs = nonempty_list(mkrhs(LIDENT))) DOT . core_type EQUAL seq_expr
+
+
+# State 463 is preventing recovery from 2 states:
+simple_pattern_not_ident ::= LPAREN pattern COLON . core_type RPAREN
+
+
+# State 347 is preventing recovery from 2 states:
+reversed_separated_nontrivial_llist(COMMA,core_type) ::= (x1 = core_type) COMMA . (x2 = core_type)
+
+
+# State 1183 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (cty = atomic_type) .
+constructor_arguments                                   ::= (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type)    . HASH           clty_longident
+                                                          | (ty = atomic_type)    . type_longident
+
+
+# State 1818 is preventing recovery from 2 states:
+meth_list ::= LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute)
+            | LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute)
+            | LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute) (tail = meth_list)
+
+
+# State 852 is preventing recovery from 2 states:
+let_binding_body_no_punning ::= val_ident COLON TYPE (xs = nonempty_list(mkrhs(LIDENT))) DOT . core_type EQUAL seq_expr
+
+
+# State 1485 is preventing recovery from 2 states:
+class_signature ::= LBRACKET . (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET                                                clty_longident                                         
+atomic_type     ::= LBRACKET . row_field                                                 BAR                                                     (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+                  | LBRACKET . BAR                                                       (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET                                               
+                  | LBRACKET . tag_field                                                 RBRACKET                                               
+
+
+# State 326 is preventing recovery from 2 states:
+reversed_separated_nontrivial_llist(COMMA,core_type) ::= (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) COMMA . (x = core_type)
+
+
+# State 172 is preventing recovery from 2 states:
 strict_function_type         ::= LPAREN . (xs = reversed_nonempty_llist(typevar))                     DOT    (ty = core_type) RPAREN         MINUSGREATER LOCAL                             (codomain = tuple_type)
                                | LPAREN . (xs = reversed_nonempty_llist(typevar))                     DOT    (ty = core_type) RPAREN         MINUSGREATER (codomain = tuple_type)          
                                | LPAREN . (xs = reversed_nonempty_llist(typevar))                     DOT    (ty = core_type) RPAREN         MINUSGREATER (codomain = strict_function_type)
@@ -710,102 +443,246 @@ atomic_type                  ::= LPAREN . (xs = reversed_separated_nontrivial_ll
                                | LPAREN . core_type                                                   RPAREN
 
 
-# State 842 is preventing recovery from 2 states:
-type_constraint             ::= COLON     . core_type COLONGREATER                              core_type                          
-                              | COLON     . core_type
-let_binding_body_no_punning ::= val_ident COLON       . TYPE                                    (xs = nonempty_list(mkrhs(LIDENT))) DOT       core_type EQUAL    seq_expr
-                              | val_ident COLON       . (xs = reversed_nonempty_llist(typevar)) DOT                                 core_type EQUAL     seq_expr
+# State 322 is preventing recovery from 2 states:
+atomic_type ::= LPAREN (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN . HASH           clty_longident
+              | LPAREN (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN . type_longident
 
 
-# State 845 is preventing recovery from 2 states:
-let_binding_body_no_punning ::= val_ident COLON TYPE (xs = nonempty_list(mkrhs(LIDENT))) DOT . core_type EQUAL seq_expr
+# State 822 is preventing recovery from 2 states:
+labeled_simple_pattern ::= LPAREN (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN
 
 
-# State 1635 is preventing recovery from 2 states:
-method_ ::= list(attribute) (private_ = virtual_with_private_flag) LIDENT COLON . possibly_poly(core_type)
+# State 349 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | (label = optlabel) LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
 
 
-# State 539 is preventing recovery from 2 states:
+# State 313 is preventing recovery from 2 states:
+tuple_type                                            ::= (ty = atomic_type) .
+reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (x1 = atomic_type)   . STAR           (x2 = atomic_type)
+atomic_type                                           ::= (ty = atomic_type)   . HASH           clty_longident    
+                                                        | (ty = atomic_type)   . type_longident
+
+
+# State 1874 is preventing recovery from 2 states:
+strict_function_type ::= LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 827 is preventing recovery from 2 states:
+let_binding_body_no_punning ::= LOCAL val_ident COLON (xs = reversed_nonempty_llist(typevar)) DOT . core_type EQUAL seq_expr
+
+
+# State 546 is preventing recovery from 2 states:
 reversed_llist(preceded(CONSTRAINT,constrain)) ::= (xs = reversed_llist(preceded(CONSTRAINT,constrain))) CONSTRAINT . core_type EQUAL core_type
 
 
-# State 1479 is preventing recovery from 2 states:
-class_type ::= (label = optlabel) . (domain = tuple_type) MINUSGREATER (codomain = class_type)
+# State 994 is preventing recovery from 2 states:
+fun_def ::= COLON . atomic_type MINUSGREATER seq_expr
 
 
-# State 1868 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL  . (ty = tuple_type)                     MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL  . (ty = tuple_type)                     MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL  . LPAREN                                (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL  . LPAREN                                (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER (codomain = tuple_type)          
-                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER LOCAL        . (codomain = tuple_type)        
-                       | LOCAL  . (ty = tuple_type)                     MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL  . LPAREN                                (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER (codomain = strict_function_type)
+# State 314 is preventing recovery from 2 states:
+reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (x1 = atomic_type) STAR . (x2 = atomic_type)
 
 
-# State 292 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL             . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
-                       | LOCAL             . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
-                       | LOCAL             . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL             . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | (ty = tuple_type) MINUSGREATER        LOCAL                                   . (codomain = tuple_type)        
-                       | LOCAL             . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
-                       | LOCAL             . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
+# State 383 is preventing recovery from 2 states:
+tag_field ::= name_tag OF opt_ampersand . (xs = reversed_separated_nonempty_llist(AMPERSAND,core_type_no_attr)) list(attribute)
 
 
-# State 265 is preventing recovery from 2 states:
-option(preceded(COLON,core_type)) ::= COLON . (x = core_type)
+# State 1853 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER              LOCAL                             (codomain = tuple_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER              (codomain = tuple_type)          
+                       | (label = LIDENT) COLON               LOCAL                                   (ty = tuple_type)                 MINUSGREATER            LOCAL  . (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER              (codomain = strict_function_type)
 
 
-# State 1292 is preventing recovery from 2 states:
-possibly_poly(core_type) ::= (xs = reversed_nonempty_llist(typevar)) DOT . core_type
+# State 1192 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= COLON constructor_arguments MINUSGREATER . atomic_type
 
 
-# State 1836 is preventing recovery from 2 states:
+# State 1450 is preventing recovery from 2 states:
+class_sig_field ::= CONSTRAINT list(attribute) . constrain_field list(post_item_attribute)
+
+
+# State 319 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+atomic_type          ::= LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    HASH            clty_longident  
+                       | LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    type_longident 
+                       | LPAREN             . MODULE                                                      ext                                       list(attribute) module_type      RPAREN
+                       | LPAREN             . core_type                                                   RPAREN                                   
+
+
+# State 1186 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= COLON (xs = reversed_nonempty_llist(typevar)) DOT . atomic_type          
+                                    | COLON (xs = reversed_nonempty_llist(typevar)) DOT . constructor_arguments MINUSGREATER atomic_type
+
+
+# State 1649 is preventing recovery from 2 states:
+method_ ::= list(attribute) private_flag LIDENT COLON . TYPE                     (xs = nonempty_list(mkrhs(LIDENT))) DOT      core_type EQUAL seq_expr
+          | list(attribute) private_flag LIDENT COLON . possibly_poly(core_type) EQUAL                               seq_expr
+
+
+# State 278 is preventing recovery from 2 states:
+atomic_type ::= LBRACKETGREATER option(BAR) . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+
+
+# State 171 is preventing recovery from 2 states:
+nonempty_type_kind ::= PRIVATE . LBRACE                          (ls = label_declarations) RBRACE
+                     | PRIVATE . DOTDOT                         
+                     | PRIVATE . (cs = constructor_declarations)
+                     | PRIVATE . (ty = core_type)               
+
+
+# State 112 is preventing recovery from 2 states:
+value_description ::= VAL (ext = ext) list(attribute) val_ident COLON . (ty = possibly_poly(core_type)) list(post_item_attribute)
+
+
+# State 1847 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)                
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)                        RPAREN MINUSGREATER     LOCAL                             (codomain = tuple_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)                        RPAREN MINUSGREATER     (codomain = tuple_type)          
+                       | (label = LIDENT) COLON               LOCAL                                   LPAREN                            (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN                            MINUSGREATER            LOCAL . (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)                        RPAREN MINUSGREATER     (codomain = strict_function_type)
+
+
+# State 362 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL               (ty = tuple_type)                       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
+                       | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = strict_function_type)
+
+
+# State 800 is preventing recovery from 2 states:
+simple_pattern_not_ident ::= LPAREN pattern COLON           . core_type RPAREN                                   
+labeled_simple_pattern   ::= LABEL  LPAREN  (pat = pattern) COLON       . (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN
+
+
+# State 413 is preventing recovery from 2 states:
+simple_pattern_not_ident ::= HASH . type_longident
+
+
+# State 293 is preventing recovery from 2 states:
+atomic_type ::= LBRACKET BAR . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+
+
+# State 298 is preventing recovery from 2 states:
+strict_function_type ::= (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
+                       | (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 355 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 1867 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
+                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 820 is preventing recovery from 2 states:
+simple_pattern_not_ident ::= LPAREN pattern         COLON . core_type                               RPAREN
+labeled_simple_pattern   ::= LPAREN (pat = pattern) COLON . (xs = reversed_nonempty_llist(typevar)) DOT    (ty = core_type) RPAREN
+
+
+# State 1410 is preventing recovery from 2 states:
+class_sig_field ::= VAL list(attribute) (flags = mutable_virtual_flags) LIDENT COLON . (ty = core_type) list(post_item_attribute)
+
+
+# State 1825 is preventing recovery from 2 states:
+meth_list   ::= (ty = atomic_type) .
+              | (ty = atomic_type)   . SEMI          
+              | (ty = atomic_type)   . SEMI           (tail = meth_list)
+atomic_type ::= (ty = atomic_type)   . HASH           clty_longident    
+              | (ty = atomic_type)   . type_longident
+
+
+# State 1846 is preventing recovery from 2 states:
 strict_function_type ::= (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
                        | (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
                        | (label = LIDENT) COLON LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
 
 
-# State 687 is preventing recovery from 2 states:
-type_constraint ::= COLON . core_type COLONGREATER core_type
-                  | COLON . core_type
+# State 802 is preventing recovery from 2 states:
+labeled_simple_pattern ::= LABEL LPAREN (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN
 
 
-# State 651 is preventing recovery from 2 states:
-let_pattern ::= (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type)
+# State 1189 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= COLON              (xs = reversed_nonempty_llist(typevar)) DOT            constructor_arguments MINUSGREATER atomic_type .
+atomic_type                       ::= (ty = atomic_type) . HASH                                  clty_longident
+                                    | (ty = atomic_type) . type_longident                       
 
 
-# State 1440 is preventing recovery from 2 states:
-class_sig_field ::= CONSTRAINT list(attribute) . constrain_field list(post_item_attribute)
+# State 1188 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= COLON (xs = reversed_nonempty_llist(typevar)) DOT constructor_arguments MINUSGREATER . atomic_type
 
 
-# State 1145 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= NONLOCAL           (cty = atomic_type) .
-constructor_arguments                                   ::= NONLOCAL           (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type) . HASH                clty_longident
-                                                          | (ty = atomic_type) . type_longident     
+# State 1181 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             (cty = atomic_type) .
+constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type)                                             . HASH           clty_longident       
+                                                          | (ty = atomic_type)                                             . type_longident
 
 
-# State 1664 is preventing recovery from 2 states:
-class_simple_expr ::= LBRACKET . (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET class_longident
+# State 1505 is preventing recovery from 2 states:
+list(and_class_description) ::= AND list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT COLON . (cty = class_type) list(post_item_attribute) (xs = list(and_class_description))
 
 
-# State 1826 is preventing recovery from 2 states:
-strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                                   (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)                
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = tuple_type)          
-                       | (label = LIDENT) COLON               LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                     (ty = core_type) RPAREN       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
-                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)      
-                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = strict_function_type)
+# State 1610 is preventing recovery from 2 states:
+value ::= list(attribute) (mutable_ = virtual_with_mutable_flag) LIDENT COLON . (ty = core_type)
 
 
-# State 1938 is preventing recovery from 2 states:
-parse_core_type' ::= . parse_core_type
+# State 1645 is preventing recovery from 2 states:
+method_ ::= list(attribute) (private_ = virtual_with_private_flag) LIDENT COLON . possibly_poly(core_type)
 
 
-# State 361 is preventing recovery from 2 states:
+# State 1859 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON               (ty = tuple_type)                       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN                    MINUSGREATER (codomain = strict_function_type)
+
+
+# State 394 is preventing recovery from 2 states:
+atomic_type ::= LBRACKET row_field BAR . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+
+
+# State 1652 is preventing recovery from 2 states:
+method_ ::= list(attribute) private_flag LIDENT COLON TYPE (xs = nonempty_list(mkrhs(LIDENT))) DOT . core_type EQUAL seq_expr
+
+
+# State 1868 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL LPAREN              (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             . (codomain = tuple_type)
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)  
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
+
+
+# State 368 is preventing recovery from 2 states:
 strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)  
                        | LOCAL              . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
                        | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
@@ -815,50 +692,141 @@ strict_function_type ::= LOCAL              . (ty = tuple_type) MINUSGREATER    
                        | LOCAL              . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)          RPAREN MINUSGREATER (codomain = strict_function_type)
 
 
-# State 1773 is preventing recovery from 2 states:
-class_self_pattern ::= LPAREN pattern COLON . core_type RPAREN
+# State 1151 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= NONLOCAL . (cty = atomic_type)
+constructor_arguments                                   ::= NONLOCAL . (cty = atomic_type)
 
 
-# State 1316 is preventing recovery from 2 states:
-payload ::= COLON . core_type
-          | COLON . signature
+# State 1193 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= COLON              constructor_arguments MINUSGREATER   atomic_type .
+atomic_type                       ::= (ty = atomic_type) . HASH                clty_longident
+                                    | (ty = atomic_type) . type_longident     
 
 
-# State 1495 is preventing recovery from 2 states:
-list(and_class_description) ::= AND list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT COLON . (cty = class_type) list(post_item_attribute) (xs = list(and_class_description))
+# State 1484 is preventing recovery from 2 states:
+class_type ::= (label = LIDENT) COLON (domain = tuple_type) MINUSGREATER . (codomain = class_type)
 
 
-# State 387 is preventing recovery from 2 states:
-atomic_type ::= LBRACKET row_field BAR . (xs = reversed_separated_nonempty_llist(BAR,row_field)) RBRACKET
+# State 175 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL  LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL  LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | LOCAL  LPAREN                                                        . (xs = reversed_nonempty_llist(typevar)) DOT             (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+atomic_type          ::= LPAREN . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    HASH            clty_longident  
+                       | LPAREN . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN                                    type_longident 
+                       | LPAREN . MODULE                                                      ext                                       list(attribute) module_type      RPAREN
+                       | LPAREN . core_type                                                   RPAREN                                   
 
 
-# State 456 is preventing recovery from 2 states:
-simple_pattern_not_ident ::= LPAREN pattern COLON . core_type RPAREN
+# State 1836 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL            . (ty = tuple_type) MINUSGREATER                            LOCAL                                   (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)                
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON               LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                     (ty = core_type) RPAREN       MINUSGREATER                      LOCAL                   . (codomain = tuple_type)
+                       | LOCAL            . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)      
+                       | LOCAL            . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)        RPAREN           MINUSGREATER (codomain = strict_function_type)
+
+
+# State 1180 is preventing recovery from 2 states:
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             GLOBAL         (cty = atomic_type) .
+constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR             GLOBAL         (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type)                                             . HASH           clty_longident
+                                                          | (ty = atomic_type)                                             . type_longident
+
+
+# State 1625 is preventing recovery from 2 states:
+method_ ::= BANG list(attribute) private_flag LIDENT COLON . TYPE                     (xs = nonempty_list(mkrhs(LIDENT))) DOT      core_type EQUAL seq_expr
+          | BANG list(attribute) private_flag LIDENT COLON . possibly_poly(core_type) EQUAL                               seq_expr
+
+
+# State 636 is preventing recovery from 2 states:
+letop_binding_body ::= (pat = simple_pattern) COLON . (typ = core_type) EQUAL (exp = seq_expr)
+
+
+# State 309 is preventing recovery from 2 states:
+reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (xs = reversed_separated_nontrivial_llist(STAR,atomic_type)) STAR             (x = atomic_type) .
+atomic_type                                           ::= (ty = atomic_type)                                           . HASH           clty_longident     
+                                                        | (ty = atomic_type)                                           . type_longident
+
+
+# State 1826 is preventing recovery from 2 states:
+meth_list ::= (ty = atomic_type) SEMI .
+            | (ty = atomic_type) SEMI   . (tail = meth_list)
+
+
+# State 1852 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON LOCAL (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON LOCAL (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
+                       | (label = LIDENT) COLON LOCAL (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 361 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) LOCAL (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LOCAL (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 1877 is preventing recovery from 2 states:
+strict_function_type ::= LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
+                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 1150 is preventing recovery from 2 states:
+generalized_constructor_arguments ::= OF . constructor_arguments
 
 
 # State 1152 is preventing recovery from 2 states:
-label_declaration_semi ::= mutable_or_global_flag LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute)
-label_declaration      ::= mutable_or_global_flag LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute)
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= NONLOCAL           (cty = atomic_type) .
+constructor_arguments                                   ::= NONLOCAL           (cty = atomic_type) .
+atomic_type                                             ::= (ty = atomic_type) . HASH                clty_longident
+                                                          | (ty = atomic_type) . type_longident     
 
 
-# State 1290 is preventing recovery from 2 states:
-primitive_declaration ::= EXTERNAL (ext = ext) list(attribute) val_ident COLON . (ty = possibly_poly(core_type)) EQUAL (prim = nonempty_list(mkrhs(raw_string))) list(post_item_attribute)
+# State 1878 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL  . (ty = tuple_type)                     MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL  . (ty = tuple_type)                     MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL  . LPAREN                                (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL  . LPAREN                                (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER (codomain = tuple_type)          
+                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER LOCAL        . (codomain = tuple_type)        
+                       | LOCAL  . (ty = tuple_type)                     MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL  . LPAREN                                (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER (codomain = strict_function_type)
 
 
 # State 340 is preventing recovery from 2 states:
-reversed_separated_nontrivial_llist(COMMA,core_type) ::= (x1 = core_type) COMMA . (x2 = core_type)
+strict_function_type ::= (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = tuple_type)          
+                       | (label = optlabel) LPAREN (xs = reversed_nonempty_llist(typevar)) DOT (ty = core_type) RPAREN MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 174 is preventing recovery from 2 states:
+strict_function_type ::= LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
 
 
 # State 1864 is preventing recovery from 2 states:
-strict_function_type ::= LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
-                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
-                       | LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+strict_function_type ::= LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | LOCAL LPAREN (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
 
 
-# State 1808 is preventing recovery from 2 states:
-meth_list ::= LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute)
-            | LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute)
-            | LIDENT COLON . possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute) (tail = meth_list)
+# State 367 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) (ty = tuple_type) MINUSGREATER . LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) (ty = tuple_type) MINUSGREATER . (codomain = tuple_type)          
+                       | (label = optlabel) (ty = tuple_type) MINUSGREATER . (codomain = strict_function_type)
+
+
+# State 1840 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON LOCAL . (ty = tuple_type) MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)          
+                       | (label = LIDENT) COLON LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON LOCAL . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)
+                       | (label = LIDENT) COLON LOCAL . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN MINUSGREATER (codomain = strict_function_type)
 
 
 # State 126 is preventing recovery from 2 states:
@@ -871,46 +839,72 @@ atomic_type          ::= LPAREN . (xs = reversed_separated_nontrivial_llist(COMM
                        | LPAREN . core_type                                                   RPAREN
 
 
-# State 689 is preventing recovery from 2 states:
-type_constraint ::= COLON core_type COLONGREATER . core_type
+# State 179 is preventing recovery from 2 states:
+strict_function_type ::= (label = LIDENT) COLON . LOCAL             (ty = tuple_type)                       MINUSGREATER                            LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON . LOCAL             (ty = tuple_type)                       MINUSGREATER                            (codomain = tuple_type)          
+                       | (label = LIDENT) COLON . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      LOCAL                             (codomain = tuple_type)
+                       | (label = LIDENT) COLON . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      (codomain = tuple_type)          
+                       | (label = LIDENT) COLON . (ty = tuple_type) MINUSGREATER                            LOCAL                                   (codomain = tuple_type)          
+                       | (label = LIDENT) COLON . (ty = tuple_type) MINUSGREATER                            (codomain = tuple_type)                
+                       | (label = LIDENT) COLON . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER LOCAL                             (codomain = tuple_type)          
+                       | (label = LIDENT) COLON . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER (codomain = tuple_type)          
+                       | (label = LIDENT) COLON . LOCAL             (ty = tuple_type)                       MINUSGREATER                            (codomain = strict_function_type)
+                       | (label = LIDENT) COLON . LOCAL             LPAREN                                  (xs = reversed_nonempty_llist(typevar)) DOT                               (ty = core_type)        RPAREN       MINUSGREATER                      (codomain = strict_function_type)
+                       | (label = LIDENT) COLON . (ty = tuple_type) MINUSGREATER                            (codomain = strict_function_type)      
+                       | (label = LIDENT) COLON . LPAREN            (xs = reversed_nonempty_llist(typevar)) DOT                                     (ty = core_type)                  RPAREN                  MINUSGREATER (codomain = strict_function_type)
 
 
 # State 1176 is preventing recovery from 2 states:
-reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (cty = atomic_type) .
-constructor_arguments                                   ::= (cty = atomic_type) .
-atomic_type                                             ::= (ty = atomic_type)    . HASH           clty_longident
-                                                          | (ty = atomic_type)    . type_longident
+reversed_separated_nonempty_llist(STAR,atomic_type_gbl) ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . NONLOCAL            (cty = atomic_type)
+                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . GLOBAL              (cty = atomic_type)
+                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . (cty = atomic_type)
+constructor_arguments                                   ::= (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . NONLOCAL            (cty = atomic_type)
+                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . GLOBAL              (cty = atomic_type)
+                                                          | (xs = reversed_separated_nonempty_llist(STAR,atomic_type_gbl)) STAR . (cty = atomic_type)
+
+
+# State 1783 is preventing recovery from 2 states:
+class_self_pattern ::= LPAREN pattern COLON . core_type RPAREN
+
+
+# State 350 is preventing recovery from 2 states:
+strict_function_type ::= (label = optlabel) LOCAL                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER LOCAL                             (codomain = tuple_type)
+                       | (label = optlabel) LOCAL                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = tuple_type)          
+                       | (label = optlabel) LOCAL                                                         LPAREN . (xs = reversed_nonempty_llist(typevar)) DOT            (ty = core_type) RPAREN MINUSGREATER (codomain = strict_function_type)
+atomic_type          ::= LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH                                      clty_longident
+                       | LPAREN             . (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN type_longident                           
+                       | LPAREN             . MODULE                                                      ext    list(attribute)                           module_type    RPAREN          
+                       | LPAREN             . core_type                                                   RPAREN
+
+
+# State 692 is preventing recovery from 2 states:
+type_constraint ::= COLONGREATER . core_type
+
+
+# State 1480 is preventing recovery from 2 states:
+signature_item ::= CLASS (ext = ext) list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT COLON . (cty = class_type) list(post_item_attribute) (bs = list(and_class_description))
 
 
 # State 315 is preventing recovery from 2 states:
-atomic_type ::= LPAREN (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN . HASH           clty_longident
-              | LPAREN (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN . type_longident
+reversed_separated_nontrivial_llist(STAR,atomic_type) ::= (x1 = atomic_type) STAR             (x2 = atomic_type) .
+atomic_type                                           ::= (ty = atomic_type) . HASH           clty_longident      
+                                                        | (ty = atomic_type) . type_longident
 
 
-# State 795 is preventing recovery from 2 states:
-labeled_simple_pattern ::= LABEL LPAREN (pat = pattern) COLON (xs = reversed_nonempty_llist(typevar)) DOT . (ty = core_type) RPAREN
+# State 1489 is preventing recovery from 2 states:
+class_type ::= (label = optlabel) . (domain = tuple_type) MINUSGREATER (codomain = class_type)
 
 
-# State 1642 is preventing recovery from 2 states:
-method_ ::= list(attribute) private_flag LIDENT COLON TYPE (xs = nonempty_list(mkrhs(LIDENT))) DOT . core_type EQUAL seq_expr
-
-
-# State 1435 is preventing recovery from 1 states:
-class_signature ::= LET OPEN list(attribute) mod_longident IN . class_signature
-
-
-# State 1460 is preventing recovery from 1 states:
-list(and_class_type_declaration) ::= AND list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT EQUAL . (csig = class_signature) list(post_item_attribute) (xs = list(and_class_type_declaration))
-
-
-# State 182 is preventing recovery from 1 states:
-type_longident                                  ::= LIDENT   . SLASH     TYPE_DISAMBIGUATOR
-mk_longident(mod_ext_longident,LIDENT)          ::= LIDENT .
-generic_type_declaration(nonrec_flag,type_kind) ::= TYPE     (ext = ext) list(attribute)    (params = type_parameters) LIDENT . (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)
+# State 1328 is preventing recovery from 1 states:
+open_description ::= OPEN BANG (ext = ext) list(attribute) . mod_ext_longident list(post_item_attribute)
 
 
 # State 129 is preventing recovery from 1 states:
 atomic_type ::= LPAREN MODULE ext list(attribute) . module_type RPAREN
+
+
+# State 1425 is preventing recovery from 1 states:
+class_sig_field ::= INHERIT list(attribute) . class_signature list(post_item_attribute)
 
 
 # State 130 is preventing recovery from 1 states:
@@ -919,68 +913,15 @@ mod_ext_longident_ ::= UIDENT   . SLASH TYPE_DISAMBIGUATOR
 ident              ::= UIDENT .
 
 
-# State 557 is preventing recovery from 1 states:
-with_constraint ::= MODULE TYPE mty_longident COLONEQUAL . (rhs = module_type)
-
-
-# State 1236 is preventing recovery from 1 states:
-paren_module_expr ::= LPAREN VAL list(attribute) (e = expr) COLON . module_type COLONGREATER module_type RPAREN
-                    | LPAREN VAL list(attribute) (e = expr) COLON . module_type RPAREN      
-
-
-# State 565 is preventing recovery from 1 states:
-with_constraint ::= MODULE mod_longident COLONEQUAL . mod_ext_longident
-
-
-# State 1946 is preventing recovery from 1 states:
-parse_mod_ext_longident' ::= . parse_mod_ext_longident
-
-
-# State 1350 is preventing recovery from 1 states:
-list(and_module_declaration) ::= AND list(attribute) module_name COLON . (mty = module_type) list(post_item_attribute) (xs = list(and_module_declaration))
-
-
-# State 559 is preventing recovery from 1 states:
-module_type ::= module_type MINUSGREATER . module_type
-
-
-# State 277 is preventing recovery from 1 states:
-mod_ext_longident ::= mod_ext_longident LPAREN . mod_ext_longident RPAREN
-
-
-# State 585 is preventing recovery from 1 states:
-paren_module_expr ::= LPAREN (me = module_expr) COLON . (mty = module_type) RPAREN
-
-
-# State 1339 is preventing recovery from 1 states:
-module_subst ::= MODULE (ext = ext) list(attribute) UIDENT COLONEQUAL . mod_ext_longident list(post_item_attribute)
-
-
-# State 1125 is preventing recovery from 1 states:
-module_binding_body ::= COLON . (mty = module_type) EQUAL (me = module_expr)
-
-
-# State 1344 is preventing recovery from 1 states:
-signature_item ::= MODULE (ext = ext) list(attribute) REC module_name COLON . (mty = module_type) list(post_item_attribute) (bs = list(and_module_declaration))
-
-
-# State 520 is preventing recovery from 1 states:
-functor_arg ::= LPAREN module_name COLON . (mty = module_type) RPAREN
-
-
-# State 622 is preventing recovery from 1 states:
-simple_expr ::= mod_longident DOT LPAREN MODULE ext list(attribute) module_expr COLON . module_type RPAREN
-
-
-# State 303 is preventing recovery from 1 states:
+# State 310 is preventing recovery from 1 states:
 atomic_type ::= (ty = atomic_type) HASH . clty_longident
 
 
-# State 273 is preventing recovery from 1 states:
-atomic_type ::= HASH . clty_longident
+# State 532 is preventing recovery from 1 states:
+module_type ::= FUNCTOR list(attribute) reversed_nonempty_llist(functor_arg) MINUSGREATER . (mty = module_type)
 
 
-# State 1807 is preventing recovery from 1 states:
+# State 1817 is preventing recovery from 1 states:
 type_longident                         ::= LIDENT   . SLASH TYPE_DISAMBIGUATOR              
 mk_longident(mod_ext_longident,LIDENT) ::= LIDENT .
 meth_list                              ::= LIDENT   . COLON possibly_poly(core_type_no_attr) list(attribute)
@@ -988,11 +929,96 @@ meth_list                              ::= LIDENT   . COLON possibly_poly(core_t
                                          | LIDENT   . COLON possibly_poly(core_type_no_attr) list(attribute) SEMI list(attribute) (tail = meth_list)
 
 
-# State 521 is preventing recovery from 1 states:
+# State 1351 is preventing recovery from 1 states:
+signature_item ::= MODULE (ext = ext) list(attribute) REC module_name COLON . (mty = module_type) list(post_item_attribute) (bs = list(and_module_declaration))
+
+
+# State 284 is preventing recovery from 1 states:
+mod_ext_longident ::= mod_ext_longident LPAREN . mod_ext_longident RPAREN
+
+
+# State 1240 is preventing recovery from 1 states:
+paren_module_expr ::= LPAREN VAL list(attribute) (e = expr) COLONGREATER . module_type RPAREN
+
+
+# State 1481 is preventing recovery from 1 states:
+type_longident                         ::= LIDENT           . SLASH TYPE_DISAMBIGUATOR   
+mk_longident(mod_ext_longident,LIDENT) ::= LIDENT .        
+class_type                             ::= (label = LIDENT) . COLON (domain = tuple_type) MINUSGREATER (codomain = class_type)
+
+
+# State 221 is preventing recovery from 1 states:
+simple_pattern_not_ident ::= LPAREN MODULE ext list(attribute) module_name COLON . module_type RPAREN
+
+
+# State 528 is preventing recovery from 1 states:
 module_type ::= LPAREN . module_type RPAREN
 
 
+# State 554 is preventing recovery from 1 states:
+with_constraint ::= MODULE TYPE mty_longident EQUAL . (rhs = module_type)
+
+
+# State 1366 is preventing recovery from 1 states:
+module_declaration_body ::= COLON . (mty = module_type)
+
+
+# State 1395 is preventing recovery from 1 states:
+class_type_declarations ::= CLASS TYPE (ext = ext) list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT EQUAL . (csig = class_signature) list(post_item_attribute) (bs = list(and_class_type_declaration))
+
+
+# State 1431 is preventing recovery from 1 states:
+class_signature ::= LET OPEN BANG list(attribute) mod_longident IN . class_signature
+
+
+# State 1434 is preventing recovery from 1 states:
+class_signature ::= LBRACKET (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET . clty_longident
+
+
+# State 572 is preventing recovery from 1 states:
+with_constraint ::= MODULE mod_longident COLONEQUAL . mod_ext_longident
+
+
+# State 1332 is preventing recovery from 1 states:
+open_description ::= OPEN (ext = ext) list(attribute) . mod_ext_longident list(post_item_attribute)
+
+
+# State 1228 is preventing recovery from 1 states:
+simple_expr ::= LPAREN MODULE ext list(attribute) module_expr COLON . module_type RPAREN
+
+
+# State 1374 is preventing recovery from 1 states:
+signature_item ::= INCLUDE (ext = ext) list(attribute) . (thing = module_type) list(post_item_attribute)
+
+
+# State 1968 is preventing recovery from 1 states:
+parse_module_type' ::= . parse_module_type
+
+
 # State 167 is preventing recovery from 1 states:
+mod_ext_longident_ ::= UIDENT   . SLASH TYPE_DISAMBIGUATOR
+                     | UIDENT .
+constr_ident       ::= UIDENT .
+
+
+# State 323 is preventing recovery from 1 states:
+atomic_type ::= LPAREN (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH . clty_longident
+
+
+# State 566 is preventing recovery from 1 states:
+module_type ::= module_type MINUSGREATER . module_type
+
+
+# State 1972 is preventing recovery from 1 states:
+parse_mty_longident' ::= . parse_mty_longident
+
+
+# State 552 is preventing recovery from 1 states:
+with_constraint ::= MODULE TYPE . mty_longident COLONEQUAL (rhs = module_type)
+                  | MODULE TYPE . mty_longident EQUAL      (rhs = module_type)
+
+
+# State 176 is preventing recovery from 1 states:
 type_longident                         ::= LIDENT           . SLASH TYPE_DISAMBIGUATOR
 strict_function_type                   ::= (label = LIDENT) . COLON LOCAL              (ty = tuple_type)                       MINUSGREATER                            LOCAL                             (codomain = tuple_type)
                                          | (label = LIDENT) . COLON LOCAL              (ty = tuple_type)                       MINUSGREATER                            (codomain = tuple_type)          
@@ -1009,87 +1035,75 @@ strict_function_type                   ::= (label = LIDENT) . COLON LOCAL       
 mk_longident(mod_ext_longident,LIDENT) ::= LIDENT .        
 
 
-# State 1321 is preventing recovery from 1 states:
-open_description ::= OPEN BANG (ext = ext) list(attribute) . mod_ext_longident list(post_item_attribute)
-
-
-# State 1233 is preventing recovery from 1 states:
-paren_module_expr ::= LPAREN VAL list(attribute) (e = expr) COLONGREATER . module_type RPAREN
-
-
-# State 1421 is preventing recovery from 1 states:
-class_signature ::= LET OPEN BANG list(attribute) mod_longident IN . class_signature
-
-
-# State 1958 is preventing recovery from 1 states:
-parse_module_type' ::= . parse_module_type
-
-
-# State 1385 is preventing recovery from 1 states:
-class_type_declarations ::= CLASS TYPE (ext = ext) list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT EQUAL . (csig = class_signature) list(post_item_attribute) (bs = list(and_class_type_declaration))
-
-
-# State 1883 is preventing recovery from 1 states:
-type_longident                                           ::= LIDENT   . SLASH     TYPE_DISAMBIGUATOR
-mk_longident(mod_ext_longident,LIDENT)                   ::= LIDENT .
-generic_type_declaration(nonrec_flag,type_kind)          ::= TYPE     (ext = ext) list(attribute)    (params = type_parameters) LIDENT . (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)                            
-generic_type_declaration(no_nonrec_flag,type_subst_kind) ::= TYPE     (ext = ext) list(attribute)    (params = type_parameters) LIDENT . COLONEQUAL                       nonempty_type_kind                                    (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)
-
-
-# State 1253 is preventing recovery from 1 states:
+# State 1260 is preventing recovery from 1 states:
 option(preceded(EQUAL,module_type)) ::= EQUAL . (x = module_type)
 
 
-# State 316 is preventing recovery from 1 states:
-atomic_type ::= LPAREN (xs = reversed_separated_nontrivial_llist(COMMA,core_type)) RPAREN HASH . clty_longident
-
-
-# State 1239 is preventing recovery from 1 states:
-paren_module_expr ::= LPAREN VAL list(attribute) (e = expr) COLON module_type COLONGREATER . module_type RPAREN
-
-
-# State 1333 is preventing recovery from 1 states:
-module_type_subst ::= MODULE TYPE (ext = ext) list(attribute) ident COLONEQUAL . (typ = module_type) list(post_item_attribute)
-
-
-# State 545 is preventing recovery from 1 states:
-with_constraint ::= MODULE TYPE . mty_longident COLONEQUAL (rhs = module_type)
-                  | MODULE TYPE . mty_longident EQUAL      (rhs = module_type)
-
-
-# State 525 is preventing recovery from 1 states:
-module_type ::= FUNCTOR list(attribute) reversed_nonempty_llist(functor_arg) MINUSGREATER . (mty = module_type)
-
-
-# State 1221 is preventing recovery from 1 states:
-simple_expr ::= LPAREN MODULE ext list(attribute) module_expr COLON . module_type RPAREN
-
-
-# State 158 is preventing recovery from 1 states:
-mod_ext_longident_ ::= UIDENT   . SLASH TYPE_DISAMBIGUATOR
-                     | UIDENT .
-constr_ident       ::= UIDENT .
-
-
-# State 212 is preventing recovery from 1 states:
-simple_pattern_not_ident ::= LPAREN MODULE ext list(attribute) module_name COLON . module_type RPAREN
-
-
-# State 1916 is preventing recovery from 1 states:
-parse_any_longident' ::= . parse_any_longident
-
-
-# State 562 is preventing recovery from 1 states:
+# State 569 is preventing recovery from 1 states:
 with_constraint ::= MODULE mod_longident EQUAL . mod_ext_longident
 
 
-# State 293 is preventing recovery from 1 states:
+# State 527 is preventing recovery from 1 states:
+functor_arg ::= LPAREN module_name COLON . (mty = module_type) RPAREN
+
+
+# State 1340 is preventing recovery from 1 states:
+module_type_subst ::= MODULE TYPE (ext = ext) list(attribute) ident COLONEQUAL . (typ = module_type) list(post_item_attribute)
+
+
+# State 1132 is preventing recovery from 1 states:
+module_binding_body ::= COLON . (mty = module_type) EQUAL (me = module_expr)
+
+
+# State 592 is preventing recovery from 1 states:
+paren_module_expr ::= LPAREN (me = module_expr) COLON . (mty = module_type) RPAREN
+
+
+# State 300 is preventing recovery from 1 states:
 type_longident                         ::= LIDENT   . SLASH TYPE_DISAMBIGUATOR
 mk_longident(mod_ext_longident,LIDENT) ::= LIDENT .
 
 
-# State 1325 is preventing recovery from 1 states:
-open_description ::= OPEN (ext = ext) list(attribute) . mod_ext_longident list(post_item_attribute)
+# State 629 is preventing recovery from 1 states:
+simple_expr ::= mod_longident DOT LPAREN MODULE ext list(attribute) module_expr COLON . module_type RPAREN
+
+
+# State 1470 is preventing recovery from 1 states:
+list(and_class_type_declaration) ::= AND list(attribute) (virt = virtual_flag) (params = formal_class_parameters) LIDENT EQUAL . (csig = class_signature) list(post_item_attribute) (xs = list(and_class_type_declaration))
+
+
+# State 1243 is preventing recovery from 1 states:
+paren_module_expr ::= LPAREN VAL list(attribute) (e = expr) COLON . module_type COLONGREATER module_type RPAREN
+                    | LPAREN VAL list(attribute) (e = expr) COLON . module_type RPAREN      
+
+
+# State 1246 is preventing recovery from 1 states:
+paren_module_expr ::= LPAREN VAL list(attribute) (e = expr) COLON module_type COLONGREATER . module_type RPAREN
+
+
+# State 1445 is preventing recovery from 1 states:
+class_signature ::= LET OPEN list(attribute) mod_longident IN . class_signature
+
+
+# State 1357 is preventing recovery from 1 states:
+list(and_module_declaration) ::= AND list(attribute) module_name COLON . (mty = module_type) list(post_item_attribute) (xs = list(and_module_declaration))
+
+
+# State 280 is preventing recovery from 1 states:
+atomic_type ::= HASH . clty_longident
+
+
+# State 191 is preventing recovery from 1 states:
+type_longident                                  ::= LIDENT   . SLASH     TYPE_DISAMBIGUATOR
+mk_longident(mod_ext_longident,LIDENT)          ::= LIDENT .
+generic_type_declaration(nonrec_flag,type_kind) ::= TYPE     (ext = ext) list(attribute)    (params = type_parameters) LIDENT . (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)
+
+
+# State 1893 is preventing recovery from 1 states:
+type_longident                                           ::= LIDENT   . SLASH     TYPE_DISAMBIGUATOR
+mk_longident(mod_ext_longident,LIDENT)                   ::= LIDENT .
+generic_type_declaration(nonrec_flag,type_kind)          ::= TYPE     (ext = ext) list(attribute)    (params = type_parameters) LIDENT . (kind_priv_manifest = type_kind) (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)                            
+generic_type_declaration(no_nonrec_flag,type_subst_kind) ::= TYPE     (ext = ext) list(attribute)    (params = type_parameters) LIDENT . COLONEQUAL                       nonempty_type_kind                                    (xs = reversed_llist(preceded(CONSTRAINT,constrain))) list(post_item_attribute)
 
 
 # State 114 is preventing recovery from 1 states:
@@ -1097,33 +1111,19 @@ mod_ext_longident_ ::= UIDENT   . SLASH TYPE_DISAMBIGUATOR
                      | UIDENT .
 
 
-# State 547 is preventing recovery from 1 states:
-with_constraint ::= MODULE TYPE mty_longident EQUAL . (rhs = module_type)
+# State 564 is preventing recovery from 1 states:
+with_constraint ::= MODULE TYPE mty_longident COLONEQUAL . (rhs = module_type)
 
 
-# State 1424 is preventing recovery from 1 states:
-class_signature ::= LBRACKET (xs = reversed_separated_nonempty_llist(COMMA,core_type)) RBRACKET . clty_longident
+# State 1926 is preventing recovery from 1 states:
+parse_any_longident' ::= . parse_any_longident
 
 
-# State 1367 is preventing recovery from 1 states:
-signature_item ::= INCLUDE (ext = ext) list(attribute) . (thing = module_type) list(post_item_attribute)
+# State 1346 is preventing recovery from 1 states:
+module_subst ::= MODULE (ext = ext) list(attribute) UIDENT COLONEQUAL . mod_ext_longident list(post_item_attribute)
 
 
-# State 1962 is preventing recovery from 1 states:
-parse_mty_longident' ::= . parse_mty_longident
-
-
-# State 1415 is preventing recovery from 1 states:
-class_sig_field ::= INHERIT list(attribute) . class_signature list(post_item_attribute)
-
-
-# State 1359 is preventing recovery from 1 states:
-module_declaration_body ::= COLON . (mty = module_type)
-
-
-# State 1471 is preventing recovery from 1 states:
-type_longident                         ::= LIDENT           . SLASH TYPE_DISAMBIGUATOR   
-mk_longident(mod_ext_longident,LIDENT) ::= LIDENT .        
-class_type                             ::= (label = LIDENT) . COLON (domain = tuple_type) MINUSGREATER (codomain = class_type)
+# State 1956 is preventing recovery from 1 states:
+parse_mod_ext_longident' ::= . parse_mod_ext_longident
 
 

--- a/vendor/parser-standard/asttypes.mli
+++ b/vendor/parser-standard/asttypes.mli
@@ -49,6 +49,15 @@ type global_flag =
   | Nonlocal
   | Nothing
 
+(* constant layouts are parsed as layout annotations, and also used
+   in the type checker as already-inferred (i.e. non-variable) layouts *)
+type const_layout =
+  | Any
+  | Value
+  | Void
+  | Immediate64
+  | Immediate
+
 type label = string
 
 type arg_label =

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -757,6 +757,15 @@ let mk_directive ~loc name arg =
       pdir_loc = make_loc loc;
     }
 
+let check_layout loc id =
+  begin
+    match id with
+    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
+    | _ -> expecting loc "layout"
+  end;
+  let loc = make_loc loc in
+  Attr.mk ~loc (mkloc id loc) (PStr [])
+
 %}
 
 /* Tokens */
@@ -3339,12 +3348,27 @@ type_parameters:
       { [] }
   | p = type_parameter
       { [p] }
-  | LPAREN ps = separated_nonempty_llist(COMMA, type_parameter) RPAREN
+  | LPAREN
+    ps = separated_nonempty_llist(COMMA, parenthesized_type_parameter)
+    RPAREN
       { ps }
 ;
-type_parameter:
-    type_variance type_variable        { $2, $1 }
+
+layout:
+  ident { check_layout $loc($1) $1 }
 ;
+
+parenthesized_type_parameter:
+    type_parameter { $1 }
+  | type_variance type_variable COLON layout
+      { {$2 with ptyp_attributes = [$4]}, $1 }
+;
+
+type_parameter:
+    type_variance type_variable attributes
+      { {$2 with ptyp_attributes = $3}, $1 }
+;
+
 type_variable:
   mktyp(
     QUOTE tyvar = ident


### PR DESCRIPTION
The desugared syntax `let local_ _ = x` is invalid.

This is currently based on the branch that contains our changes: `rebase-js-extensions-on-upstream`. Happy to rebase this on top of an other branch.