### PR TITLE
Add a mode for erasing erasable jane-syntax

### DIFF
--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -16,6 +16,9 @@ let is_doc = function
   | {attr_name= {Location.txt= "ocaml.doc" | "ocaml.text"; _}; _} -> true
   | _ -> false
 
+let is_erasable_jane_syntax attr =
+  String.is_prefix ~prefix:"jane.erasable." attr.attr_name.txt
+
 let dedup_cmts fragment ast comments =
   let of_ast ast =
     let docs = ref (Set.empty (module Cmt)) in
@@ -100,6 +103,11 @@ let make_mapper conf ~ignore_doc_comments =
   in
   (* sort attributes *)
   let attributes (m : Ast_mapper.mapper) (atrs : attribute list) =
+    let atrs =
+      if Erase_jane_syntax.should_erase () then
+        List.filter atrs ~f:(fun a -> not (is_erasable_jane_syntax a))
+      else atrs
+    in
     let atrs =
       if ignore_doc_comments then
         List.filter atrs ~f:(fun a -> not (is_doc a))

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -31,7 +31,8 @@ type t =
   ; disable_conf_files: bool
   ; ignore_invalid_options: bool
   ; ocp_indent_config: bool
-  ; config: (string * string) list }
+  ; config: (string * string) list
+  ; erase_jane_syntax: bool }
 
 let default =
   { lib_conf= Conf.default
@@ -48,7 +49,8 @@ let default =
   ; disable_conf_files= false
   ; ignore_invalid_options= false
   ; ocp_indent_config= false
-  ; config= [] }
+  ; config= []
+  ; erase_jane_syntax= false }
 
 let global_conf = ref default
 
@@ -325,6 +327,15 @@ let ocp_indent_config =
     ~set:(fun ocp_indent_config conf -> {conf with ocp_indent_config})
     Arg.(value & flag & info ["ocp-indent-config"] ~doc ~docs)
 
+let erase_jane_syntax =
+  let doc =
+    "Erase all erasable Jane Street syntax extensions.  THIS OPTION WILL \
+     CHANGE THE RESULTING AST."
+  in
+  declare_option
+    ~set:(fun erase_jane_syntax conf -> {conf with erase_jane_syntax})
+    Arg.(value & flag & info ["erase-jane-syntax"] ~doc ~docs)
+
 let terms =
   [ Term.(
       const (fun lib_conf_modif conf ->
@@ -343,7 +354,8 @@ let terms =
   ; disable_conf_files
   ; ignore_invalid_options
   ; ocp_indent_config
-  ; config ]
+  ; config
+  ; erase_jane_syntax ]
 
 let global_term =
   let compose (t1 : ('a -> 'b) Term.t) (t2 : ('b -> 'c) Term.t) :
@@ -752,6 +764,7 @@ let validate_action () =
       Error (Printf.sprintf "Cannot specify %s with %s" a1 a2)
 
 let validate () =
+  Erase_jane_syntax.set_should_erase !global_conf.erase_jane_syntax ;
   let root =
     Option.map !global_conf.root
       ~f:Fpath.(fun x -> v x |> to_absolute |> normalize)

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -764,6 +764,8 @@ let validate_action () =
       Error (Printf.sprintf "Cannot specify %s with %s" a1 a2)
 
 let validate () =
+  (* We have to store this globally so that we can access it in the parser,
+     which doesn't have a [Conf_t.t]. *)
   Erase_jane_syntax.set_should_erase !global_conf.erase_jane_syntax ;
   let root =
     Option.map !global_conf.root

--- a/lib/bin_conf/dune
+++ b/lib/bin_conf/dune
@@ -11,4 +11,4 @@
    Ocamlformat_result.Global_scope))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib re))
+ (libraries erase_jane_syntax ocamlformat-lib re))

--- a/lib/erase_jane_syntax/dune
+++ b/lib/erase_jane_syntax/dune
@@ -1,0 +1,3 @@
+(library
+ (public_name ocamlformat.erase_jane_syntax)
+ (name erase_jane_syntax))

--- a/lib/erase_jane_syntax/erase_jane_syntax.ml
+++ b/lib/erase_jane_syntax/erase_jane_syntax.ml
@@ -1,0 +1,5 @@
+let should_erase_ref = ref false
+
+let set_should_erase yn = should_erase_ref := yn
+
+let should_erase () = !should_erase_ref

--- a/lib/erase_jane_syntax/erase_jane_syntax.mli
+++ b/lib/erase_jane_syntax/erase_jane_syntax.mli
@@ -1,0 +1,3 @@
+val set_should_erase : bool -> unit
+
+val should_erase : unit -> bool

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3703,6 +3703,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to local-erased.ml.stdout
+   (with-stderr-to local-erased.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --erase-jane-syntax %{dep:tests/local.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local-erased.ml.ref local-erased.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local-erased.ml.err local-erased.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to local.ml.stdout
    (with-stderr-to local.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/local.ml})))))

--- a/test/passing/tests/local-erased.ml.opts
+++ b/test/passing/tests/local-erased.ml.opts
@@ -1,0 +1,1 @@
+--erase-jane-syntax

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -1,69 +1,65 @@
 let f a b c = 1
 
-let f (local_ a) ~foo:(local_ b) ?foo:(local_ c = 1) ~(local_ d) = ()
+let f a ~foo:b ?foo:(c = 1) ~d = ()
 
-let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
+let f ~x ~(y : string) ?(z : string) = ()
 
-let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
+let xs = [(fun a (type b) ~c -> 1)]
 
-let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]
+let xs = [(fun a (type b) ~c -> 1)]
 
-let f () = local_
-  let a = [local_ 1] in
-  let local_ r = 1 in
-  let local_ f : 'a. 'a -> 'a = fun x -> local_ x in
-  let local_ g a b c : int = 1 in
-  let () = g (local_ fun () -> ()) in
-  local_ "asdfasdfasdfasdfasdfasdfasdf"
+let f () =
+  let a = [1] in
+  let r = 1 in
+  let f : 'a. 'a -> 'a = fun x -> x in
+  let g a b c : int = 1 in
+  let () = g (fun () -> ()) in
+  "asdfasdfasdfasdfasdfasdfasdf"
 
-let f () = exclave_
-  let a = [exclave_ 1] in
-  let local_ r = 1 in
-  let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
-  let local_ g a b c : int = 1 in
-  let () = g (exclave_ fun () -> ()) in
-  exclave_ "asdfasdfasdfasdfasdfasdfasdf"
+let f () =
+  let a = [1] in
+  let r = 1 in
+  let f : 'a. 'a -> 'a = fun x -> x in
+  let g a b c : int = 1 in
+  let () = g (fun () -> ()) in
+  "asdfasdfasdfasdfasdfasdfasdf"
 
-type 'a r = {mutable a: 'a; b: 'a; global_ c: 'a}
+type 'a r = {mutable a: 'a; b: 'a; c: 'a}
 
-type 'a r =
-  | Foo of global_ 'a
-  | Bar of 'a * global_ 'a
-  | Baz of global_ int * string * global_ 'a
+type 'a r = Foo of 'a | Bar of 'a * 'a | Baz of int * string * 'a
 
-type ('a, 'b) cfn =
-  a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
+type ('a, 'b) cfn = a:'a -> ?b:b -> 'a -> int -> 'b
 
 type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
 
-let _ = local_ ()
+let _ = ()
 
-let _ = exclave_ ()
+let _ = ()
 
-let () = local_ x
+let () = x
 
-let () = exclave_ x
+let () = x
 
-let {b} = local_ ()
+let {b} = ()
 
-let {b} = exclave_ ()
+let {b} = ()
 
-let () = local_ r
+let () = r
 
-let () = exclave_ r
+let () = r
 
-let local_ x : string = "hi"
+let x : string = "hi"
 
-let (x : string) = local_ "hi"
+let (x : string) = "hi"
 
-let (x : string) = exclave_ "hi"
+let (x : string) = "hi"
 
-let local_ x = ("hi" : string)
+let x = ("hi" : string)
 
-let x = exclave_ ("hi" : string)
+let x = ("hi" : string)
 
-let x : 'a. 'a -> 'a = local_ "hi"
+let x : 'a. 'a -> 'a = "hi"
 
-let x : 'a. 'a -> 'a = exclave_ "hi"
+let x : 'a. 'a -> 'a = "hi"
 
