### PR TITLE
No fail fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest


### PR DESCRIPTION
Currently ocaml and windows don't play well on github CI. This PR prevent fail-fast, so that other OS (such as Linux) will still get tested. 

Hopefully the problem will be sorted out someday and we can restore fail-fast.