### PR TITLE
Github build workflow uses OCaml 4.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           - windows-latest
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
-          - 4.13.x
+          - 4.14.x
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This should (I hope, let's see what CI does) update the versions of libraries we depend on for consistency with what we're doing locally.  This shows up in the autogenerated help text from `cmdliner`, which is how I noticed this.