-let local_ f : 'a. 'a -> 'a = "hi"
+let f : 'a. 'a -> 'a = "hi"

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -1,0 +1,69 @@
+let f a b c = 1
+
+let f (local_ a) ~foo:(local_ b) ?foo:(local_ c = 1) ~(local_ d) = ()
+
+let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
+
+let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
+
+let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]
+
+let f () = local_
+  let a = [local_ 1] in
+  let local_ r = 1 in
+  let local_ f : 'a. 'a -> 'a = fun x -> local_ x in
+  let local_ g a b c : int = 1 in
+  let () = g (local_ fun () -> ()) in
+  local_ "asdfasdfasdfasdfasdfasdfasdf"
+
+let f () = exclave_
+  let a = [exclave_ 1] in
+  let local_ r = 1 in
+  let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
+  let local_ g a b c : int = 1 in
+  let () = g (exclave_ fun () -> ()) in
+  exclave_ "asdfasdfasdfasdfasdfasdfasdf"
+
+type 'a r = {mutable a: 'a; b: 'a; global_ c: 'a}
+
+type 'a r =
+  | Foo of global_ 'a
+  | Bar of 'a * global_ 'a
+  | Baz of global_ int * string * global_ 'a
+
+type ('a, 'b) cfn =
+  a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
+
+type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+let _ = local_ ()
+
+let _ = exclave_ ()
+
+let () = local_ x
+
+let () = exclave_ x
+
+let {b} = local_ ()
+
+let {b} = exclave_ ()
+
+let () = local_ r
+
+let () = exclave_ r
+
+let local_ x : string = "hi"
+
+let (x : string) = local_ "hi"
+
+let (x : string) = exclave_ "hi"
+
+let local_ x = ("hi" : string)
+
+let x = exclave_ ("hi" : string)
+
+let x : 'a. 'a -> 'a = local_ "hi"
+
+let x : 'a. 'a -> 'a = exclave_ "hi"
+
+let local_ f : 'a. 'a -> 'a = "hi"

--- a/vendor/ocaml-common/location.ml
+++ b/vendor/ocaml-common/location.ml
@@ -18,6 +18,36 @@ open Lexing
 type t = Warnings.loc =
   { loc_start: position; loc_end: position; loc_ghost: bool }
 
+let equal
+      { loc_start = { pos_fname = loc_start_pos_fname_1
+                    ; pos_lnum = loc_start_pos_lnum_1
+                    ; pos_bol = loc_start_pos_bol_1
+                    ; pos_cnum = loc_start_pos_cnum_1 }
+      ; loc_end = { pos_fname = loc_end_pos_fname_1
+                  ; pos_lnum = loc_end_pos_lnum_1
+                  ; pos_bol = loc_end_pos_bol_1
+                  ; pos_cnum = loc_end_pos_cnum_1 }
+      ; loc_ghost = loc_ghost_1 }
+      { loc_start = { pos_fname = loc_start_pos_fname_2
+                    ; pos_lnum = loc_start_pos_lnum_2
+                    ; pos_bol = loc_start_pos_bol_2
+                    ; pos_cnum = loc_start_pos_cnum_2 }
+      ; loc_end = { pos_fname = loc_end_pos_fname_2
+                  ; pos_lnum = loc_end_pos_lnum_2
+                  ; pos_bol = loc_end_pos_bol_2
+                  ; pos_cnum = loc_end_pos_cnum_2 }
+      ; loc_ghost = loc_ghost_2 }
+  =
+  String.equal loc_start_pos_fname_1 loc_start_pos_fname_2 &&
+  Int.equal    loc_start_pos_lnum_1  loc_start_pos_lnum_2  &&
+  Int.equal    loc_start_pos_bol_1   loc_start_pos_bol_2   &&
+  Int.equal    loc_start_pos_cnum_1  loc_start_pos_cnum_2  &&
+  String.equal loc_end_pos_fname_1   loc_end_pos_fname_2   &&
+  Int.equal    loc_end_pos_lnum_1    loc_end_pos_lnum_2    &&
+  Int.equal    loc_end_pos_bol_1     loc_end_pos_bol_2     &&
+  Int.equal    loc_end_pos_cnum_1    loc_end_pos_cnum_2    &&
+  Bool.equal   loc_ghost_1           loc_ghost_2
+
 let in_file = Warnings.ghost_loc_in_file
 
 let none = in_file "_none_"

--- a/vendor/ocaml-common/location.mli
+++ b/vendor/ocaml-common/location.mli
@@ -35,6 +35,12 @@ type t = Warnings.loc = {
    Else all fields are correct.
 *)
 
+(** Strict equality: Two locations are equal iff every field is equal.  Two
+    locations that happen to refer to the same place -- for instance, if one has
+    [pos_lnum] set correctly and the other has [pos_lnum = -1] -- are not
+    considered to be equal. *)
+val equal : t -> t -> bool
+
 val none : t
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -601,3 +601,26 @@ module Of = struct
   let inherit_ ?loc ty =
     mk ?loc (Oinherit ty)
 end
+
+(* Jane Street extension *)
+module Jane = struct
+  let sign_str = function
+    | Positive -> ""
+    | Negative -> "-"
+
+  let pconst_unboxed_integer sign value suffix =
+    if Erase_jane_syntax.should_erase ()
+    then Pconst_integer (sign_str sign ^ value, suffix)
+    else Pconst_unboxed_integer (sign, value, suffix)
+
+  let pconst_unboxed_float sign value suffix =
+    if Erase_jane_syntax.should_erase ()
+    then Pconst_float (sign_str sign ^ value, suffix)
+    else Pconst_unboxed_float (sign, value, suffix)
+
+  let ptyp_constr_unboxed ident args =
+    if Erase_jane_syntax.should_erase ()
+    then Ptyp_constr (ident, args)
+    else Ptyp_constr_unboxed (ident, args)
+end
+(* End Jane Street extension *)

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -506,3 +506,19 @@ module Of:
       label with_loc -> core_type -> object_field
     val inherit_: ?loc:loc -> core_type -> object_field
   end
+
+(* Jane Street extension *)
+(** Jane Street syntax *)
+module Jane:
+  sig
+    (** One value per constructor, constructs [_desc]s, not split by AST
+        category.  These are used to toggle construction based on whether we're
+        erasing Jane syntax or not; if we are, they return the erased
+        version. *)
+
+    val pconst_unboxed_integer : sign -> string -> char option -> constant_desc
+    val pconst_unboxed_float : sign -> string -> char option -> constant_desc
+
+    val ptyp_constr_unboxed : lid -> core_type list -> core_type_desc
+  end
+(* End Jane Street extension *)

--- a/vendor/parser-extended/dune
+++ b/vendor/parser-extended/dune
@@ -3,7 +3,12 @@
  (public_name ocamlformat-lib.parser_extended)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
- (libraries compiler-libs.common menhirLib parser_shims ocaml_common))
+ (libraries
+  erase_jane_syntax
+  compiler-libs.common
+  menhirLib
+  parser_shims
+  ocaml_common))
 
 (ocamllex lexer)
 

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -214,15 +214,19 @@ let include_functor_attr =
   Attr.mk ~loc:Location.none include_functor_ext_loc (PStr [])
 
 let mkexp_stack ~loc exp =
+  if Erase_jane_syntax.should_erase () then exp else
   ghexp ~loc (Pexp_apply(local_extension, [Nolabel, exp]))
 
 let mkpat_stack pat =
+  if Erase_jane_syntax.should_erase () then pat else
   {pat with ppat_attributes = local_attr :: pat.ppat_attributes}
 
 let mktyp_stack typ =
+  if Erase_jane_syntax.should_erase () then typ else
   {typ with ptyp_attributes = local_attr :: typ.ptyp_attributes}
 
 let wrap_exp_stack exp =
+  if Erase_jane_syntax.should_erase () then exp else
   {exp with pexp_attributes = local_attr :: exp.pexp_attributes}
 
 let mkexp_local_if p ~loc exp =
@@ -244,6 +248,7 @@ let exclave_extension loc =
     (Pexp_extension(exclave_ext_loc loc, PStr []))
 
 let mkexp_exclave ~loc ~kwd_loc exp =
+  if Erase_jane_syntax.should_erase () then exp else
   ghexp ~loc (Pexp_apply(exclave_extension (make_loc kwd_loc), [Nolabel, exp]))
 
 let curry_attr =
@@ -253,6 +258,7 @@ let is_curry_attr attr =
   attr.attr_name.txt = "extension.curry"
 
 let mktyp_curry typ =
+  if Erase_jane_syntax.should_erase () then typ else
   {typ with ptyp_attributes = curry_attr :: typ.ptyp_attributes}
 
 let maybe_curry_typ typ =
@@ -268,6 +274,7 @@ let global_attr loc =
   Attr.mk ~loc:Location.none (global_loc loc) (PStr [])
 
 let mkld_global ld loc =
+  if Erase_jane_syntax.should_erase () then ld else
   { ld with pld_attributes = global_attr loc :: ld.pld_attributes }
 
 let mkld_global_maybe gbl ld loc =
@@ -276,6 +283,7 @@ let mkld_global_maybe gbl ld loc =
   | Nothing -> ld
 
 let mkcty_global cty loc =
+  if Erase_jane_syntax.should_erase () then cty else
   { cty with ptyp_attributes = global_attr loc :: cty.ptyp_attributes }
 
 let mkcty_global_maybe gbl cty loc =
@@ -3643,7 +3651,7 @@ atomic_type:
     | tys = actual_type_parameters
       tid = mkrhs(type_longident)
       HASH_SUFFIX
-        { Ptyp_constr_unboxed(tid, tys) }
+        { Jane.ptyp_constr_unboxed tid tys }
     | tys = actual_type_parameters
       tid = mkrhs(type_longident)
         { Ptyp_constr(tid, tys) } %prec below_HASH
