### PR TITLE
Don't desugar `let _ = local_ x`

### DIFF
--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -332,10 +332,10 @@ module Let_binding = struct
                annotations and extensions into the pattern and the
                expression. *)
             match lb_pat.ppat_desc with
-            | Ppat_any -> (false, lb_exp)
-            | _ ->
+            | Ppat_var _ | Ppat_constraint ({ppat_desc = Ppat_var _;_}, _) ->
                 let sattrs, _ = check_local_attr sbody.pexp_attributes in
                 (true, {sbody with pexp_attributes= sattrs})
+            | _ -> (false, lb_exp)
           in
           let pattrs, _ = check_local_attr lb_pat.ppat_attributes in
           let pat = {lb_pat with ppat_attributes= pattrs} in

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -326,8 +326,17 @@ module Let_binding = struct
           ( { pexp_desc= Pexp_extension ({txt= "extension.local"; _}, PStr [])
             ; _ }
           , [(Nolabel, sbody)] ) ->
-          let sattrs, _ = check_local_attr sbody.pexp_attributes in
-          let sbody = {sbody with pexp_attributes= sattrs} in
+          let islocal, sbody =
+            (* The desugaring is only valid for some patterns. The pattern
+               part must still be rewritten as the parser duplicated the type
+               annotations and extensions into the pattern and the
+               expression. *)
+            match lb_pat.ppat_desc with
+            | Ppat_any -> (false, lb_exp)
+            | _ ->
+                let sattrs, _ = check_local_attr sbody.pexp_attributes in
+                (true, {sbody with pexp_attributes= sattrs})
+          in
           let pattrs, _ = check_local_attr lb_pat.ppat_attributes in
           let pat = {lb_pat with ppat_attributes= pattrs} in
           let fake_ctx =
@@ -338,7 +347,7 @@ module Let_binding = struct
               ; lb_attributes= []
               ; lb_loc= Location.none }
           in
-          ( true
+          ( islocal
           , fake_ctx
           , sub_pat ~ctx:fake_ctx pat
           , sub_exp ~ctx:fake_ctx sbody )

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3710,7 +3710,7 @@
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/local.ml local.ml.stdout)))
+ (action (diff tests/local.ml.ref local.ml.stdout)))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -34,3 +34,5 @@ type ('a, 'b) cfn =
   a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
 
 type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+let _ = local_ ()

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -45,3 +45,7 @@ let () = local_ r
 
 let local_ x : string = "hi"
 let (x : string) = local_ "hi"
+let x = local_ ("hi" : string)
+
+let x : 'a . 'a -> 'a = local_ "hi"
+let local_ f : 'a. 'a -> 'a = "hi"

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -36,3 +36,9 @@ type ('a, 'b) cfn =
 type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
 
 let _ = local_ ()
+
+let () = local_ x
+
+let {b} = local_ ()
+
+let () = local_ r

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -42,3 +42,6 @@ let () = local_ x
 let {b} = local_ ()
 
 let () = local_ r
+
+let local_ x : string = "hi"
+let (x : string) = local_ "hi"

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -42,3 +42,7 @@ let () = local_ x
 let {b} = local_ ()
 
 let () = local_ r
+
+let local_ x : string = "hi"
+
+let (x : string) = local_ "hi"

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -1,0 +1,44 @@
+let f a b c = 1
+
+let f (local_ a) ~foo:(local_ b) ?foo:(local_ c = 1) ~(local_ d) = ()
+
+let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
+
+let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
+
+let f () = local_
+  let a = [local_ 1] in
+  let local_ r = 1 in
+  let local_ f : 'a. 'a -> 'a = fun x -> local_ x in
+  let local_ g a b c : int = 1 in
+  let () = g (local_ fun () -> ()) in
+  local_ "asdfasdfasdfasdfasdfasdfasdf"
+
+let f () =
+  exclave_
+  (let a = [exclave_ 1] in
+   let local_ r = 1 in
+   let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
+   let local_ g a b c : int = 1 in
+   let () = g (exclave_ (fun () -> ())) in
+   exclave_ "asdfasdfasdfasdfasdfasdfasdf" )
+
+type 'a r = {mutable a: 'a; b: 'a; global_ c: 'a}
+
+type 'a r =
+  | Foo of global_ 'a
+  | Bar of 'a * global_ 'a
+  | Baz of global_ int * string * global_ 'a
+
+type ('a, 'b) cfn =
+  a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
+
+type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+let _ = local_ ()
+
+let () = local_ x
+
+let {b} = local_ ()
+
+let () = local_ r

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -46,3 +46,9 @@ let () = local_ r
 let local_ x : string = "hi"
 
 let (x : string) = local_ "hi"
+
+let local_ x = ("hi" : string)
+
+let x : 'a. 'a -> 'a = local_ "hi"
+
+let local_ f : 'a. 'a -> 'a = "hi"


### PR DESCRIPTION
The desugared syntax `let local_ _ = x` is invalid.

Same as https://github.com/janestreet/ocamlformat/pull/20, rebased on the `jane` branch.