### PR TITLE
better exclave_ formatting

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2322,6 +2322,16 @@ end = struct
           ; _ }
       , _ ) ->
         false
+    | ( Exp
+          { pexp_desc=
+              Pexp_apply
+                ( { pexp_desc=
+                      Pexp_extension ({txt= "extension.exclave"; _}, PStr [])
+                  ; _ }
+                , [(Nolabel, _)] )
+          ; _ }
+      , _ ) ->
+        false
     | _, {pexp_desc= Pexp_infix _; pexp_attributes= _ :: _; _} -> true
     | ( Str
           { pstr_desc=

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1411,6 +1411,15 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
     ; _ } ->
       ( fmt " local_"
       , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp ~ctx sbody) )
+  | { pexp_desc=
+        Pexp_apply
+          ( { pexp_desc=
+                Pexp_extension ({txt= "extension.exclave"; _}, PStr [])
+            ; _ }
+          , [(Nolabel, sbody)] )
+    ; _ } ->
+      ( fmt " exclave_"
+      , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp ~ctx sbody) )
   | _ -> (noop, fmt_expression c ~eol:(fmt "@;<1000 0>") xbody)
 
 and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -6,6 +6,8 @@ let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
 
 let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
 
+let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]
+
 let f () = local_
   let a = [local_ 1] in
   let local_ r = 1 in
@@ -14,14 +16,13 @@ let f () = local_
   let () = g (local_ fun () -> ()) in
   local_ "asdfasdfasdfasdfasdfasdfasdf"
 
-let f () =
-  exclave_
-  (let a = [exclave_ 1] in
-   let local_ r = 1 in
-   let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
-   let local_ g a b c : int = 1 in
-   let () = g (exclave_ (fun () -> ())) in
-   exclave_ "asdfasdfasdfasdfasdfasdfasdf" )
+let f () = exclave_
+  let a = [exclave_ 1] in
+  let local_ r = 1 in
+  let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
+  let local_ g a b c : int = 1 in
+  let () = g (exclave_ (fun () -> ())) in
+  exclave_ "asdfasdfasdfasdfasdfasdfasdf"
 
 type 'a r = {mutable a: 'a; b: 'a; global_ c: 'a}
 
@@ -37,15 +38,28 @@ type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
 
 let _ = local_ ()
 
+let _ = exclave_ ()
+
 let () = local_ x
+
+let () = exclave_ x
 
 let {b} = local_ ()
 
+let {b} = exclave_ ()
+
 let () = local_ r
+
+let () = exclave_ r
 
 let local_ x : string = "hi"
 let (x : string) = local_ "hi"
+
+let (x : string) = exclave_ "hi"
+
 let x = local_ ("hi" : string)
 
+let x = exclave_ ("hi" : string)
 let x : 'a . 'a -> 'a = local_ "hi"
+let x : 'a . 'a -> 'a = exclave_ "hi"
 let local_ f : 'a. 'a -> 'a = "hi"

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -6,6 +6,8 @@ let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
 
 let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
 
+let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]
+
 let f () = local_
   let a = [local_ 1] in
   let local_ r = 1 in
@@ -14,14 +16,13 @@ let f () = local_
   let () = g (local_ fun () -> ()) in
   local_ "asdfasdfasdfasdfasdfasdfasdf"
 
-let f () =
-  exclave_
-  (let a = [exclave_ 1] in
-   let local_ r = 1 in
-   let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
-   let local_ g a b c : int = 1 in
-   let () = g (exclave_ (fun () -> ())) in
-   exclave_ "asdfasdfasdfasdfasdfasdfasdf" )
+let f () = exclave_
+  let a = [exclave_ 1] in
+  let local_ r = 1 in
+  let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
+  let local_ g a b c : int = 1 in
+  let () = g (exclave_ fun () -> ()) in
+  exclave_ "asdfasdfasdfasdfasdfasdfasdf"
 
 type 'a r = {mutable a: 'a; b: 'a; global_ c: 'a}
 
@@ -37,18 +38,32 @@ type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
 
 let _ = local_ ()
 
+let _ = exclave_ ()
+
 let () = local_ x
+
+let () = exclave_ x
 
 let {b} = local_ ()
 
+let {b} = exclave_ ()
+
 let () = local_ r
+
+let () = exclave_ r
 
 let local_ x : string = "hi"
 
 let (x : string) = local_ "hi"
 
+let (x : string) = exclave_ "hi"
+
 let local_ x = ("hi" : string)
 
+let x = exclave_ ("hi" : string)
+
 let x : 'a. 'a -> 'a = local_ "hi"
+
+let x : 'a. 'a -> 'a = exclave_ "hi"
 
 let local_ f : 'a. 'a -> 'a = "hi"


### PR DESCRIPTION
This PR improves the formatting of `exclave_`, so now it should be very similar to `local_`. Apologies of not doing it correctly in the first try.

See [local.ml.ref](https://github.com/janestreet/ocamlformat/pull/28/files#diff-857ae052bf2cda3767fd26c0594ac7d70638df6b91d07539643af5de9aa9105d) for difference.