@@ -3790,9 +3798,9 @@ constant:
 
   (* Jane Street extension *)
   | HASH_INT     { let (n, m) = $1 in
-                   mkconst ~loc:$sloc (Pconst_unboxed_integer(Positive, n, m)) }
+                   mkconst ~loc:$sloc (Jane.pconst_unboxed_integer Positive n m) }
   | HASH_FLOAT   { let (f, m) = $1 in
-                   mkconst ~loc:$sloc (Pconst_unboxed_float (Positive, f, m)) }
+                   mkconst ~loc:$sloc (Jane.pconst_unboxed_float Positive f m) }
   (* End Jane Street extension *)
 ;
 signed_constant:
@@ -3809,16 +3817,16 @@ signed_constant:
   (* Jane Street extension *)
   | MINUS HASH_INT    { let (n, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_integer(Negative,n,m)) }
+                          (Jane.pconst_unboxed_integer Negative n m) }
   | MINUS HASH_FLOAT  { let (f, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_float(Negative,f,m)) }
+                          (Jane.pconst_unboxed_float Negative f m) }
   | PLUS HASH_INT     { let (n, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_integer (Positive,n,m)) }
+                          (Jane.pconst_unboxed_integer Positive n m) }
   | PLUS HASH_FLOAT   { let (f, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_float (Positive,f,m)) }
+                          (Jane.pconst_unboxed_float Positive f m) }
   (* End Jane Street extension *)
 ;
 

--- a/vendor/parser-standard/jane_syntax.ml
+++ b/vendor/parser-standard/jane_syntax.ml
@@ -89,7 +89,7 @@ module Local = struct
     | ["type"; "local"] -> Some (Ltyp_local typ)
     | _ -> None
 
-  let constr_arg_of ~loc ~attrs lcarg =
+  let constr_arg_of ~loc lcarg =
     (* See Note [Wrapping with make_entire_jane_syntax] *)
     Constructor_argument.make_entire_jane_syntax ~loc feature (fun () ->
       match lcarg with
@@ -97,8 +97,8 @@ module Local = struct
         (* Although there's only one constructor here, the use of [core_type]
            means we need to be able to tell the two uses apart *)
         Constructor_argument.make_jane_syntax
-          feature ["constructor_argument"; "global"] @@
-        Constructor_argument.add_attributes attrs carg)
+          feature ["constructor_argument"; "global"]
+          carg)
 
   let of_constr_arg =
     Constructor_argument.match_jane_syntax_piece feature @@ fun carg -> function
@@ -109,17 +109,13 @@ module Local = struct
     | Lexp_local expr ->
       (* See Note [Wrapping with make_entire_jane_syntax] *)
       Expression.make_entire_jane_syntax ~loc feature (fun () ->
-        (* We encode [local_ e] with an extra "dummy" wrapper to get a place to
-           hang the outer location. *)
         Expression.make_jane_syntax feature ["local"] @@
-        Expression.make_dummy ~attrs expr)
+        Expression.add_attributes attrs expr)
     | Lexp_exclave expr ->
       (* See Note [Wrapping with make_entire_jane_syntax] *)
       Expression.make_entire_jane_syntax ~loc feature (fun () ->
-        (* We encode [exclave_ e] with an extra "dummy" wrapper to get a place to
-           hang the outer location. *)
         Expression.make_jane_syntax feature ["exclave"] @@
-        Expression.make_dummy ~attrs expr)
+        Expression.add_attributes attrs expr)
     | Lexp_constrain_local expr ->
       (* See Note [Wrapping with make_entire_jane_syntax] *)
       Expression.make_entire_jane_syntax ~loc feature (fun () ->
@@ -128,12 +124,8 @@ module Local = struct
 
   let of_expr =
     Expression.match_jane_syntax_piece feature @@ fun expr -> function
-      | ["local"] ->
-        Expression.match_dummy expr |>
-        Option.map (fun expr' -> Lexp_local expr')
-      | ["exclave"] ->
-        Expression.match_dummy expr |>
-        Option.map (fun expr' -> Lexp_exclave expr')
+      | ["local"] -> Some (Lexp_local expr)
+      | ["exclave"] -> Some (Lexp_exclave expr)
       | ["constrain_local"] -> Some (Lexp_constrain_local expr)
       | _ -> None
 
@@ -533,8 +525,8 @@ module Constructor_argument = struct
 
   let of_ast = Constructor_argument.make_of_ast ~of_ast_internal
 
-  let ast_of ~loc (jcarg, attrs) = match jcarg with
-    | Jcarg_local x -> Local.constr_arg_of ~loc ~attrs x
+  let ast_of ~loc jcarg = match jcarg with
+    | Jcarg_local x -> Local.constr_arg_of ~loc x
 end
 
 module Expression = struct

--- a/vendor/parser-standard/jane_syntax.ml
+++ b/vendor/parser-standard/jane_syntax.ml
@@ -41,10 +41,114 @@ open Jane_syntax_parsing
    future syntax features to remember to do this wrapping.
 *)
 
+module Builtin = struct
+  let make_curry_attr, extract_curry_attr, has_curry_attr =
+    Embedded_name.marker_attribute_handler ["curry"]
+
+  let is_curried typ = has_curry_attr typ.ptyp_attributes
+
+  let mark_curried ~loc typ = match typ.ptyp_desc with
+    | Ptyp_arrow _ when not (is_curried typ) ->
+        Core_type.add_attributes [make_curry_attr ~loc] typ
+    | _ -> typ
+
+  let non_syntax_attributes attrs =
+    Option.value ~default:attrs (extract_curry_attr attrs)
+end
+
+(** Locality modes *)
+module Local = struct
+  let feature : Feature.t = Language_extension Local
+
+  type constructor_argument = Lcarg_global of core_type
+
+  type nonrec core_type = Ltyp_local of core_type
+
+  type nonrec expression =
+    | Lexp_local of expression
+    | Lexp_exclave of expression
+    | Lexp_constrain_local of expression
+      (* Invariant: [Lexp_constrain_local] is the direct child of a
+         [Pexp_constraint] or [Pexp_coerce] node.  For more, see the [.mli]
+         file. *)
+
+  type nonrec pattern = Lpat_local of pattern
+  (* Invariant: [Lpat_local] is always the outermost part of a pattern. *)
+
+  let type_of ~loc ~attrs = function
+    | Ltyp_local typ ->
+      (* See Note [Wrapping with make_entire_jane_syntax] *)
+      Core_type.make_entire_jane_syntax ~loc feature (fun () ->
+        (* Although there's only one constructor here, the use of
+           [constructor_argument] means we need to be able to tell the two uses
+           apart *)
+        Core_type.make_jane_syntax feature ["type"; "local"] @@
+        Core_type.add_attributes attrs typ)
+
+  let of_type = Core_type.match_jane_syntax_piece feature @@ fun typ -> function
+    | ["type"; "local"] -> Some (Ltyp_local typ)
+    | _ -> None
+
+  let constr_arg_of ~loc ~attrs lcarg =
+    (* See Note [Wrapping with make_entire_jane_syntax] *)
+    Constructor_argument.make_entire_jane_syntax ~loc feature (fun () ->
+      match lcarg with
+      | Lcarg_global carg ->
+        (* Although there's only one constructor here, the use of [core_type]
+           means we need to be able to tell the two uses apart *)
+        Constructor_argument.make_jane_syntax
+          feature ["constructor_argument"; "global"] @@
+        Constructor_argument.add_attributes attrs carg)
+
+  let of_constr_arg =
+    Constructor_argument.match_jane_syntax_piece feature @@ fun carg -> function
+      | ["constructor_argument"; "global"] -> Some (Lcarg_global carg)
+      | _ -> None
+
+  let expr_of ~loc ~attrs = function
+    | Lexp_local expr ->
+      (* See Note [Wrapping with make_entire_jane_syntax] *)
+      Expression.make_entire_jane_syntax ~loc feature (fun () ->
+        (* We encode [local_ e] with an extra "dummy" wrapper to get a place to
+           hang the outer location. *)
+        Expression.make_jane_syntax feature ["local"] @@
+        Expression.make_dummy ~attrs expr)
+    | Lexp_exclave expr ->
+      (* See Note [Wrapping with make_entire_jane_syntax] *)
+      Expression.make_entire_jane_syntax ~loc feature (fun () ->
+        (* We encode [exclave_ e] with an extra "dummy" wrapper to get a place to
+           hang the outer location. *)
+        Expression.make_jane_syntax feature ["exclave"] @@
+        Expression.make_dummy ~attrs expr)
+    | Lexp_constrain_local expr ->
+      (* See Note [Wrapping with make_entire_jane_syntax] *)
+      Expression.make_entire_jane_syntax ~loc feature (fun () ->
+        Expression.make_jane_syntax feature ["constrain_local"] @@
+        Expression.add_attributes attrs expr)
+
+  let of_expr =
+    Expression.match_jane_syntax_piece feature @@ fun expr -> function
+      | ["local"] ->
+        Expression.match_dummy expr |>
+        Option.map (fun expr' -> Lexp_local expr')
+      | ["exclave"] ->
+        Expression.match_dummy expr |>
+        Option.map (fun expr' -> Lexp_exclave expr')
+      | ["constrain_local"] -> Some (Lexp_constrain_local expr)
+      | _ -> None
+
+  let pat_of ~loc ~attrs = function
+    | Lpat_local pat ->
+      (* See Note [Wrapping with make_entire_jane_syntax] *)
+      Pattern.make_entire_jane_syntax ~loc feature (fun () ->
+        Pattern.add_attributes attrs pat)
+
+  let of_pat pat = Lpat_local pat
+end
+
 (** List and array comprehensions *)
 module Comprehensions = struct
   let feature : Feature.t = Language_extension Comprehensions
