### PR TITLE
Check formatting in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Opam dependencies
         run: opam install --deps-only -t .
 
+      - name: Self-formatting test
+        run: opam exec -- dune build @fmt
+
       - name: Runtest
         run: opam exec -- dune runtest
 

--- a/HACKING.jst.md
+++ b/HACKING.jst.md
@@ -180,8 +180,10 @@ Validity checking
 The ocamlformat repo has (at least) two validity checks for repo health:
 
 * The ocamlformat sources themselves must be formatted. You can run this check
-with `make fmt`.  To reformat files that are incorrect, run `dune build @fmt
---auto-promote`. Running `make test` runs and `dune test` together.
+with `make fmt` (which will also auto-format `dune-project`).  To reformat files
+that are incorrect, run `dune build @fmt --auto-promote`. Running `make test`
+runs `make fmt` and `dune runtest` together.  The CI will check both the
+formatting check and the ocamlformat tests (but will not update `dune-project`).
 
 * All commits must be signed off. This is easy. When you're done with your
 sequence of commits and it's all ready to merge, just run

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -956,12 +956,7 @@ end = struct
               | {pof_desc= Otag (_, t1); _} -> typ == t1
               | {pof_desc= Oinherit t1; _} -> typ == t1 ) )
       | Ptyp_class (_, l) -> assert (List.exists l ~f)
-
-      (* Jane Street extension *)
-      | Ptyp_constr_unboxed (_, t1N) -> assert (List.exists t1N ~f)
-      (* End Jane Street extension *)
-
-      )
+      | Ptyp_constr_unboxed (_, t1N) -> assert (List.exists t1N ~f) )
     | Td {ptype_manifest; _} -> (
       match ptype_manifest with
       | Some t -> assert (t == typ)
@@ -1683,12 +1678,8 @@ end = struct
       | Ptyp_any | Ptyp_var _ | Ptyp_object _ | Ptyp_class _
        |Ptyp_variant _ | Ptyp_poly _ | Ptyp_package _ | Ptyp_extension _ ->
           None
-
-      (* Jane Street extension *)
       | Ptyp_constr_unboxed (_, _ :: _ :: _) -> Some (Comma, Non)
-      | Ptyp_constr_unboxed _ -> Some (Apply, Non)
-      (* End Jane Street extension *)
-    )
+      | Ptyp_constr_unboxed _ -> Some (Apply, Non) )
     | {ctx= Cty {pcty_desc; _}; ast= Typ typ; _} -> (
       match pcty_desc with
       | Pcty_constr (_, _ :: _ :: _) -> Some (Comma, Non)
@@ -1804,11 +1795,7 @@ end = struct
       | Ptyp_any | Ptyp_var _ | Ptyp_constr _ | Ptyp_object _
        |Ptyp_class _ | Ptyp_variant _ | Ptyp_poly _ | Ptyp_extension _ ->
           None
-
-      (* Jane Street extension *)
-      | Ptyp_constr_unboxed _ -> None
-      (* End Jane Street extension *)
-    )
+      | Ptyp_constr_unboxed _ -> None )
     | Td _ -> None
     | Cty {pcty_desc; _} -> (
       match pcty_desc with Pcty_arrow _ -> Some MinusGreater | _ -> None )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -262,14 +262,10 @@ let fmt_constant c ?epi {pconst_desc; pconst_loc= loc} =
   Cmts.fmt c loc
   @@
   match pconst_desc with
-
-  (* Jane Street extension *)
   | Pconst_unboxed_integer (sign, lit, suf)
-  | Pconst_unboxed_float (sign, lit, suf) ->
-      (match sign with Positive -> noop | Negative -> char '-') $
-      char '#' $ str lit $ opt suf char
-  (* End Jane Street extension *)
-
+   |Pconst_unboxed_float (sign, lit, suf) ->
+      (match sign with Positive -> noop | Negative -> char '-')
+      $ char '#' $ str lit $ opt suf char
   | Pconst_integer (lit, suf) | Pconst_float (lit, suf) ->
       str lit $ opt suf char
   | Pconst_char _ -> wrap "'" "'" @@ str (Source.char_literal c.source loc)
@@ -965,17 +961,15 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
            (sub_typ ~ctx >> fmt_core_type c) )
       $ fmt "@ "
       $ fmt_longident_loc c ~pre:"#" lid
-
-  (* Jane Street extension *)
   | Ptyp_constr_unboxed (lid, []) -> fmt_longident_loc c lid $ char '#'
   | Ptyp_constr_unboxed (lid, [t1]) ->
-      fmt_core_type c (sub_typ ~ctx t1) $ fmt "@ " $ fmt_longident_loc c lid $ char '#'
+      fmt_core_type c (sub_typ ~ctx t1)
+      $ fmt "@ " $ fmt_longident_loc c lid $ char '#'
   | Ptyp_constr_unboxed (lid, t1N) ->
       wrap_fits_breaks c.conf "(" ")"
         (list t1N (Params.comma_sep c.conf)
            (sub_typ ~ctx >> fmt_core_type c) )
       $ fmt "@ " $ fmt_longident_loc c lid $ char '#'
-  (* End Jane Street extension *)
 
 and fmt_package_type c ctx cnstrs =
   let fmt_cstr ~first ~last:_ (lid, typ) =


### PR DESCRIPTION
We didn't run ocamlformat's self-formatting check in CI; now we do.

I deleted many of the "Jane Street extension" markers, as the auto-formatting was putting them in strange places.