-  let extension_string = Feature.extension_component feature
 
   type iterator =
     | Range of { start     : expression
@@ -92,11 +196,10 @@ module Comprehensions = struct
      v}
   *)
 
-  let comprehension_expr names x = Expression.make_jane_syntax feature names x
+  let comprehension_expr = Expression.make_jane_syntax feature
 
   (** First, we define how to go from the nice AST to the OCaml AST; this is
-      the [expr_of_...] family of expressions, culminating in
-      [expr_of_comprehension_expr]. *)
+      the [expr_of_...] family of expressions, culminating in [expr_of]. *)
 
   let expr_of_iterator = function
     | Range { start; stop; direction } ->
@@ -108,7 +211,8 @@ module Comprehensions = struct
             | Downto -> "downto" ]
           (Ast_helper.Exp.tuple [start; stop])
     | In seq ->
-        comprehension_expr ["for"; "in"] seq
+        comprehension_expr ["for"; "in"] (Ast_helper.Exp.lazy_ seq)
+        (* See Note [Wrapping with Pexp_lazy] *)
 
   let expr_of_clause_binding { pattern; iterator; attributes } =
     Ast_helper.Vb.mk ~attrs:attributes pattern (expr_of_iterator iterator)
@@ -123,28 +227,24 @@ module Comprehensions = struct
     | When cond ->
         comprehension_expr ["when"] (Ast_helper.Exp.sequence cond rest)
 
-  let expr_of_comprehension ~type_ { body; clauses } =
-    (* We elect to wrap the body in a new AST node (here, [Pexp_lazy])
-       because it makes it so there is no AST node that can carry multiple Jane
-       Syntax-related attributes in addition to user-written attributes. This
-       choice simplifies the definition of [comprehension_expr_of_expr], as
-       part of its contract is threading through the user-written attributes
-       on the outermost node.
-    *)
+  let expr_of_comprehension ~type_ ~attrs { body; clauses } =
+    (* See Note [Wrapping with Pexp_lazy] *)
     comprehension_expr
       type_
-      (Ast_helper.Exp.lazy_
-        (List.fold_right
-          expr_of_clause
-          clauses
-          (comprehension_expr ["body"] body)))
+      (Expression.add_attributes
+         attrs
+         (Ast_helper.Exp.lazy_
+            (List.fold_right
+               expr_of_clause
+               clauses
+               (comprehension_expr ["body"] (Ast_helper.Exp.lazy_ body)))))
 
   let expr_of ~loc ~attrs cexpr =
     (* See Note [Wrapping with make_entire_jane_syntax] *)
-    let expr = Expression.make_entire_jane_syntax ~loc feature (fun () ->
+    Expression.make_entire_jane_syntax ~loc feature (fun () ->
       match cexpr with
       | Cexp_list_comprehension comp ->
-          expr_of_comprehension ~type_:["list"] comp
+          expr_of_comprehension ~type_:["list"] ~attrs comp
       | Cexp_array_comprehension (amut, comp) ->
           expr_of_comprehension
             ~type_:[ "array"
@@ -152,39 +252,38 @@ module Comprehensions = struct
                      | Mutable   -> "mutable"
                      | Immutable -> "immutable"
                    ]
+            ~attrs
             comp)
-    in
-    { expr with pexp_attributes = expr.pexp_attributes @ attrs }
 
   (** Then, we define how to go from the OCaml AST to the nice AST; this is
-      the [..._of_expr] family of expressions, culminating in
-      [comprehension_expr_of_expr]. *)
+      the [..._of_expr] family of expressions, culminating in [of_expr]. *)
 
   module Desugaring_error = struct
     type error =
-      | Non_comprehension_embedding of Embedded_name.t
-      | Non_embedding
-      | Bad_comprehension_embedding of string list
       | No_clauses
+      | Unexpected_attributes of attributes
+      (* Note [Wrapping with Pexp_lazy]
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+         We require that every internal comprehensions node contain at least one
+         constructor, using [Pexp_lazy] by convention when there isn't another
+         obvious choice.  This means that every internal AST node synthesized
+         for comprehensions can contain no other attributes, which we can then
+         check for and raise [Unexpected_attributes] if we get this wrong.  This
+         helps guard against attribute erros. *)
 
     let report_error ~loc = function
-      | Non_comprehension_embedding name ->
-          Location.errorf ~loc
-            "Tried to desugar the non-comprehension embedded term %a@ \
-             as part of a comprehension expression"
-            Embedded_name.pp_quoted_name name
-      | Non_embedding ->
-          Location.errorf ~loc
-            "Tried to desugar a non-embedded expression@ \
-             as part of a comprehension expression"
-      | Bad_comprehension_embedding subparts ->
-          Location.errorf ~loc
-            "Unknown, unexpected, or malformed@ comprehension embedded term %a"
-            Embedded_name.pp_quoted_name
-            (Embedded_name.of_feature feature subparts)
       | No_clauses ->
           Location.errorf ~loc
             "Tried to desugar a comprehension with no clauses"
+      | Unexpected_attributes attrs ->
+          Location.errorf ~loc
+            "An internal synthesized comprehension node had extra attributes.@.\
+             The attributes had the following names:@ %a"
+            (Format.pp_print_list
+               ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+               (fun ppf attr -> Format.fprintf ppf "\"%s\"" attr.attr_name.txt))
+            attrs
 
     exception Error of Location.t * error
 
@@ -197,33 +296,22 @@ module Comprehensions = struct
     let raise expr err = raise (Error(expr.pexp_loc, err))
   end
 
-  (* Returns the expression node with the outermost Jane Syntax-related
-     attribute removed. *)
-  let expand_comprehension_extension_expr expr =
-    match find_and_remove_jane_syntax_attribute expr.pexp_attributes with
-    | Some (ext_name, attributes) -> begin
-        match Jane_syntax_parsing.Embedded_name.components ext_name with
-        | comprehensions :: names
-          when String.equal comprehensions extension_string ->
-            names, { expr with pexp_attributes = attributes }
-        | _ :: _ ->
-            Desugaring_error.raise expr (Non_comprehension_embedding ext_name)
-      end
-    | None ->
-        Desugaring_error.raise expr Non_embedding
+  let match_comprehension_piece matcher =
+    Expression.match_jane_syntax_piece feature @@ fun expr subparts ->
+      match expr.pexp_attributes with
+      | [] -> matcher expr subparts
+      | _ :: _ as attrs ->
+        Desugaring_error.raise expr (Unexpected_attributes attrs)
 
-  let iterator_of_expr expr =
-    match expand_comprehension_extension_expr expr with
-    | ["for"; "range"; "upto"],
-      { pexp_desc = Pexp_tuple [start; stop]; _ } ->
-        Range { start; stop; direction = Upto }
-    | ["for"; "range"; "downto"],
-      { pexp_desc = Pexp_tuple [start; stop]; _ } ->
-        Range { start; stop; direction = Downto }
-    | ["for"; "in"], seq ->
-        In seq
-    | bad, _ ->
-        Desugaring_error.raise expr (Bad_comprehension_embedding bad)
+  let iterator_of_expr = match_comprehension_piece @@ fun expr subparts ->
+    match subparts, expr.pexp_desc with
+    |["for"; "range"; "upto"], Pexp_tuple [start; stop] ->
+        Some (Range { start; stop; direction = Upto })
+    | ["for"; "range"; "downto"], Pexp_tuple [start; stop] ->
+        Some (Range { start; stop; direction = Downto })
+    | ["for"; "in"], Pexp_lazy seq ->
+        Some (In seq)
+    | _ -> None
 
   let clause_binding_of_vb { pvb_pat; pvb_expr; pvb_attributes; pvb_loc = _ } =
     { pattern = pvb_pat
@@ -234,19 +322,20 @@ module Comprehensions = struct
 
   let comprehension_of_expr =
     let rec raw_comprehension_of_expr expr =
-      match expand_comprehension_extension_expr expr with
-      | ["for"], { pexp_desc = Pexp_let(Nonrecursive, iterators, rest); _ } ->
-          add_clause
-            (For (List.map clause_binding_of_vb iterators))
-            (raw_comprehension_of_expr rest)
-      | ["when"], { pexp_desc = Pexp_sequence(cond, rest); _ } ->
-          add_clause
-            (When cond)
-            (raw_comprehension_of_expr rest)
-      | ["body"], body ->
-          { body; clauses = [] }
-      | bad, _ ->
-          Desugaring_error.raise expr (Bad_comprehension_embedding bad)
+      expr |> match_comprehension_piece @@ fun expr subparts ->
+        match subparts, expr.pexp_desc with
+        | ["for"], Pexp_let(Nonrecursive, iterators, rest) ->
+            Option.some @@ add_clause
+              (For (List.map clause_binding_of_vb iterators))
+              (raw_comprehension_of_expr rest)
+        | ["when"], Pexp_sequence(cond, rest) ->
+            Option.some @@ add_clause
+              (When cond)
+              (raw_comprehension_of_expr rest)
+        | ["body"], Pexp_lazy body ->
+            Some { body; clauses = [] }
+        | _ ->
+            None
     in
     fun expr ->
       match raw_comprehension_of_expr expr with
@@ -254,24 +343,22 @@ module Comprehensions = struct
           Desugaring_error.raise expr No_clauses
       | comp -> comp
 
-  (* Returns remaining unconsumed attributes on outermost expression *)
-  let comprehension_expr_of_expr expr =
-    let name, wrapper = expand_comprehension_extension_expr expr in
-    let comp =
-      match name, wrapper.pexp_desc with
-      | ["list"], Pexp_lazy comp ->
-          Cexp_list_comprehension (comprehension_of_expr comp)
-      | ["array"; "mutable"], Pexp_lazy comp ->
-          Cexp_array_comprehension (Mutable, comprehension_of_expr comp)
-      | ["array"; "immutable"], Pexp_lazy comp ->
-          (* assert_extension_enabled:
-            See Note [Check for immutable extension in comprehensions code] *)
-          assert_extension_enabled ~loc:expr.pexp_loc Immutable_arrays ();
-          Cexp_array_comprehension (Immutable, comprehension_of_expr comp)
-      | bad, _ ->
-          Desugaring_error.raise expr (Bad_comprehension_embedding bad)
-    in
-    comp, wrapper.pexp_attributes
+  let of_expr = match_comprehension_piece @@ fun expr subparts ->
+    (* See Note [Wrapping with Pexp_lazy] *)
+    match subparts, expr.pexp_desc with
+    | ["list"], Pexp_lazy comp ->
+      Some (Cexp_list_comprehension (comprehension_of_expr comp))
+    | ["array"; "mutable"], Pexp_lazy comp ->
+      Some (Cexp_array_comprehension (Mutable,
+                                      comprehension_of_expr comp))
+    | ["array"; "immutable"], Pexp_lazy comp ->
+      (* assert_extension_enabled:
+         See Note [Check for immutable extension in comprehensions code]
+      *)
+      assert_extension_enabled ~loc:expr.pexp_loc Immutable_arrays ();
+      Some (Cexp_array_comprehension (Immutable,
+                                      comprehension_of_expr comp))
+    | _ -> None
 end
 
 (** Immutable arrays *)
@@ -290,9 +377,8 @@ module Immutable_arrays = struct
       Expression.make_entire_jane_syntax ~loc feature (fun () ->
         Ast_helper.Exp.array ~attrs elts)
 
-  (* Returns remaining unconsumed attributes *)
   let of_expr expr = match expr.pexp_desc with
-    | Pexp_array elts -> Iaexp_immutable_array elts, expr.pexp_attributes
+    | Pexp_array elts -> Iaexp_immutable_array elts
     | _ -> failwith "Malformed immutable array expression"
 
   let pat_of ~loc ~attrs = function
@@ -301,9 +387,8 @@ module Immutable_arrays = struct
       Pattern.make_entire_jane_syntax ~loc feature (fun () ->
         Ast_helper.Pat.array ~attrs elts)
 
-  (* Returns remaining unconsumed attributes *)
   let of_pat pat = match pat.ppat_desc with
-    | Ppat_array elts -> Iapat_immutable_array elts, pat.ppat_attributes
+    | Ppat_array elts -> Iapat_immutable_array elts
     | _ -> failwith "Malformed immutable array pattern"
 end
 
@@ -358,7 +443,7 @@ module Strengthen = struct
   (* Returns remaining unconsumed attributes *)
   let of_mty mty = match mty.pmty_desc with
     | Pmty_functor(Named(_, mty), {pmty_desc = Pmty_alias mod_id}) ->
-       { mty; mod_id }, mty.pmty_attributes
+       { mty; mod_id }
     | _ -> failwith "Malformed strengthened module type"
 end
 
@@ -388,14 +473,14 @@ module Unboxed_constants = struct
   let of_expr expr =
     let loc = expr.pexp_loc in
     match expr.pexp_desc with
-    | Pexp_constant const -> of_constant ~loc const, expr.pexp_attributes
+    | Pexp_constant const -> of_constant ~loc const
     | _ -> fail_malformed ~loc
 
   (* Returns remaining unconsumed attributes *)
   let of_pat pat =
     let loc = pat.ppat_loc in
     match pat.ppat_desc with
-    | Ppat_constant const -> of_constant ~loc const, pat.ppat_attributes
+    | Ppat_constant const -> of_constant ~loc const
     | _ -> fail_malformed ~loc
 
   let constant_of = function
@@ -421,47 +506,59 @@ module type AST = sig
   type ast
 
   val of_ast : ast -> t option
+  val ast_of : loc:Location.t -> t -> ast
 end
 
 module Core_type = struct
-  type t = |
+  type t =
+    | Jtyp_local of Local.core_type
 
-  let of_ast_internal (feat : Feature.t) _typ = match feat with
+  let of_ast_internal (feat : Feature.t) typ = match feat with
+    | Language_extension Local -> Some (Jtyp_local (Local.of_type typ))
     | _ -> None
 
   let of_ast = Core_type.make_of_ast ~of_ast_internal
+
+  let ast_of ~loc (jtyp, attrs) = match jtyp with
+    | Jtyp_local x -> Local.type_of ~loc ~attrs x
 end
 
 module Constructor_argument = struct
-  type t = |
+  type t =
+    | Jcarg_local of Local.constructor_argument
 
-  let of_ast_internal (feat : Feature.t) _carg = match feat with
+  let of_ast_internal (feat : Feature.t) carg = match feat with
+    | Language_extension Local -> Some (Jcarg_local (Local.of_constr_arg carg))
     | _ -> None
 
   let of_ast = Constructor_argument.make_of_ast ~of_ast_internal
+
+  let ast_of ~loc (jcarg, attrs) = match jcarg with
+    | Jcarg_local x -> Local.constr_arg_of ~loc ~attrs x
 end
 
 module Expression = struct
   type t =
+    | Jexp_local           of Local.expression
     | Jexp_comprehension   of Comprehensions.expression
     | Jexp_immutable_array of Immutable_arrays.expression
     | Jexp_unboxed_constant of Unboxed_constants.expression
 
   let of_ast_internal (feat : Feature.t) expr = match feat with
+    | Language_extension Local ->
+      Some (Jexp_local (Local.of_expr expr))
     | Language_extension Comprehensions ->
-      let expr, attrs = Comprehensions.comprehension_expr_of_expr expr in
-      Some (Jexp_comprehension expr, attrs)
+      Some (Jexp_comprehension (Comprehensions.of_expr expr))
     | Language_extension Immutable_arrays ->
-      let expr, attrs = Immutable_arrays.of_expr expr in
-      Some (Jexp_immutable_array expr, attrs)
+      Some (Jexp_immutable_array (Immutable_arrays.of_expr expr))
     | Language_extension Layouts ->
-      let expr, attrs = Unboxed_constants.of_expr expr in
-      Some (Jexp_unboxed_constant expr, attrs)
+      Some (Jexp_unboxed_constant (Unboxed_constants.of_expr expr))
     | _ -> None
 
   let of_ast = Expression.make_of_ast ~of_ast_internal
 
-  let expr_of ~loc ~attrs = function
+  let ast_of ~loc (jexp, attrs) = match jexp with
+    | Jexp_local            x -> Local.expr_of             ~loc ~attrs x
     | Jexp_comprehension    x -> Comprehensions.expr_of    ~loc ~attrs x
     | Jexp_immutable_array  x -> Immutable_arrays.expr_of  ~loc ~attrs x
     | Jexp_unboxed_constant x -> Unboxed_constants.expr_of ~loc ~attrs x
@@ -469,21 +566,23 @@ end
 
 module Pattern = struct
   type t =
+    | Jpat_local           of Local.pattern
     | Jpat_immutable_array of Immutable_arrays.pattern
     | Jpat_unboxed_constant of Unboxed_constants.pattern
 
   let of_ast_internal (feat : Feature.t) pat = match feat with
+    | Language_extension Local ->
+      Some (Jpat_local (Local.of_pat pat))
     | Language_extension Immutable_arrays ->
-      let expr, attrs = Immutable_arrays.of_pat pat in
-      Some (Jpat_immutable_array expr, attrs)
+      Some (Jpat_immutable_array (Immutable_arrays.of_pat pat))
     | Language_extension Layouts ->
-      let pat, attrs = Unboxed_constants.of_pat pat in
-      Some (Jpat_unboxed_constant pat, attrs)
+      Some (Jpat_unboxed_constant (Unboxed_constants.of_pat pat))
     | _ -> None
 
   let of_ast = Pattern.make_of_ast ~of_ast_internal
 
-  let pat_of ~loc ~attrs = function
+  let ast_of ~loc (jpat, attrs) = match jpat with
+    | Jpat_local x -> Local.pat_of ~loc ~attrs x
     | Jpat_immutable_array x -> Immutable_arrays.pat_of ~loc ~attrs x
     | Jpat_unboxed_constant x -> Unboxed_constants.pat_of ~loc ~attrs x
 end
@@ -494,11 +593,13 @@ module Module_type = struct
 
   let of_ast_internal (feat : Feature.t) mty = match feat with
     | Language_extension Module_strengthening ->
-      let mty, attrs = Strengthen.of_mty mty in
-      Some (Jmty_strengthen mty, attrs)
+      Some (Jmty_strengthen (Strengthen.of_mty mty))
     | _ -> None
 
   let of_ast = Module_type.make_of_ast ~of_ast_internal
+
+  let ast_of ~loc (jmty, attrs) = match jmty with
+    | Jmty_strengthen x -> Strengthen.mty_of ~loc ~attrs x
 end
 
 module Signature_item = struct
@@ -512,6 +613,9 @@ module Signature_item = struct
     | _ -> None
 
   let of_ast = Signature_item.make_of_ast ~of_ast_internal
+
+  let ast_of ~loc jsig = match jsig with
+    | Jsig_include_functor x -> Include_functor.sig_item_of ~loc x
 end
 
 module Structure_item = struct
@@ -525,6 +629,9 @@ module Structure_item = struct
     | _ -> None
 
   let of_ast = Structure_item.make_of_ast ~of_ast_internal
+
+  let ast_of ~loc jstr = match jstr with
+    | Jstr_include_functor x -> Include_functor.str_item_of ~loc x
 end
 
 module Extension_constructor = struct
@@ -534,4 +641,7 @@ module Extension_constructor = struct
     | _ -> None
 
   let of_ast = Extension_constructor.make_of_ast ~of_ast_internal
+
+  let ast_of ~loc:_ (jext, _attrs) = match jext with
+    | (_ : t) -> .
 end

--- a/vendor/parser-standard/jane_syntax_parsing.ml
+++ b/vendor/parser-standard/jane_syntax_parsing.ml
@@ -4,7 +4,7 @@
     where each novel piece of syntax is represented using one of two embeddings:
 
     1. As an AST item carrying an attribute. The AST item serves as the "body"
-      of the syntax indicated by the attribute.
+       of the syntax indicated by the attribute.
     2. As a pair of an extension node and an AST item that serves as the "body".
        Here, the "pair" is embedded as a pair-like construct in the relevant AST
        category, e.g. [include sig [%jane.ERASABILITY.EXTNAME];; BODY end] for
@@ -14,7 +14,13 @@
     enabled by [-extension EXTNAME] on the command line), the attribute (if
     used) must be [[@jane.ERASABILITY.EXTNAME]], and the extension node (if
     used) must be [[%jane.ERASABILITY.EXTNAME]]. For built-in syntax, we use
-    [_builtin] instead of an language extension name.
+    [_builtin] instead of a language extension name.
+
+    The only exception to this is that for some built-in syntax, we instead use
+    certain "marker" attributes, designed to be created by the parser when a
+    full Jane-syntax encoding would be too heavyweight; for these, we use
+    [_marker] instead of an extension name, and allow arbitrary dot-separated
+    strings (see below) to follow it.
 
     The [ERASABILITY] component indicates to tools such as ocamlformat and
     ppxlib whether or not the attribute is erasable. See the documentation of
@@ -79,6 +85,38 @@
 
 open Parsetree
 
+(** We carefully regulate which bindings we import from [Language_extension] to
+    ensure that we can import this file into places like ocamlformat or the Jane
+    Street internal repo with no changes.
+*)
+module Language_extension = struct
+  include Language_extension_kernel
+  include (
+    Language_extension
+      : Language_extension_kernel.Language_extension_for_jane_syntax)
+end
+
+(** For the same reason, we don't want this file to depend on [Misc] or similar
+    utility libraries, so we define any generic utility functionality in this
+    module. *)
+module Util : sig
+  val find_map_last_and_split :
+    f:('a -> 'b option) -> 'a list -> ('a list * 'b * 'a list) option
+          (* [find_map_last_and_split ~f l] returns a triple [pre, y, post] such
+             that [l = pre @ x @ post], [f x = Some y], and for all [x'] in
+             [post], [f x' = None].  If, for all [z] in [l], [f z = None], then
+             it returns [None]. *)
+end = struct
+  let find_map_last_and_split =
+    let rec go post ~f = function
+      | [] -> None
+      | x :: xs -> match f x with
+        | Some y -> Some (List.rev xs, y, post)
+        | None -> go (x :: post) ~f xs
+    in
+    fun ~f xs -> go [] ~f (List.rev xs)
+end
+
 (******************************************************************************)
 
 module Feature : sig
@@ -91,6 +129,8 @@ module Feature : sig
     | Unknown_extension of string
 
   val describe_uppercase : t -> string
+
+  val describe_lowercase : t -> string
 
   val extension_component : t -> string
 
@@ -107,11 +147,15 @@ end = struct
 
   let builtin_component = "_builtin"
 
-  let describe_uppercase = function
+  let describe ~uppercase = function
     | Language_extension ext ->
-        "The extension \"" ^ Language_extension.to_string ext ^ "\""
+        (if uppercase then "T" else "t") ^ "he extension \"" ^
+        Language_extension.to_string ext ^ "\""
     | Builtin ->
-        "Built-in syntax"
+        (if uppercase then "B" else "b") ^ "uilt-in syntax"
+
+  let describe_uppercase = describe ~uppercase:true
+  let describe_lowercase = describe ~uppercase:false
 
   let extension_component = function
     | Language_extension ext -> Language_extension.to_string ext
@@ -252,6 +296,16 @@ module Embedded_name : sig
       Not exposed. *)
   val of_string : string -> (t, Misnamed_embedding_error.t) result option
 
+  val marker_attribute_handler :
+    string list -> (loc:Location.t -> attribute)
+                 * (attributes -> attributes option)
+                 * (attributes -> bool)
+
+  (** Checks whether a name is a "marker attribute name", as created by
+      [marker_attribute_handler] (see the .mli file).  Used to avoid trying to
+      desguar them as normal Jane syntax.  Not exposed. *)
+  val is_marker : t -> bool
+
   (** Print out the embedded form of a Jane-syntax name, in quotes; for use in
       error messages. *)
   val pp_quoted_name : Format.formatter -> t -> unit
@@ -315,6 +369,37 @@ end = struct
          end
       end
     | _ :: _ | [] -> None
+
+  let marker_component = "_marker"
+
+  let marker_attribute_handler components =
+    let t =
+      { erasability = Erasable; components = marker_component :: components }
+    in
+    let make ~loc =
+      let loc = Location.ghostify loc in
+      Ast_helper.Attr.mk ~loc (Location.mkloc (to_string t) loc) (PStr [])
+    in
+    let is_t = function
+      | { attr_name = { txt = name; loc = _ }
+        ; attr_payload = PStr []
+        ; attr_loc = _ } ->
+        String.equal (to_string t) name
+      | _ -> false
+    in
+    let extract attrs =
+      attrs |>
+      Util.find_map_last_and_split
+        ~f:(fun attr -> if is_t attr then Some () else None) |>
+      Option.map (fun (pre, (), post) -> pre @ post)
+    in
+    let has = List.exists is_t in
+    make, extract, has
+
+  let is_marker = function
+    | { erasability = Erasable; components = feature :: _ } ->
+      String.equal feature marker_component
+    | _ -> false
 
   let pp_quoted_name ppf t = Format.fprintf ppf "\"%s\"" (to_string t)
 
@@ -457,6 +542,8 @@ module type AST_syntactic_category = sig
 end
 
 module type AST_internal = sig
+  type 'ast with_attributes
+
   include AST_syntactic_category
 
   val embedding_syntax : Embedding_syntax.t
@@ -468,20 +555,28 @@ module type AST_internal = sig
       the body.  If the embedded term is malformed in any way, raises an error;
       if the input isn't an embedding of one of our novel syntactic features,
       returns [None].  Partial inverse of [make_jane_syntax]. *)
-  val match_jane_syntax : ast -> (Embedded_name.t * ast) option
+  val match_jane_syntax : ast -> (Embedded_name.t * ast with_attributes) option
+end
+
+module type AST_with_attributes_internal = sig
+  include AST_internal with type 'ast with_attributes := 'ast * attributes
+  val add_attributes : attributes -> ast -> ast
+  val set_attributes : ast -> attributes -> ast
 end
 
 (* Parses the embedded name from an embedding, raising if
     the embedding is malformed. Malformed means either:
 
     1. The embedding has a payload; attribute payloads must
-    be empty, so other ppxes can traverse "into" them.
+       be empty, so other ppxes can traverse "into" them.
 
-    2. NAME is missing; e.g. the attribute is just [[@jane]].
+    2. NAME is missing; i.e., the attribute is just [[@jane]] or
+       [[@jane.ERASABILITY]], and similarly for extension nodes.
 *)
 let parse_embedding_exn ~loc ~payload ~name ~embedding_syntax =
   let raise_error err = raise (Error (loc, err)) in
   match Embedded_name.of_string name with
+  | Some (Ok name) when Embedded_name.is_marker name -> None
   | Some (Ok name) -> begin
       let raise_malformed err =
         raise_error (Malformed_embedding (embedding_syntax, name, err))
@@ -494,28 +589,64 @@ let parse_embedding_exn ~loc ~payload ~name ~embedding_syntax =
       raise_error (Misnamed_embedding (err, name, embedding_syntax))
   | None -> None
 
+(** Extracts the last attribute (in list order) that was inserted by the Jane
+    Syntax framework, and returns the rest of the attributes in the same
+    relative order as was input.  The attributes that come before the extracted
+    one are first, and the attributes that come after are last; this last
+    component is guaranteed not to have any Jane Syntax attributes in it. *)
 let find_and_remove_jane_syntax_attribute =
-  let rec loop rest ~rev_prefix =
-    match rest with
-    | [] -> None
-    | attr :: rest ->
-      let { attr_name = { txt = name; loc = attr_loc }; attr_payload } =
-        attr
-      in
-      begin
-        match
-         parse_embedding_exn
-           ~loc:attr_loc
-           ~payload:attr_payload
-           ~name
-           ~embedding_syntax:Attribute
-        with
-        | None -> loop rest ~rev_prefix:(attr :: rev_prefix)
-        | Some name -> Some (name, List.rev_append rev_prefix rest)
-      end
-  in
-  fun attributes -> loop attributes ~rev_prefix:[]
-;;
+  Util.find_map_last_and_split
+    ~f:(fun { attr_name = { txt = name; loc }; attr_payload = payload } ->
+          parse_embedding_exn ~loc ~payload ~name ~embedding_syntax:Attribute)
+
+module Desugaring_error = struct
+  type error =
+    | Wrong_embedding of Embedded_name.t
+    | Non_embedding
+    | Bad_embedding of string list
+    | Unexpected_attributes of attributes
+
+  exception Error of Location.t * Feature.t * error
+
+  let report_term_for_feature ppf feature =
+    Format.fprintf ppf "term for@ %s" (Feature.describe_lowercase feature)
+
+  let report_error ~loc ~feature = function
+    | Wrong_embedding name ->
+      Location.errorf ~loc
+        "Tried to desugar the embedded term %a@ \
+         as part of a %a, a different feature"
+        Embedded_name.pp_quoted_name name
+        report_term_for_feature feature
+    | Non_embedding ->
+      Location.errorf ~loc
+        "Tried to desugar a non-embedded expression as part of a %a"
+        report_term_for_feature feature
+    | Bad_embedding subparts ->
+      Location.errorf ~loc
+        "Unknown, unexpected, or malformed embedded %a at %a"
+        report_term_for_feature
+          feature
+        Embedded_name.pp_quoted_name
+          (Embedded_name.of_feature feature subparts)
+    | Unexpected_attributes attrs ->
+      Location.errorf ~loc
+        "Non-Jane-syntax attributes were present \
+         at internal Jane-syntax points as part@ of a %a@.\
+         The attributes had the following names:@ %a"
+        report_term_for_feature
+          feature
+        (Format.pp_print_list
+           ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+           (fun ppf attr -> Format.fprintf ppf "\"%s\"" attr.attr_name.txt))
+          attrs
+
+  let () =
+    Location.register_error_of_exn
+      (function
+        | Error(loc, feature, err) -> Some (report_error ~loc ~feature err)
+        | _ -> None)
+end
 
 (** For a syntactic category, produce translations into and out of
     our novel syntax, using parsetree attributes as the encoding.
@@ -525,10 +656,13 @@ module Make_with_attribute
        include AST_syntactic_category
 
        val attributes : ast -> attributes
-       val with_attributes : ast -> attributes -> ast
-     end) : AST_internal with type ast = AST_syntactic_category.ast
+       val set_attributes : ast -> attributes -> ast
+     end) : AST_with_attributes_internal
+              with type ast = AST_syntactic_category.ast
 = struct
     include AST_syntactic_category
+
+    let add_attributes attrs ast = set_attributes ast (attributes ast @ attrs)
 
     let embedding_syntax = Embedding_syntax.Attribute
 
@@ -542,12 +676,13 @@ module Make_with_attribute
         ; attr_payload = PStr []
         }
       in
-      with_attributes ast (attr :: attributes ast)
+      add_attributes [attr] ast
 
-    let match_jane_syntax ast =
+   let match_jane_syntax ast =
       match find_and_remove_jane_syntax_attribute (attributes ast) with
       | None -> None
-      | Some (name, attrs) -> Some (name, with_attributes ast attrs)
+      | Some (inner_attrs, name, outer_attrs) ->
+        Some (name, (set_attributes ast inner_attrs, outer_attrs))
 end
 
 (** For a syntactic category, produce translations into and out of
@@ -577,34 +712,35 @@ module Make_with_extension_node
           name/format of the extension or the possible body terms (for which see
           [AST.match_extension]). Partial inverse of [make_extension_use]. *)
       val match_extension_use : ast -> (extension * ast) option
-     end) : AST_internal with type ast = AST_syntactic_category.ast =
-  struct
-    include AST_syntactic_category
+    end) : AST_internal with type ast = AST_syntactic_category.ast
+                         and type 'ast with_attributes := 'ast =
+struct
+  include AST_syntactic_category
 
-    let embedding_syntax = Embedding_syntax.Extension_node
+  let embedding_syntax = Embedding_syntax.Extension_node
 
-    let make_jane_syntax name ast =
-      make_extension_use
-        ast
-        ~extension_node:
-          (make_extension_node
-             ({ txt = Embedded_name.to_string name
-              ; loc = !Ast_helper.default_loc },
-              PStr []))
+  let make_jane_syntax name ast =
+    make_extension_use
+      ast
+      ~extension_node:
+        (make_extension_node
+           ({ txt = Embedded_name.to_string name
+            ; loc = !Ast_helper.default_loc },
+            PStr []))
 
-    let match_jane_syntax ast =
-      match match_extension_use ast with
+  let match_jane_syntax ast =
+    match match_extension_use ast with
+    | None -> None
+    | Some (({txt = name; loc = ext_loc}, ext_payload), body) ->
+      match
+        parse_embedding_exn
+          ~loc:ext_loc
+          ~payload:ext_payload
+          ~name
+          ~embedding_syntax
+      with
       | None -> None
-      | Some (({txt = name; loc = ext_loc}, ext_payload), body) ->
-        match
-          parse_embedding_exn
-            ~loc:ext_loc
-            ~payload:ext_payload
-            ~name
-            ~embedding_syntax
-        with
-        | None -> None
-        | Some name -> Some (name, body)
+      | Some name -> Some (name, body)
 end
 
 (** The AST parameters for every subset of types; embedded as
@@ -618,7 +754,7 @@ module Type_AST_syntactic_category = struct
   let with_location typ l = { typ with ptyp_loc = l }
 
   let attributes typ = typ.ptyp_attributes
-  let with_attributes typ ptyp_attributes = { typ with ptyp_attributes }
+  let set_attributes typ ptyp_attributes = { typ with ptyp_attributes }
 end
 
 (** Types; embedded as [[[%jane.FEATNAME] * BODY]]. *)
@@ -644,7 +780,7 @@ module Expression0 = Make_with_attribute (struct
   let with_location expr l = { expr with pexp_loc = l }
 
   let attributes expr = expr.pexp_attributes
-  let with_attributes expr pexp_attributes = { expr with pexp_attributes }
+  let set_attributes expr pexp_attributes = { expr with pexp_attributes }
 end)
 
 (** Patterns; embedded using an attribute on the pattern. *)
@@ -656,7 +792,7 @@ module Pattern0 = Make_with_attribute (struct
   let with_location pat l = { pat with ppat_loc = l }
 
   let attributes pat = pat.ppat_attributes
-  let with_attributes pat ppat_attributes = { pat with ppat_attributes }
+  let set_attributes pat ppat_attributes = { pat with ppat_attributes }
 end)
 
 (** Module types; embedded using an attribute on the module type. *)
@@ -668,7 +804,7 @@ module Module_type0 = Make_with_attribute (struct
     let with_location mty l = { mty with pmty_loc = l }
 
     let attributes mty = mty.pmty_attributes
-    let with_attributes mty pmty_attributes = { mty with pmty_attributes }
+    let set_attributes mty pmty_attributes = { mty with pmty_attributes }
 end)
 
 (** Extension constructors; embedded using an attribute. *)
@@ -680,7 +816,7 @@ module Extension_constructor0 = Make_with_attribute (struct
     let with_location ext l = { ext with pext_loc = l }
 
     let attributes ext = ext.pext_attributes
-    let with_attributes ext pext_attributes = { ext with pext_attributes }
+    let set_attributes ext pext_attributes = { ext with pext_attributes }
 end)
 
 (** Signature items; embedded as
@@ -757,16 +893,57 @@ end)
 (* Main exports *)
 
 module type AST = sig
+  type 'a with_attributes
   type ast
 
   val make_jane_syntax : Feature.t -> string list -> ast -> ast
   val make_entire_jane_syntax :
     loc:Location.t -> Feature.t -> (unit -> ast) -> ast
-  val make_of_ast :
-    of_ast_internal:(Feature.t -> ast -> 'a option) -> (ast -> 'a option)
+  val match_jane_syntax_piece :
+    Feature.t -> (ast -> string list -> 'a option) -> ast -> 'a
+  val make_of_ast
+    :  of_ast_internal:(Feature.t -> ast -> 'a option)
+    -> (ast -> ('a with_attributes) option)
 end
 
-module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
+module type AST_without_attributes =
+  AST with type 'ast with_attributes := 'ast
+
+module type AST_with_attributes = sig
+  include AST with type 'ast with_attributes := 'ast * attributes
+
+  val add_attributes : attributes -> ast -> ast
+end
+
+module type Handle_attributes = sig
+  type 'ast t
+  val map_ast : f:('ast1 -> 'ast2) -> 'ast1 t -> 'ast2 t
+  val assert_no_attributes :
+    loc:Location.t -> feature:Feature.t -> 'ast t -> 'ast
+end
+
+module Uses_attributes = struct
+  type 'ast t = 'ast * attributes
+  let map_ast ~f (ast, attrs) = (f ast, attrs)
+  let assert_no_attributes ~loc ~feature = function
+    | ast, [] -> ast
+    | _, (_ :: _ as attrs) ->
+      raise (Desugaring_error.Error (loc, feature, Unexpected_attributes attrs))
+end
+
+module Uses_extensions = struct
+  type 'ast t = 'ast
+  let map_ast ~f = f
+  let assert_no_attributes ~loc:_ ~feature:_ ast = ast
+end
+
+module Make_ast
+    (Handle_attributes : Handle_attributes)
+    (AST : AST_internal
+             with type 'ast with_attributes := 'ast Handle_attributes.t)
+  : AST with type ast = AST.ast
+         and type 'ast with_attributes := 'ast Handle_attributes.t =
+struct
   include AST
 
   let make_jane_syntax feature trailing_components ast =
@@ -777,7 +954,7 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
   let make_entire_jane_syntax ~loc feature ast =
     AST.with_location
       (make_jane_syntax feature []
-         (Ast_helper.with_default_loc (Location.ghostify loc) ast))
+         (Ast_helper.with_default_loc { loc with loc_ghost = true } ast))
       loc
 
   (** Generically lift our custom ASTs for our novel syntax from OCaml ASTs. *)
@@ -786,13 +963,14 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
       let loc = AST.location ast in
       let raise_error err = raise (Error (loc, err)) in
       match AST.match_jane_syntax ast with
-      | Some ({ erasability; components = [name] }, ast) -> begin
+      | Some ({ erasability; components = [name] }, ast_attrs) -> begin
           match Feature.of_component name with
-          | Ok feat -> begin
+          | Ok feat -> Some begin
+            ast_attrs |> Handle_attributes.map_ast ~f:(fun ast ->
               match of_ast_internal feat ast with
-              | Some ext_ast -> Some ext_ast
+              | Some ext_ast -> ext_ast
               | None ->
-                  raise_error (Wrong_syntactic_category(feat, AST.plural))
+                  raise_error (Wrong_syntactic_category(feat, AST.plural)))
             end
           | Error err -> raise_error begin match err with
             | Disabled_extension ext ->
@@ -806,13 +984,70 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
       | None -> None
     in
     of_ast
+
+  let match_jane_syntax_piece feature match_subparts ast =
+    let raise_error err =
+      raise (Desugaring_error.Error(location ast, feature, err))
+    in
+    match AST.match_jane_syntax ast with
+    | Some (embedded_name, ast_attrs) -> begin
+        let ast' =
+          Handle_attributes.assert_no_attributes
+            ~loc:(location ast) ~feature ast_attrs
+        in
+        match Embedded_name.components embedded_name with
+        | extension_string :: subparts
+          when String.equal
+                 extension_string
+                 (Feature.extension_component feature) -> begin
+            match match_subparts ast' subparts with
+            | Some ext_ast -> ext_ast
+            | None -> raise_error (Bad_embedding subparts)
+          end
+        | _ -> raise_error (Wrong_embedding embedded_name)
+      end
+    | None -> raise_error Non_embedding
 end
 
-module Expression = Make_ast(Expression0)
-module Pattern = Make_ast(Pattern0)
-module Module_type = Make_ast(Module_type0)
-module Signature_item = Make_ast(Signature_item0)
-module Structure_item = Make_ast(Structure_item0)
-module Core_type = Make_ast(Core_type0)
-module Constructor_argument = Make_ast(Constructor_argument0)
-module Extension_constructor = Make_ast(Extension_constructor0)
+module Make_extension_ast
+  :  functor (AST : AST_internal with type 'ast with_attributes := 'ast)
+  -> AST_without_attributes with type ast = AST.ast =
+  Make_ast (Uses_extensions)
+
+module Make_attribute_ast (AST : AST_with_attributes_internal)
+  : AST_with_attributes with type ast = AST.ast =
+struct
+  include Make_ast (Uses_attributes) (AST)
+  let add_attributes = AST.add_attributes
+end
+
+module Expression = struct
+  include Make_attribute_ast(Expression0)
+
+  let make_dummy ~attrs expr =
+    let unit =
+      Ast_helper.Exp.construct
+        (Location.mkloc (Longident.Lident "()") !Ast_helper.default_loc)
+        None
+    in
+    Ast_helper.Exp.sequence ~attrs unit expr
+
+  let match_dummy expr =
+    match expr.pexp_desc with
+    | Pexp_sequence
+        ( { pexp_desc =
+              Pexp_construct ({ txt = Lident "()"; loc = _ }, None)
+          ; pexp_attributes = []
+          ; pexp_loc = _; pexp_loc_stack = _ }
+        , expr') ->
+      Some expr'
+    | _ -> None
+end
+
+module Pattern = Make_attribute_ast(Pattern0)
+module Module_type = Make_attribute_ast(Module_type0)
+module Signature_item = Make_extension_ast(Signature_item0)
+module Structure_item = Make_extension_ast(Structure_item0)
+module Core_type = Make_attribute_ast(Core_type0)
+module Constructor_argument = Make_attribute_ast(Constructor_argument0)
+module Extension_constructor = Make_attribute_ast(Extension_constructor0)

--- a/vendor/parser-standard/jane_syntax_parsing.mli
+++ b/vendor/parser-standard/jane_syntax_parsing.mli
@@ -212,12 +212,8 @@ module type AST = sig
       {[
         let of_expr =
           Expression.match_jane_syntax_piece feature @@ fun expr -> function
-          | ["local"] ->
-            Expression.match_dummy expr |>
-            Option.map (fun expr' -> Lexp_local expr')
-          | ["exclave"] ->
-            Expression.match_dummy expr |>
-            Option.map (fun expr' -> Lexp_exclave expr')
+          | ["local"] -> Some (Lexp_local expr)
+          | ["exclave"] -> Some (Lexp_exclave expr)
           | _ -> None
       ]}
   *)
@@ -267,20 +263,8 @@ end
 module type AST_without_attributes =
   AST with type 'ast with_attributes := 'ast
 
-module Expression : sig
-  include AST_with_attributes with type ast = Parsetree.expression
-
-  (** Wraps an expression in a dummy do-nothing expression, to get an extra spot
-      to hang a location.  By default, the locations are set to
-      [!Ast_helper.default_loc].  Currently encoded as [(); e]. *)
-  val make_dummy :
-    attrs:Parsetree.attributes -> Parsetree.expression -> Parsetree.expression
-
-  (** Removes the extra do-nothing expression node created with [make_dummy] if
-      it was present, ignoring attributes.  Currently turns [(); e] into
-      [Some e]. *)
-  val match_dummy : Parsetree.expression -> Parsetree.expression option
-end
+module Expression :
+  AST_with_attributes with type ast = Parsetree.expression
 
 module Pattern :
   AST_with_attributes with type ast = Parsetree.pattern
@@ -298,7 +282,7 @@ module Core_type :
   AST_with_attributes with type ast = Parsetree.core_type
 
 module Constructor_argument :
-  AST_with_attributes with type ast = Parsetree.core_type
+  AST_without_attributes with type ast = Parsetree.core_type
 
 module Extension_constructor :
   AST_with_attributes with type ast = Parsetree.extension_constructor

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -184,8 +184,7 @@ let local_if : type ast. ast Local_syntax_category.t -> _ -> _ -> ast -> ast =
 let global_if global_flag sloc carg =
   match global_flag with
   | Global ->
-      Jane_syntax.Local.constr_arg_of ~loc:(make_loc sloc) ~attrs:[]
-        (Lcarg_global carg)
+      Jane_syntax.Local.constr_arg_of ~loc:(make_loc sloc) (Lcarg_global carg)
   | Nothing ->
       carg
 
@@ -698,7 +697,7 @@ let mk_directive ~loc name arg =
 let check_layout loc id =
   begin
     match id with
-    | ("any" | "value" | "void" | "immediate64" | "immediate") -> ()
+    | ("any" | "value" | "void" | "immediate64" | "immediate" | "float64") -> ()
     | _ -> expecting loc "layout"
   end;
   let loc = make_loc loc in
@@ -706,7 +705,7 @@ let check_layout loc id =
 
 (* Unboxed literals *)
 
-(* CR layouts v2: The [unboxed_*] functions will both be improved and lose
+(* CR layouts v2.5: The [unboxed_*] functions will both be improved and lose
    their explicit assert once we have real unboxed literals in Jane syntax; they
    may also get re-inlined at that point *)
 let unboxed_literals_extension = Language_extension.Layouts


### PR DESCRIPTION
We will use this mode to prepare our public-release code.  We still get a weaker round-tripping check -- we check that the resulting trees are equal _except_ for `jane.erasable.*` attributes.