### PR TITLE
Revert "Revert "Add a mode for erasing erasable jane-syntax (#32)""

### DIFF
--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -16,6 +16,9 @@ let is_doc = function
   | {attr_name= {Location.txt= "ocaml.doc" | "ocaml.text"; _}; _} -> true
   | _ -> false
 
+let is_erasable_jane_syntax attr =
+  String.is_prefix ~prefix:"jane.erasable." attr.attr_name.txt
+
 let dedup_cmts fragment ast comments =
   let of_ast ast =
     let docs = ref (Set.empty (module Cmt)) in
@@ -66,7 +69,7 @@ let docstring (c : Conf.t) =
 let sort_attributes : attributes -> attributes =
   List.sort ~compare:Poly.compare
 
-let make_mapper conf ~ignore_doc_comments =
+let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
   let open Ast_helper in
   (* remove locations *)
   let location _ _ = Location.none in
@@ -100,6 +103,11 @@ let make_mapper conf ~ignore_doc_comments =
   in
   (* sort attributes *)
   let attributes (m : Ast_mapper.mapper) (atrs : attribute list) =
+    let atrs =
+      if erase_jane_syntax then
+        List.filter atrs ~f:(fun a -> not (is_erasable_jane_syntax a))
+      else atrs
+    in
     let atrs =
       if ignore_doc_comments then
         List.filter atrs ~f:(fun a -> not (is_doc a))
@@ -160,12 +168,15 @@ let make_mapper conf ~ignore_doc_comments =
   ; pat
   ; typ }
 
-let ast fragment ~ignore_doc_comments c =
-  map fragment (make_mapper c ~ignore_doc_comments)
+let ast fragment ~ignore_doc_comments ~erase_jane_syntax c =
+  map fragment (make_mapper c ~ignore_doc_comments ~erase_jane_syntax)
 
-let equal fragment ~ignore_doc_comments c ast1 ast2 =
+let equal fragment ~ignore_doc_comments ~erase_jane_syntax c ~old:ast1
+    ~new_:ast2 =
   let map = ast fragment c ~ignore_doc_comments in
-  equal fragment (map ast1) (map ast2)
+  equal fragment
+    (map ~erase_jane_syntax ast1)
+    (map ~erase_jane_syntax:false ast2)
 
 let ast = ast ~ignore_doc_comments:false
 
@@ -196,15 +207,21 @@ let docstrings (type a) (fragment : a t) s =
   let (_ : a) = map fragment (make_docstring_mapper docstrings) s in
   !docstrings
 
-let docstring conf =
-  let mapper = make_mapper conf ~ignore_doc_comments:false in
+let docstring conf ~erase_jane_syntax =
+  let mapper =
+    make_mapper conf ~ignore_doc_comments:false ~erase_jane_syntax
+  in
   let normalize_code = normalize_code conf mapper in
   docstring conf ~normalize_code
 
-let moved_docstrings fragment c s1 s2 =
+let moved_docstrings fragment ~erase_jane_syntax c ~old:s1 ~new_:s2 =
   let d1 = docstrings fragment s1 in
   let d2 = docstrings fragment s2 in
-  let equal (_, x) (_, y) = String.equal (docstring c x) (docstring c y) in
+  let equal ~old:(_, x) ~new_:(_, y) =
+    String.equal
+      (docstring c x ~erase_jane_syntax)
+      (docstring c y ~erase_jane_syntax:false)
+  in
   let cmt_kind = `Doc_comment in
   let cmt (loc, x) = Cmt.create x loc in
   let dropped x = {Cmt.kind= `Dropped (cmt x); cmt_kind} in
@@ -213,11 +230,17 @@ let moved_docstrings fragment c s1 s2 =
   match List.zip d1 d2 with
   | Unequal_lengths ->
       (* We only return the ones that are not in both lists. *)
-      let l1 = List.filter d1 ~f:(fun x -> not (List.mem ~equal d2 x)) in
+      let l1 =
+        List.filter d1 ~f:(fun old ->
+            List.for_all d2 ~f:(fun new_ -> not (equal ~old ~new_)) )
+      in
       let l1 = List.map ~f:dropped l1 in
-      let l2 = List.filter d2 ~f:(fun x -> not (List.mem ~equal d1 x)) in
+      let l2 =
+        List.filter d2 ~f:(fun new_ ->
+            List.for_all d1 ~f:(fun old -> not (equal ~old ~new_)) )
+      in
       let l2 = List.map ~f:added l2 in
       List.rev_append l1 l2
   | Ok l ->
-      let l = List.filter l ~f:(fun (x, y) -> not (equal x y)) in
+      let l = List.filter l ~f:(fun (old, new_) -> not (equal ~old ~new_)) in
       List.map ~f:modified l

--- a/lib/Normalize_std_ast.mli
+++ b/lib/Normalize_std_ast.mli
@@ -9,11 +9,27 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val ast : 'a Std_ast.t -> Conf.t -> 'a -> 'a
-(** Normalize an AST fragment. *)
+val ast : 'a Std_ast.t -> erase_jane_syntax:bool -> Conf.t -> 'a -> 'a
+(** Normalize an AST fragment. If [erase_jane_syntax] is true, remove all
+    [Jane_syntax] attributes signaling erasable syntax. *)
 
 val equal :
-  'a Std_ast.t -> ignore_doc_comments:bool -> Conf.t -> 'a -> 'a -> bool
-(** Compare fragments for equality up to normalization. *)
+     'a Std_ast.t
+  -> ignore_doc_comments:bool
+  -> erase_jane_syntax:bool
+  -> Conf.t
+  -> old:'a
+  -> new_:'a
+  -> bool
+(** Compare fragments for equality up to normalization. If
+    [erase_jane_syntax] is true, first removes all [Jane_syntax] attributes
+    signaling erasable syntax from the [old] AST fragment; the [new_] AST
+    fragment should already omit them. *)
 
-val moved_docstrings : 'a Std_ast.t -> Conf.t -> 'a -> 'a -> Cmt.error list
+val moved_docstrings :
+     'a Std_ast.t
+  -> erase_jane_syntax:bool
+  -> Conf.t
+  -> old:'a
+  -> new_:'a
+  -> Cmt.error list

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -327,9 +327,11 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
         | std_t_new -> Ok std_t_new
       in
       (* Ast not preserved ? *)
+      let erase_jane_syntax = Erase_jane_syntax.should_erase () in
       ( if
           (not
-             (Normalize_std_ast.equal std_fg conf std_t.ast std_t_new.ast
+             (Normalize_std_ast.equal std_fg conf ~old:std_t.ast
+                ~new_:std_t_new.ast ~erase_jane_syntax
                 ~ignore_doc_comments:(not conf.opr_opts.comment_check.v) ) )
           && not
                (Normalize_extended_ast.equal fg conf t.ast t_new.ast
@@ -337,11 +339,12 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
         then
           let old_ast =
             dump_ast std_fg ~suffix:".old"
-              (Normalize_std_ast.ast std_fg conf std_t.ast)
+              (Normalize_std_ast.ast std_fg ~erase_jane_syntax conf std_t.ast)
           in
           let new_ast =
             dump_ast std_fg ~suffix:".new"
-              (Normalize_std_ast.ast std_fg conf std_t_new.ast)
+              (Normalize_std_ast.ast std_fg ~erase_jane_syntax:false conf
+                 std_t_new.ast )
           in
           let args ~suffix =
             [ ("output file", dump_formatted ~suffix fmted)
@@ -351,12 +354,12 @@ let format (type a b) (fg : a Extended_ast.t) (std_fg : b Std_ast.t)
                    Option.map f_opt ~f:(fun f -> (s, String.sexp_of_t f)) )
           in
           if
-            Normalize_std_ast.equal std_fg ~ignore_doc_comments:true conf
-              std_t.ast std_t_new.ast
+            Normalize_std_ast.equal std_fg ~ignore_doc_comments:true
+              ~erase_jane_syntax conf ~old:std_t.ast ~new_:std_t_new.ast
           then
             let docstrings =
-              Normalize_std_ast.moved_docstrings std_fg conf std_t.ast
-                std_t_new.ast
+              Normalize_std_ast.moved_docstrings std_fg ~erase_jane_syntax
+                conf ~old:std_t.ast ~new_:std_t_new.ast
             in
             let args = args ~suffix:".unequal-docs" in
             internal_error

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -31,7 +31,8 @@ type t =
   ; disable_conf_files: bool
   ; ignore_invalid_options: bool
   ; ocp_indent_config: bool
-  ; config: (string * string) list }
+  ; config: (string * string) list
+  ; erase_jane_syntax: bool }
 
 let default =
   { lib_conf= Conf.default
@@ -48,7 +49,8 @@ let default =
   ; disable_conf_files= false
   ; ignore_invalid_options= false
   ; ocp_indent_config= false
-  ; config= [] }
+  ; config= []
+  ; erase_jane_syntax= false }
 
 let global_conf = ref default
 
@@ -325,6 +327,17 @@ let ocp_indent_config =
     ~set:(fun ocp_indent_config conf -> {conf with ocp_indent_config})
     Arg.(value & flag & info ["ocp-indent-config"] ~doc ~docs)
 
+let erase_jane_syntax =
+  let doc =
+    "Erase all erasable Jane Street syntax extensions.  Jane Street uses \
+     this to generate the upstream-compatible public release code for our \
+     libraries (vs. the variant with Jane Street-specific syntax).  THIS \
+     OPTION WILL CHANGE THE RESULTING AST."
+  in
+  declare_option
+    ~set:(fun erase_jane_syntax conf -> {conf with erase_jane_syntax})
+    Arg.(value & flag & info ["erase-jane-syntax"] ~doc ~docs)
+
 let terms =
   [ Term.(
       const (fun lib_conf_modif conf ->
@@ -343,7 +356,8 @@ let terms =
   ; disable_conf_files
   ; ignore_invalid_options
   ; ocp_indent_config
-  ; config ]
+  ; config
+  ; erase_jane_syntax ]
 
 let global_term =
   let compose (t1 : ('a -> 'b) Term.t) (t2 : ('b -> 'c) Term.t) :
@@ -752,6 +766,9 @@ let validate_action () =
       Error (Printf.sprintf "Cannot specify %s with %s" a1 a2)
 
 let validate () =
+  (* We have to store this globally so that we can access it in the parser,
+     which doesn't have a [Conf_t.t]. *)
+  Erase_jane_syntax.set_should_erase !global_conf.erase_jane_syntax ;
   let root =
     Option.map !global_conf.root
       ~f:Fpath.(fun x -> v x |> to_absolute |> normalize)

--- a/lib/bin_conf/dune
+++ b/lib/bin_conf/dune
@@ -11,4 +11,4 @@
    Ocamlformat_result.Global_scope))
  (instrumentation
   (backend bisect_ppx))
- (libraries ocamlformat-lib re))
+ (libraries erase_jane_syntax ocamlformat-lib re))

--- a/lib/erase_jane_syntax/dune
+++ b/lib/erase_jane_syntax/dune
@@ -1,0 +1,3 @@
+(library
+ (public_name ocamlformat.erase_jane_syntax)
+ (name erase_jane_syntax))

--- a/lib/erase_jane_syntax/erase_jane_syntax.ml
+++ b/lib/erase_jane_syntax/erase_jane_syntax.ml
@@ -1,0 +1,5 @@
+let should_erase_ref = ref false
+
+let set_should_erase yn = should_erase_ref := yn
+
+let should_erase () = !should_erase_ref

--- a/lib/erase_jane_syntax/erase_jane_syntax.mli
+++ b/lib/erase_jane_syntax/erase_jane_syntax.mli
@@ -1,0 +1,29 @@
+(** Whether or not Jane Street-specific syntax should be erased. Anything in
+    vendor/parser-extended that could generate one of the Jane
+    Street-specific constructors we add to the extended parsetree needs to
+    check [should_erase] and, if true, generate the corresponding "plain"
+    version, as per the compiler's [Jane_syntax] construction.
+
+    When the user does request erasure, the result of ocamlformat {e will}
+    modify the parse tree, but will also be parseable by upstream OCaml; we
+    validate that the resulting parse tree is only modified to the point of
+    removing Jane Street-specific syntax.
+
+    This is done as a separate library so that it can be availble from the
+    parser-extended Menhir parser, which we can't pass a local boolean flag
+    into. This library is then depended on by everything that needs to know
+    about this global state. While on the ocamlformat side, we could put this
+    in the configuration type, that would not work for the Menhir parser;
+    thus, we take this somewhat more invasive approach. *)
+
+val set_should_erase : bool -> unit
+(** Toggle whether Jane Street specific parse tree components ought to be
+    erased from parsing/printing: [true] if they should be erased (so that
+    the parse tree will be modified by ocamlformat), [false] if they should
+    not. *)
+
+val should_erase : unit -> bool
+(** Check whether Jane Street specific parse tree components ought to be
+    erased from parsing/printing: [true] if they should be erased (so that
+    the parse tree will be modified by ocamlformat), [false] if they should
+    not. *)

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -546,6 +546,12 @@ OPTIONS
            (or in $HOME/.config/.ocamlformat if $XDG_CONFIG_HOME is
            undefined) is applied.
 
+       --erase-jane-syntax
+           Erase all erasable Jane Street syntax extensions. Jane Street uses
+           this to generate the upstream-compatible public release code for
+           our libraries (vs. the variant with Jane Street-specific syntax).
+           THIS OPTION WILL CHANGE THE RESULTING AST.
+
        -g, --debug
            Generate debugging output. The flag is unset by default.
 

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3703,6 +3703,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to local-erased.ml.stdout
+   (with-stderr-to local-erased.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --erase-jane-syntax %{dep:tests/local.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local-erased.ml.ref local-erased.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local-erased.ml.err local-erased.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to local.ml.stdout
    (with-stderr-to local.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/local.ml})))))

--- a/test/passing/tests/local-erased.ml.opts
+++ b/test/passing/tests/local-erased.ml.opts
@@ -1,0 +1,1 @@
+--erase-jane-syntax

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -1,0 +1,65 @@
+let f a b c = 1
+
+let f a ~foo:b ?foo:(c = 1) ~d = ()
+
+let f ~x ~(y : string) ?(z : string) = ()
+
+let xs = [(fun a (type b) ~c -> 1)]
+
+let xs = [(fun a (type b) ~c -> 1)]
+
+let f () =
+  let a = [1] in
+  let r = 1 in
+  let f : 'a. 'a -> 'a = fun x -> x in
+  let g a b c : int = 1 in
+  let () = g (fun () -> ()) in
+  "asdfasdfasdfasdfasdfasdfasdf"
+
+let f () =
+  let a = [1] in
+  let r = 1 in
+  let f : 'a. 'a -> 'a = fun x -> x in
+  let g a b c : int = 1 in
+  let () = g (fun () -> ()) in
+  "asdfasdfasdfasdfasdfasdfasdf"
+
+type 'a r = {mutable a: 'a; b: 'a; c: 'a}
+
+type 'a r = Foo of 'a | Bar of 'a * 'a | Baz of int * string * 'a
+
+type ('a, 'b) cfn = a:'a -> ?b:b -> 'a -> int -> 'b
+
+type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+let _ = ()
+
+let _ = ()
+
+let () = x
+
+let () = x
+
+let {b} = ()
+
+let {b} = ()
+
+let () = r
+
+let () = r
+
+let x : string = "hi"
+
+let (x : string) = "hi"
+
+let (x : string) = "hi"
+
+let x = ("hi" : string)
+
+let x = ("hi" : string)
+
+let x : 'a. 'a -> 'a = "hi"
+
+let x : 'a. 'a -> 'a = "hi"
+
+let f : 'a. 'a -> 'a = "hi"

--- a/vendor/ocaml-common/location.ml
+++ b/vendor/ocaml-common/location.ml
@@ -18,6 +18,36 @@ open Lexing
 type t = Warnings.loc =
   { loc_start: position; loc_end: position; loc_ghost: bool }
 
+let equal
+      { loc_start = { pos_fname = loc_start_pos_fname_1
+                    ; pos_lnum = loc_start_pos_lnum_1
+                    ; pos_bol = loc_start_pos_bol_1
+                    ; pos_cnum = loc_start_pos_cnum_1 }
+      ; loc_end = { pos_fname = loc_end_pos_fname_1
+                  ; pos_lnum = loc_end_pos_lnum_1
+                  ; pos_bol = loc_end_pos_bol_1
+                  ; pos_cnum = loc_end_pos_cnum_1 }
+      ; loc_ghost = loc_ghost_1 }
+      { loc_start = { pos_fname = loc_start_pos_fname_2
+                    ; pos_lnum = loc_start_pos_lnum_2
+                    ; pos_bol = loc_start_pos_bol_2
+                    ; pos_cnum = loc_start_pos_cnum_2 }
+      ; loc_end = { pos_fname = loc_end_pos_fname_2
+                  ; pos_lnum = loc_end_pos_lnum_2
+                  ; pos_bol = loc_end_pos_bol_2
+                  ; pos_cnum = loc_end_pos_cnum_2 }
+      ; loc_ghost = loc_ghost_2 }
+  =
+  String.equal loc_start_pos_fname_1 loc_start_pos_fname_2 &&
+  Int.equal    loc_start_pos_lnum_1  loc_start_pos_lnum_2  &&
+  Int.equal    loc_start_pos_bol_1   loc_start_pos_bol_2   &&
+  Int.equal    loc_start_pos_cnum_1  loc_start_pos_cnum_2  &&
+  String.equal loc_end_pos_fname_1   loc_end_pos_fname_2   &&
+  Int.equal    loc_end_pos_lnum_1    loc_end_pos_lnum_2    &&
+  Int.equal    loc_end_pos_bol_1     loc_end_pos_bol_2     &&
+  Int.equal    loc_end_pos_cnum_1    loc_end_pos_cnum_2    &&
+  Bool.equal   loc_ghost_1           loc_ghost_2
+
 let in_file = Warnings.ghost_loc_in_file
 
 let none = in_file "_none_"

--- a/vendor/ocaml-common/location.mli
+++ b/vendor/ocaml-common/location.mli
@@ -35,6 +35,12 @@ type t = Warnings.loc = {
    Else all fields are correct.
 *)
 
+(** Strict equality: Two locations are equal iff every field is equal.  Two
+    locations that happen to refer to the same place -- for instance, if one has
+    [pos_lnum] set correctly and the other has [pos_lnum = -1] -- are not
+    considered to be equal. *)
+val equal : t -> t -> bool
+
 val none : t
 (** An arbitrary value of type [t]; describes an empty ghost range. *)
 

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -601,3 +601,26 @@ module Of = struct
   let inherit_ ?loc ty =
     mk ?loc (Oinherit ty)
 end
+
+(* Jane Street extension *)
+module Jane = struct
+  let sign_str = function
+    | Positive -> ""
+    | Negative -> "-"
+
+  let pconst_unboxed_integer sign value suffix =
+    if Erase_jane_syntax.should_erase ()
+    then Pconst_integer (sign_str sign ^ value, suffix)
+    else Pconst_unboxed_integer (sign, value, suffix)
+
+  let pconst_unboxed_float sign value suffix =
+    if Erase_jane_syntax.should_erase ()
+    then Pconst_float (sign_str sign ^ value, suffix)
+    else Pconst_unboxed_float (sign, value, suffix)
+
+  let ptyp_constr_unboxed ident args =
+    if Erase_jane_syntax.should_erase ()
+    then Ptyp_constr (ident, args)
+    else Ptyp_constr_unboxed (ident, args)
+end
+(* End Jane Street extension *)

--- a/vendor/parser-extended/ast_helper.mli
+++ b/vendor/parser-extended/ast_helper.mli
@@ -506,3 +506,19 @@ module Of:
       label with_loc -> core_type -> object_field
     val inherit_: ?loc:loc -> core_type -> object_field
   end
+
+(* Jane Street extension *)
+(** Jane Street syntax *)
+module Jane:
+  sig
+    (** One value per constructor, constructs [_desc]s, not split by AST
+        category.  These are used to toggle construction based on whether we're
+        erasing Jane syntax or not; if we are, they return the erased
+        version. *)
+
+    val pconst_unboxed_integer : sign -> string -> char option -> constant_desc
+    val pconst_unboxed_float : sign -> string -> char option -> constant_desc
+
+    val ptyp_constr_unboxed : lid -> core_type list -> core_type_desc
+  end
+(* End Jane Street extension *)

--- a/vendor/parser-extended/dune
+++ b/vendor/parser-extended/dune
@@ -3,7 +3,12 @@
  (public_name ocamlformat-lib.parser_extended)
  (flags
   (:standard -w -9 -open Parser_shims -open Ocaml_common))
- (libraries compiler-libs.common menhirLib parser_shims ocaml_common))
+ (libraries
+  erase_jane_syntax
+  compiler-libs.common
+  menhirLib
+  parser_shims
+  ocaml_common))
 
 (ocamllex lexer)
 

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -214,15 +214,19 @@ let include_functor_attr =
   Attr.mk ~loc:Location.none include_functor_ext_loc (PStr [])
 
 let mkexp_stack ~loc exp =
+  if Erase_jane_syntax.should_erase () then exp else
   ghexp ~loc (Pexp_apply(local_extension, [Nolabel, exp]))
 
 let mkpat_stack pat =
+  if Erase_jane_syntax.should_erase () then pat else
   {pat with ppat_attributes = local_attr :: pat.ppat_attributes}
 
 let mktyp_stack typ =
+  if Erase_jane_syntax.should_erase () then typ else
   {typ with ptyp_attributes = local_attr :: typ.ptyp_attributes}
 
 let wrap_exp_stack exp =
+  if Erase_jane_syntax.should_erase () then exp else
   {exp with pexp_attributes = local_attr :: exp.pexp_attributes}
 
 let mkexp_local_if p ~loc exp =
@@ -244,6 +248,7 @@ let exclave_extension loc =
     (Pexp_extension(exclave_ext_loc loc, PStr []))
 
 let mkexp_exclave ~loc ~kwd_loc exp =
+  if Erase_jane_syntax.should_erase () then exp else
   ghexp ~loc (Pexp_apply(exclave_extension (make_loc kwd_loc), [Nolabel, exp]))
 
 let curry_attr =
@@ -253,6 +258,7 @@ let is_curry_attr attr =
   attr.attr_name.txt = "extension.curry"
 
 let mktyp_curry typ =
+  if Erase_jane_syntax.should_erase () then typ else
   {typ with ptyp_attributes = curry_attr :: typ.ptyp_attributes}
 
 let maybe_curry_typ typ =
@@ -268,6 +274,7 @@ let global_attr loc =
   Attr.mk ~loc:Location.none (global_loc loc) (PStr [])
 
 let mkld_global ld loc =
+  if Erase_jane_syntax.should_erase () then ld else
   { ld with pld_attributes = global_attr loc :: ld.pld_attributes }
 
 let mkld_global_maybe gbl ld loc =
@@ -276,6 +283,7 @@ let mkld_global_maybe gbl ld loc =
   | Nothing -> ld
 
 let mkcty_global cty loc =
+  if Erase_jane_syntax.should_erase () then cty else
   { cty with ptyp_attributes = global_attr loc :: cty.ptyp_attributes }
 
 let mkcty_global_maybe gbl cty loc =
@@ -3643,7 +3651,7 @@ atomic_type:
     | tys = actual_type_parameters
       tid = mkrhs(type_longident)
       HASH_SUFFIX
-        { Ptyp_constr_unboxed(tid, tys) }
+        { Jane.ptyp_constr_unboxed tid tys }
     | tys = actual_type_parameters
       tid = mkrhs(type_longident)
         { Ptyp_constr(tid, tys) } %prec below_HASH
@@ -3790,9 +3798,9 @@ constant:
 
   (* Jane Street extension *)
   | HASH_INT     { let (n, m) = $1 in
-                   mkconst ~loc:$sloc (Pconst_unboxed_integer(Positive, n, m)) }
+                   mkconst ~loc:$sloc (Jane.pconst_unboxed_integer Positive n m) }
   | HASH_FLOAT   { let (f, m) = $1 in
-                   mkconst ~loc:$sloc (Pconst_unboxed_float (Positive, f, m)) }
+                   mkconst ~loc:$sloc (Jane.pconst_unboxed_float Positive f m) }
   (* End Jane Street extension *)
 ;
 signed_constant:
@@ -3809,16 +3817,16 @@ signed_constant:
   (* Jane Street extension *)
   | MINUS HASH_INT    { let (n, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_integer(Negative,n,m)) }
+                          (Jane.pconst_unboxed_integer Negative n m) }
   | MINUS HASH_FLOAT  { let (f, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_float(Negative,f,m)) }
+                          (Jane.pconst_unboxed_float Negative f m) }
   | PLUS HASH_INT     { let (n, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_integer (Positive,n,m)) }
+                          (Jane.pconst_unboxed_integer Positive n m) }
   | PLUS HASH_FLOAT   { let (f, m) = $2 in
                         mkconst ~loc:$sloc
-                          (Pconst_unboxed_float (Positive,f,m)) }
+                          (Jane.pconst_unboxed_float Positive f m) }
   (* End Jane Street extension *)
 ;
 

--- a/vendor/parser-standard/jane_syntax.mli
+++ b/vendor/parser-standard/jane_syntax.mli
@@ -23,29 +23,108 @@
 (*********************************************)
 (* Individual features *)
 
+(** The ASTs for built-in syntax extensions.  No ASTs as yet; for now, we just
+    have some attribute machinery. *)
+module Builtin : sig
+  (** Mark an arrow type as "curried" (written with parentheses) for the local
+      extension.  This is done unconditionally by the parser: [a -> (b -> c)] is
+      parsed as [a -> ((b -> c)[@CURRY])] for some (private) attribute.  A
+      non-arrow type won't be modified by this function.
+
+      We leave this as an attribute because it's only used internally, and
+      changing function types/adding another kind of arrow is a *lot* of
+      work. *)
+  val mark_curried :
+    loc:Location.t -> Parsetree.core_type -> Parsetree.core_type
+
+  (** Check if a type was marked as curried via [mark_curried].  Does not modify
+      the attributes of the type. *)
+  val is_curried : Parsetree.core_type -> bool
+
+  (** Return all the attributes from the given list that were not added by
+      marking functions such as [mark_curried].  The same as accessing
+      [ptyp_attributes] if the type was not so marked. *)
+  val non_syntax_attributes : Parsetree.attributes -> Parsetree.attributes
+end
+
+(** The ASTs for locality modes *)
+module Local : sig
+  type core_type = Ltyp_local of Parsetree.core_type
+  (** [local_ TYPE]
+
+      Invariant: Only used in arrow types (e.g., [local_ a -> local_ b]), and
+      has no attributes (the inner [core_type] can).
+
+      The other part of locality that shows up in types is the marking of what's
+      curried (i.e., represented with explicit parentheses in the source); this
+      is represented by the [Builtin.mark_curried] machinery, which see. *)
+
+  type constructor_argument =
+    | Lcarg_global of Parsetree.core_type
+    (** [global_ TYPE]
+
+        E.g.: [type t = { x : global_ string }] or
+        [type t = C of global_ string]. *)
+
+  type expression =
+    | Lexp_local of Parsetree.expression
+    (** [local_ EXPR] *)
+    | Lexp_exclave of Parsetree.expression
+    (** [exclave_ EXPR] *)
+    | Lexp_constrain_local of Parsetree.expression
+    (** This represents the shadow [local_] that is inserted on the RHS of a
+        [let local_ f : t = e in ...] binding.
+
+        Invariant: [Lexp_constrain_local] occurs on the LHS of a
+        [Pexp_constraint] or [Pexp_coerce] node.
+
+        We don't inline the definition of [Pexp_constraint] or [Pexp_coerce]
+        here because nroberts's (@ncik-roberts's) forthcoming syntactic
+        function arity parsing patch handles this case more directly, and we
+        don't want to double the amount of work we're doing. *)
+
+  type pattern =
+    | Lpat_local of Parsetree.pattern
+    (** [local_ PAT]
+
+        Invariant: [Lpat_local] is always the outermost part of a pattern. *)
+
+  val type_of :
+    loc:Location.t -> attrs:Parsetree.attributes ->
+    core_type -> Parsetree.core_type
+  val constr_arg_of :
+    loc:Location.t -> constructor_argument -> Parsetree.core_type
+  val expr_of :
+    loc:Location.t -> attrs:Parsetree.attributes ->
+    expression -> Parsetree.expression
+  val pat_of :
+    loc:Location.t -> attrs:Parsetree.attributes ->
+    pattern -> Parsetree.pattern
+end
+
 (** The ASTs for list and array comprehensions *)
 module Comprehensions : sig
   type iterator =
     | Range of { start     : Parsetree.expression
                ; stop      : Parsetree.expression
                ; direction : Asttypes.direction_flag }
-    (** "= START to STOP" (direction = Upto)
-        "= START downto STOP" (direction = Downto) *)
+    (** [= START to STOP] (direction = [Upto])
+        [= START downto STOP] (direction = [Downto]) *)
     | In of Parsetree.expression
-    (** "in EXPR" *)
+    (** [in EXPR] *)
 
   (* In [Typedtree], the [pattern] moves into the [iterator]. *)
   type clause_binding =
     { pattern    : Parsetree.pattern
     ; iterator   : iterator
     ; attributes : Parsetree.attribute list }
-    (** [@...] PAT (in/=) ... *)
+    (** [[@...] PAT (in/=) ...] *)
 
   type clause =
     | For of clause_binding list
-    (** "for PAT (in/=) ... and PAT (in/=) ... and ..."; must be nonempty *)
+    (** [for PAT (in/=) ... and PAT (in/=) ... and ...]; must be nonempty *)
     | When of Parsetree.expression
-    (** "when EXPR" *)
+    (** [when EXPR] *)
 
   type comprehension =
     { body : Parsetree.expression
@@ -55,10 +134,10 @@ module Comprehensions : sig
 
   type expression =
     | Cexp_list_comprehension  of comprehension
-    (** [BODY ...CLAUSES...] *)
+    (** [[BODY ...CLAUSES...]] *)
     | Cexp_array_comprehension of Asttypes.mutable_flag * comprehension
-    (** [|BODY ...CLAUSES...|] (flag = Mutable)
-        [:BODY ...CLAUSES...:] (flag = Immutable)
+    (** [[|BODY ...CLAUSES...|]] (flag = [Mutable])
+        [[:BODY ...CLAUSES...:]] (flag = [Immutable])
           (only allowed with [-extension immutable_arrays]) *)
 
   val expr_of :
@@ -72,11 +151,11 @@ end
 module Immutable_arrays : sig
   type expression =
     | Iaexp_immutable_array of Parsetree.expression list
-    (** [: E1; ...; En :] *)
+    (** [[: E1; ...; En :]] *)
 
   type pattern =
     | Iapat_immutable_array of Parsetree.pattern list
-    (** [: P1; ...; Pn :] **)
+    (** [[: P1; ...; Pn :]] **)
 
   val expr_of :
     loc:Location.t -> attrs:Parsetree.attributes ->
@@ -92,9 +171,11 @@ end
 module Include_functor : sig
   type signature_item =
     | Ifsig_include_functor of Parsetree.include_description
+    (** [include functor MTY] *)
 
   type structure_item =
     | Ifstr_include_functor of Parsetree.include_declaration
+    (** [include functor MOD] *)
 
   val sig_item_of : loc:Location.t -> signature_item -> Parsetree.signature_item
   val str_item_of : loc:Location.t -> structure_item -> Parsetree.structure_item
@@ -114,7 +195,20 @@ end
 module Unboxed_constants : sig
   type t =
     | Float of string * char option
+    (** Unboxed float constants such as [3.4#], [-2e5#], or [+1.4e-4#g].
+
+        Unlike with boxed constants, the sign (if present) is included.
+
+        Suffixes [g-z][G-Z] are accepted by the parser.
+        Suffixes are rejected by the typechecker. *)
     | Integer of string * char
+    (** Unboxed float constants such as [3#], [-3#l], [+3#L], or [3#n].
+
+        Unlike with boxed constants, the sign (if present) is included.
+
+        Suffixes [g-z][G-Z] are *required* by the parser.
+        Suffixes except ['l'], ['L'] and ['n'] are rejected by the typechecker.
+    *)
 
   type expression = t
   type pattern = t
@@ -199,6 +293,14 @@ module type AST = sig
       match on [sexp.pexp_desc] *without going up an indentation level*.  This
       is important to reduce the number of merge conflicts. *)
   val of_ast : ast -> t option
+
+  (** The dual of [of_ast], only used by [Ast_mapper].  This is built up from
+      the various [FEATURE.CATEGORY_of], such as [Local.type_of], which you
+      should prefer.  This generic version allows for easier construction of
+      OCaml AST terms from Jane syntax ASTs when you don't know which Jane
+      syntax feature you have; this doesn't occur very frequently, hence the
+      limited use. *)
+  val ast_of : loc:Location.t -> t -> ast
 end
 
 (******************************************)
@@ -206,26 +308,31 @@ end
 
 (** Novel syntax in types *)
 module Core_type : sig
-  type t = |
+  type t =
+    | Jtyp_local of Local.core_type
 
   include AST
     with type t := t * Parsetree.attributes
      and type ast := Parsetree.core_type
 end
 
-(** Novel syntax in constructor arguments; this isn't a core AST type,
-    but captures where [global_] lives *)
+(** Novel syntax in constructor arguments; this isn't a core AST type, but
+    captures where [global_] lives.  Unlike types, they don't have attributes;
+    any attributes are either on the label declaration they're in (if any) or on
+    the inner type. *)
 module Constructor_argument : sig
-  type t = |
+  type t =
+    | Jcarg_local of Local.constructor_argument
 
   include AST
-    with type t := t * Parsetree.attributes
+    with type t := t
      and type ast := Parsetree.core_type
 end
 
 (** Novel syntax in expressions *)
 module Expression : sig
   type t =
+    | Jexp_local            of Local.expression
     | Jexp_comprehension    of Comprehensions.expression
     | Jexp_immutable_array  of Immutable_arrays.expression
     | Jexp_unboxed_constant of Unboxed_constants.expression
@@ -233,23 +340,18 @@ module Expression : sig
   include AST
     with type t := t * Parsetree.attributes
      and type ast := Parsetree.expression
-
-  val expr_of :
-    loc:Location.t -> attrs:Parsetree.attributes -> t -> Parsetree.expression
 end
 
 (** Novel syntax in patterns *)
 module Pattern : sig
   type t =
+    | Jpat_local           of Local.pattern
     | Jpat_immutable_array of Immutable_arrays.pattern
     | Jpat_unboxed_constant of Unboxed_constants.pattern
 
   include AST
     with type t := t * Parsetree.attributes
      and type ast := Parsetree.pattern
-
-  val pat_of :
-    loc:Location.t -> attrs:Parsetree.attributes -> t -> Parsetree.pattern
 end
 
 (** Novel syntax in module types *)

--- a/vendor/parser-standard/jane_syntax_parsing.ml
+++ b/vendor/parser-standard/jane_syntax_parsing.ml
@@ -4,7 +4,7 @@
     where each novel piece of syntax is represented using one of two embeddings:
 
     1. As an AST item carrying an attribute. The AST item serves as the "body"
-      of the syntax indicated by the attribute.
+       of the syntax indicated by the attribute.
     2. As a pair of an extension node and an AST item that serves as the "body".
        Here, the "pair" is embedded as a pair-like construct in the relevant AST
        category, e.g. [include sig [%jane.ERASABILITY.EXTNAME];; BODY end] for
@@ -14,7 +14,13 @@
     enabled by [-extension EXTNAME] on the command line), the attribute (if
     used) must be [[@jane.ERASABILITY.EXTNAME]], and the extension node (if
     used) must be [[%jane.ERASABILITY.EXTNAME]]. For built-in syntax, we use
-    [_builtin] instead of an language extension name.
+    [_builtin] instead of a language extension name.
+
+    The only exception to this is that for some built-in syntax, we instead use
+    certain "marker" attributes, designed to be created by the parser when a
+    full Jane-syntax encoding would be too heavyweight; for these, we use
+    [_marker] instead of an extension name, and allow arbitrary dot-separated
+    strings (see below) to follow it.
 
     The [ERASABILITY] component indicates to tools such as ocamlformat and
     ppxlib whether or not the attribute is erasable. See the documentation of
@@ -79,6 +85,45 @@
 
 open Parsetree
 
+(** We carefully regulate which bindings we import from [Language_extension] to
+    ensure that we can import this file into places like ocamlformat or the Jane
+    Street internal repo with no changes.
+*)
+module Language_extension = struct
+  include Language_extension_kernel
+  include (
+    Language_extension
+      : Language_extension_kernel.Language_extension_for_jane_syntax)
+end
+
+(** For the same reason, we don't want this file to depend on new additions to
+    [Misc] or similar utility libraries, so we define any generic utility
+    functionality in this module. *)
+module Util : sig
+  val split_last_opt : 'a list -> ('a list * 'a) option
+          (* Like [Misc.split_last], but doesn't throw any exceptions. *)
+
+  val find_map_last_and_split :
+    f:('a -> 'b option) -> 'a list -> ('a list * 'b * 'a list) option
+          (* [find_map_last_and_split ~f l] returns a triple [pre, y, post] such
+             that [l = pre @ x @ post], [f x = Some y], and for all [x'] in
+             [post], [f x' = None].  If, for all [z] in [l], [f z = None], then
+             it returns [None]. *)
+end = struct
+  let split_last_opt = function
+    | [] -> None
+    | (_ :: _) as xs -> Some (Misc.split_last xs)
+
+  let find_map_last_and_split =
+    let rec go post ~f = function
+      | [] -> None
+      | x :: xs -> match f x with
+        | Some y -> Some (List.rev xs, y, post)
+        | None -> go (x :: post) ~f xs
+    in
+    fun ~f xs -> go [] ~f (List.rev xs)
+end
+
 (******************************************************************************)
 
 module Feature : sig
@@ -91,6 +136,8 @@ module Feature : sig
     | Unknown_extension of string
 
   val describe_uppercase : t -> string
+
+  val describe_lowercase : t -> string
 
   val extension_component : t -> string
 
@@ -107,11 +154,15 @@ end = struct
 
   let builtin_component = "_builtin"
 
-  let describe_uppercase = function
+  let describe ~uppercase = function
     | Language_extension ext ->
-        "The extension \"" ^ Language_extension.to_string ext ^ "\""
+        (if uppercase then "T" else "t") ^ "he extension \"" ^
+        Language_extension.to_string ext ^ "\""
     | Builtin ->
-        "Built-in syntax"
+        (if uppercase then "B" else "b") ^ "uilt-in syntax"
+
+  let describe_uppercase = describe ~uppercase:true
+  let describe_lowercase = describe ~uppercase:false
 
   let extension_component = function
     | Language_extension ext -> Language_extension.to_string ext
@@ -206,6 +257,10 @@ module Erasability = struct
     | Erasable
     | Non_erasable
 
+  let equal t1 t2 = match t1, t2 with
+    | Erasable, Erasable | Non_erasable, Non_erasable -> true
+    | (Erasable | Non_erasable), _ -> false
+
   let to_string = function
     | Erasable -> "erasable"
     | Non_erasable -> "non_erasable"
@@ -251,6 +306,16 @@ module Embedded_name : sig
           of our Jane-syntax machinery.
       Not exposed. *)
   val of_string : string -> (t, Misnamed_embedding_error.t) result option
+
+  val marker_attribute_handler :
+    string list -> (loc:Location.t -> attribute)
+                 * (attributes -> attributes option)
+                 * (attributes -> bool)
+
+  (** Checks whether a name is a "marker attribute name", as created by
+      [marker_attribute_handler] (see the .mli file).  Used to avoid trying to
+      desguar them as normal Jane syntax.  Not exposed. *)
+  val is_marker : t -> bool
 
   (** Print out the embedded form of a Jane-syntax name, in quotes; for use in
       error messages. *)
@@ -316,6 +381,37 @@ end = struct
       end
     | _ :: _ | [] -> None
 
+  let marker_component = "_marker"
+
+  let marker_attribute_handler components =
+    let t =
+      { erasability = Erasable; components = marker_component :: components }
+    in
+    let make ~loc =
+      let loc = Location.ghostify loc in
+      Ast_helper.Attr.mk ~loc (Location.mkloc (to_string t) loc) (PStr [])
+    in
+    let is_t = function
+      | { attr_name = { txt = name; loc = _ }
+        ; attr_payload = PStr []
+        ; attr_loc = _ } ->
+        String.equal (to_string t) name
+      | _ -> false
+    in
+    let extract attrs =
+      attrs |>
+      Util.find_map_last_and_split
+        ~f:(fun attr -> if is_t attr then Some () else None) |>
+      Option.map (fun (pre, (), post) -> pre @ post)
+    in
+    let has = List.exists is_t in
+    make, extract, has
+
+  let is_marker = function
+    | { erasability = Erasable; components = feature :: _ } ->
+      String.equal feature marker_component
+    | _ -> false
+
   let pp_quoted_name ppf t = Format.fprintf ppf "\"%s\"" (to_string t)
 
   let pp_a_term ppf (esyn, t) =
@@ -342,6 +438,7 @@ module Error = struct
     | Misnamed_embedding of
         Misnamed_embedding_error.t * string * Embedding_syntax.t
     | Bad_introduction of Embedding_syntax.t * Embedded_name.t
+    | Missing_location_attribute
 
   (** The exception type thrown when desugaring a piece of modular syntax from
       an OCaml AST *)
@@ -422,6 +519,11 @@ let report_error ~loc = function
         Embedded_name.pp_a_term (what, name)
         (Embedding_syntax.name what)
         Embedded_name.pp_a_term (what, { name with components = [ext] })
+  | Missing_location_attribute ->
+      Location.errorf
+        ~loc
+        "@[All attribute embeddings are expected to contain a location \
+           attribute,@ but one was missing here.@]"
 
 let () =
   Location.register_error_of_exn
@@ -457,6 +559,8 @@ module type AST_syntactic_category = sig
 end
 
 module type AST_internal = sig
+  type 'ast with_attributes
+
   include AST_syntactic_category
 
   val embedding_syntax : Embedding_syntax.t
@@ -468,20 +572,28 @@ module type AST_internal = sig
       the body.  If the embedded term is malformed in any way, raises an error;
       if the input isn't an embedding of one of our novel syntactic features,
       returns [None].  Partial inverse of [make_jane_syntax]. *)
-  val match_jane_syntax : ast -> (Embedded_name.t * ast) option
+  val match_jane_syntax : ast -> (Embedded_name.t * ast with_attributes) option
+end
+
+module type AST_with_attributes_internal = sig
+  include AST_internal with type 'ast with_attributes := 'ast * attributes
+  val add_attributes : attributes -> ast -> ast
+  val set_attributes : ast -> attributes -> ast
 end
 
 (* Parses the embedded name from an embedding, raising if
     the embedding is malformed. Malformed means either:
 
     1. The embedding has a payload; attribute payloads must
-    be empty, so other ppxes can traverse "into" them.
+       be empty, so other ppxes can traverse "into" them.
 
-    2. NAME is missing; e.g. the attribute is just [[@jane]].
+    2. NAME is missing; i.e., the attribute is just [[@jane]] or
+       [[@jane.ERASABILITY]], and similarly for extension nodes.
 *)
 let parse_embedding_exn ~loc ~payload ~name ~embedding_syntax =
   let raise_error err = raise (Error (loc, err)) in
   match Embedded_name.of_string name with
+  | Some (Ok name) when Embedded_name.is_marker name -> None
   | Some (Ok name) -> begin
       let raise_malformed err =
         raise_error (Malformed_embedding (embedding_syntax, name, err))
@@ -494,28 +606,64 @@ let parse_embedding_exn ~loc ~payload ~name ~embedding_syntax =
       raise_error (Misnamed_embedding (err, name, embedding_syntax))
   | None -> None
 
+(** Extracts the last attribute (in list order) that was inserted by the Jane
+    Syntax framework, and returns the rest of the attributes in the same
+    relative order as was input.  The attributes that come before the extracted
+    one are first, and the attributes that come after are last; this last
+    component is guaranteed not to have any Jane Syntax attributes in it. *)
 let find_and_remove_jane_syntax_attribute =
-  let rec loop rest ~rev_prefix =
-    match rest with
-    | [] -> None
-    | attr :: rest ->
-      let { attr_name = { txt = name; loc = attr_loc }; attr_payload } =
-        attr
-      in
-      begin
-        match
-         parse_embedding_exn
-           ~loc:attr_loc
-           ~payload:attr_payload
-           ~name
-           ~embedding_syntax:Attribute
-        with
-        | None -> loop rest ~rev_prefix:(attr :: rev_prefix)
-        | Some name -> Some (name, List.rev_append rev_prefix rest)
-      end
-  in
-  fun attributes -> loop attributes ~rev_prefix:[]
-;;
+  Util.find_map_last_and_split
+    ~f:(fun { attr_name = { txt = name; loc }; attr_payload = payload } ->
+          parse_embedding_exn ~loc ~payload ~name ~embedding_syntax:Attribute)
+
+module Desugaring_error = struct
+  type error =
+    | Wrong_embedding of Embedded_name.t
+    | Non_embedding
+    | Bad_embedding of string list
+    | Unexpected_attributes of attributes
+
+  exception Error of Location.t * Feature.t * error
+
+  let report_term_for_feature ppf feature =
+    Format.fprintf ppf "term for@ %s" (Feature.describe_lowercase feature)
+
+  let report_error ~loc ~feature = function
+    | Wrong_embedding name ->
+      Location.errorf ~loc
+        "Tried to desugar the embedded term %a@ \
+         as part of a %a, a different feature"
+        Embedded_name.pp_quoted_name name
+        report_term_for_feature feature
+    | Non_embedding ->
+      Location.errorf ~loc
+        "Tried to desugar a non-embedded expression as part of a %a"
+        report_term_for_feature feature
+    | Bad_embedding subparts ->
+      Location.errorf ~loc
+        "Unknown, unexpected, or malformed embedded %a at %a"
+        report_term_for_feature
+          feature
+        Embedded_name.pp_quoted_name
+          (Embedded_name.of_feature feature subparts)
+    | Unexpected_attributes attrs ->
+      Location.errorf ~loc
+        "Non-Jane-syntax attributes were present \
+         at internal Jane-syntax points as part@ of a %a@.\
+         The attributes had the following names:@ %a"
+        report_term_for_feature
+          feature
+        (Format.pp_print_list
+           ~pp_sep:(fun ppf () -> Format.fprintf ppf ",@ ")
+           (fun ppf attr -> Format.fprintf ppf "\"%s\"" attr.attr_name.txt))
+          attrs
+
+  let () =
+    Location.register_error_of_exn
+      (function
+        | Error(loc, feature, err) -> Some (report_error ~loc ~feature err)
+        | _ -> None)
+end
 
 (** For a syntactic category, produce translations into and out of
     our novel syntax, using parsetree attributes as the encoding.
@@ -525,29 +673,91 @@ module Make_with_attribute
        include AST_syntactic_category
 
        val attributes : ast -> attributes
-       val with_attributes : ast -> attributes -> ast
-     end) : AST_internal with type ast = AST_syntactic_category.ast
+       val set_attributes : ast -> attributes -> ast
+     end) : AST_with_attributes_internal
+              with type ast = AST_syntactic_category.ast
 = struct
     include AST_syntactic_category
 
+    let add_attributes attrs ast = set_attributes ast (attributes ast @ attrs)
+
     let embedding_syntax = Embedding_syntax.Attribute
 
+    let make_attr loc name =
+      let loc = Location.ghostify loc in
+      { attr_name = { txt = Embedded_name.to_string name; loc }
+      ; attr_loc = loc
+      ; attr_payload = PStr []
+      }
+
     let make_jane_syntax name ast =
-      let attr =
-        { attr_name =
-            { txt = Embedded_name.to_string name
-            ; loc = !Ast_helper.default_loc
-            }
-        ; attr_loc = !Ast_helper.default_loc
-        ; attr_payload = PStr []
-        }
+      let attr = make_attr !Ast_helper.default_loc name in
+      let attrs =
+        match Embedded_name.components name with
+        | [feature_component] ->
+            (* Outermost; save the location *)
+            let save_loc = location ast in
+            [ make_attr
+                save_loc
+                { name
+                  with components =
+                         [ feature_component
+                         ; "_location"
+                         ; if save_loc.loc_ghost then "_ghost" else "_nonghost"]
+                }
+            ; attr ]
+        | _ :: _ :: _ ->
+            [attr]
       in
-      with_attributes ast (attr :: attributes ast)
+      add_attributes attrs ast
+
+    let restore_location_from_attr (name : Embedded_name.t) ast =
+      match name with
+      | { erasability; components = [feature_component] } ->
+          let raise_error err = raise (Error(location ast, err)) in
+          begin match Util.split_last_opt (attributes ast) with
+          | Some ( attrs
+                 , { attr_name = { txt; loc }
+                   ; attr_loc
+                   ; attr_payload = PStr [] } ) -> begin
+              match Embedded_name.of_string txt with
+              | Some (Ok
+                  { erasability = loc_erasability
+                  ; components = [ loc_feature_component
+                                 ; "_location"
+                                 ; ghostiness ]
+                  })
+                when (* Checks about the outer match, deferred so that
+                        [Misnamed_embedding] is raised preferentially *)
+                     loc.loc_ghost &&
+                     Location.equal loc attr_loc &&
+                     (* Checks about the inner match *)
+                     String.equal feature_component loc_feature_component &&
+                     Erasability.equal erasability loc_erasability ->
+                let restored_loc =
+                  { loc with loc_ghost = match ghostiness with
+                      | "_ghost" -> true
+                      | "_nonghost" -> false
+                      | _ -> raise_error Missing_location_attribute }
+                in
+                with_location (set_attributes ast attrs) restored_loc
+              | Some (Error err) ->
+                  raise_error (Misnamed_embedding (err, txt, Attribute))
+              | _ -> raise_error Missing_location_attribute
+            end
+          | _ -> raise_error Missing_location_attribute
+          end
+      | { erasability = _; components = _ :: _ :: _ } ->
+          ast
 
     let match_jane_syntax ast =
       match find_and_remove_jane_syntax_attribute (attributes ast) with
       | None -> None
-      | Some (name, attrs) -> Some (name, with_attributes ast attrs)
+      | Some (inner_attrs, name, outer_attrs) ->
+        Some (name,
+              (restore_location_from_attr name @@
+               set_attributes ast inner_attrs,
+               outer_attrs))
 end
 
 (** For a syntactic category, produce translations into and out of
@@ -577,34 +787,35 @@ module Make_with_extension_node
           name/format of the extension or the possible body terms (for which see
           [AST.match_extension]). Partial inverse of [make_extension_use]. *)
       val match_extension_use : ast -> (extension * ast) option
-     end) : AST_internal with type ast = AST_syntactic_category.ast =
-  struct
-    include AST_syntactic_category
+    end) : AST_internal with type ast = AST_syntactic_category.ast
+                         and type 'ast with_attributes := 'ast =
+struct
+  include AST_syntactic_category
 
-    let embedding_syntax = Embedding_syntax.Extension_node
+  let embedding_syntax = Embedding_syntax.Extension_node
 
-    let make_jane_syntax name ast =
-      make_extension_use
-        ast
-        ~extension_node:
-          (make_extension_node
-             ({ txt = Embedded_name.to_string name
-              ; loc = !Ast_helper.default_loc },
-              PStr []))
+  let make_jane_syntax name ast =
+    make_extension_use
+      ast
+      ~extension_node:
+        (make_extension_node
+           ({ txt = Embedded_name.to_string name
+            ; loc = !Ast_helper.default_loc },
+            PStr []))
 
-    let match_jane_syntax ast =
-      match match_extension_use ast with
+  let match_jane_syntax ast =
+    match match_extension_use ast with
+    | None -> None
+    | Some (({txt = name; loc = ext_loc}, ext_payload), body) ->
+      match
+        parse_embedding_exn
+          ~loc:ext_loc
+          ~payload:ext_payload
+          ~name
+          ~embedding_syntax
+      with
       | None -> None
-      | Some (({txt = name; loc = ext_loc}, ext_payload), body) ->
-        match
-          parse_embedding_exn
-            ~loc:ext_loc
-            ~payload:ext_payload
-            ~name
-            ~embedding_syntax
-        with
-        | None -> None
-        | Some name -> Some (name, body)
+      | Some name -> Some (name, body)
 end
 
 (** The AST parameters for every subset of types; embedded as
@@ -618,7 +829,7 @@ module Type_AST_syntactic_category = struct
   let with_location typ l = { typ with ptyp_loc = l }
 
   let attributes typ = typ.ptyp_attributes
-  let with_attributes typ ptyp_attributes = { typ with ptyp_attributes }
+  let set_attributes typ ptyp_attributes = { typ with ptyp_attributes }
 end
 
 (** Types; embedded as [[[%jane.FEATNAME] * BODY]]. *)
@@ -644,7 +855,7 @@ module Expression0 = Make_with_attribute (struct
   let with_location expr l = { expr with pexp_loc = l }
 
   let attributes expr = expr.pexp_attributes
-  let with_attributes expr pexp_attributes = { expr with pexp_attributes }
+  let set_attributes expr pexp_attributes = { expr with pexp_attributes }
 end)
 
 (** Patterns; embedded using an attribute on the pattern. *)
@@ -656,7 +867,7 @@ module Pattern0 = Make_with_attribute (struct
   let with_location pat l = { pat with ppat_loc = l }
 
   let attributes pat = pat.ppat_attributes
-  let with_attributes pat ppat_attributes = { pat with ppat_attributes }
+  let set_attributes pat ppat_attributes = { pat with ppat_attributes }
 end)
 
 (** Module types; embedded using an attribute on the module type. *)
@@ -668,7 +879,7 @@ module Module_type0 = Make_with_attribute (struct
     let with_location mty l = { mty with pmty_loc = l }
 
     let attributes mty = mty.pmty_attributes
-    let with_attributes mty pmty_attributes = { mty with pmty_attributes }
+    let set_attributes mty pmty_attributes = { mty with pmty_attributes }
 end)
 
 (** Extension constructors; embedded using an attribute. *)
@@ -680,7 +891,7 @@ module Extension_constructor0 = Make_with_attribute (struct
     let with_location ext l = { ext with pext_loc = l }
 
     let attributes ext = ext.pext_attributes
-    let with_attributes ext pext_attributes = { ext with pext_attributes }
+    let set_attributes ext pext_attributes = { ext with pext_attributes }
 end)
 
 (** Signature items; embedded as
@@ -757,16 +968,57 @@ end)
 (* Main exports *)
 
 module type AST = sig
+  type 'a with_attributes
   type ast
 
   val make_jane_syntax : Feature.t -> string list -> ast -> ast
   val make_entire_jane_syntax :
     loc:Location.t -> Feature.t -> (unit -> ast) -> ast
-  val make_of_ast :
-    of_ast_internal:(Feature.t -> ast -> 'a option) -> (ast -> 'a option)
+  val match_jane_syntax_piece :
+    Feature.t -> (ast -> string list -> 'a option) -> ast -> 'a
+  val make_of_ast
+    :  of_ast_internal:(Feature.t -> ast -> 'a option)
+    -> (ast -> ('a with_attributes) option)
 end
 
-module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
+module type AST_without_attributes =
+  AST with type 'ast with_attributes := 'ast
+
+module type AST_with_attributes = sig
+  include AST with type 'ast with_attributes := 'ast * attributes
+
+  val add_attributes : attributes -> ast -> ast
+end
+
+module type Handle_attributes = sig
+  type 'ast t
+  val map_ast : f:('ast1 -> 'ast2) -> 'ast1 t -> 'ast2 t
+  val assert_no_attributes :
+    loc:Location.t -> feature:Feature.t -> 'ast t -> 'ast
+end
+
+module Uses_attributes = struct
+  type 'ast t = 'ast * attributes
+  let map_ast ~f (ast, attrs) = (f ast, attrs)
+  let assert_no_attributes ~loc ~feature = function
+    | ast, [] -> ast
+    | _, (_ :: _ as attrs) ->
+      raise (Desugaring_error.Error (loc, feature, Unexpected_attributes attrs))
+end
+
+module Uses_extensions = struct
+  type 'ast t = 'ast
+  let map_ast ~f = f
+  let assert_no_attributes ~loc:_ ~feature:_ ast = ast
+end
+
+module Make_ast
+    (Handle_attributes : Handle_attributes)
+    (AST : AST_internal
+             with type 'ast with_attributes := 'ast Handle_attributes.t)
+  : AST with type ast = AST.ast
+         and type 'ast with_attributes := 'ast Handle_attributes.t =
+struct
   include AST
 
   let make_jane_syntax feature trailing_components ast =
@@ -786,13 +1038,14 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
       let loc = AST.location ast in
       let raise_error err = raise (Error (loc, err)) in
       match AST.match_jane_syntax ast with
-      | Some ({ erasability; components = [name] }, ast) -> begin
+      | Some ({ erasability; components = [name] }, ast_attrs) -> begin
           match Feature.of_component name with
-          | Ok feat -> begin
+          | Ok feat -> Some begin
+            ast_attrs |> Handle_attributes.map_ast ~f:(fun ast ->
               match of_ast_internal feat ast with
-              | Some ext_ast -> Some ext_ast
+              | Some ext_ast -> ext_ast
               | None ->
-                  raise_error (Wrong_syntactic_category(feat, AST.plural))
+                  raise_error (Wrong_syntactic_category(feat, AST.plural)))
             end
           | Error err -> raise_error begin match err with
             | Disabled_extension ext ->
@@ -806,13 +1059,58 @@ module Make_ast (AST : AST_internal) : AST with type ast = AST.ast = struct
       | None -> None
     in
     of_ast
+
+  let match_jane_syntax_piece feature match_subparts ast =
+    let raise_error err =
+      raise (Desugaring_error.Error(location ast, feature, err))
+    in
+    match AST.match_jane_syntax ast with
+    | Some (embedded_name, ast_attrs) -> begin
+        let ast' =
+          Handle_attributes.assert_no_attributes
+            ~loc:(location ast) ~feature ast_attrs
+        in
+        match Embedded_name.components embedded_name with
+        | extension_string :: subparts
+          when String.equal
+                 extension_string
+                 (Feature.extension_component feature) -> begin
+            match match_subparts ast' subparts with
+            | Some ext_ast -> ext_ast
+            | None -> raise_error (Bad_embedding subparts)
+          end
+        | _ -> raise_error (Wrong_embedding embedded_name)
+      end
+    | None -> raise_error Non_embedding
 end
 
-module Expression = Make_ast(Expression0)
-module Pattern = Make_ast(Pattern0)
-module Module_type = Make_ast(Module_type0)
-module Signature_item = Make_ast(Signature_item0)
-module Structure_item = Make_ast(Structure_item0)
-module Core_type = Make_ast(Core_type0)
-module Constructor_argument = Make_ast(Constructor_argument0)
-module Extension_constructor = Make_ast(Extension_constructor0)
+module Make_extension_ast
+  :  functor (AST : AST_internal with type 'ast with_attributes := 'ast)
+  -> AST_without_attributes with type ast = AST.ast =
+  Make_ast (Uses_extensions)
+
+module Make_attribute_ast (AST : AST_with_attributes_internal)
+  : AST_with_attributes with type ast = AST.ast =
+struct
+  include Make_ast (Uses_attributes) (AST)
+  let add_attributes = AST.add_attributes
+end
+
+module Expression = Make_attribute_ast(Expression0)
+module Pattern = Make_attribute_ast(Pattern0)
+module Module_type = Make_attribute_ast(Module_type0)
+module Signature_item = Make_extension_ast(Signature_item0)
+module Structure_item = Make_extension_ast(Structure_item0)
+module Core_type = Make_attribute_ast(Core_type0)
+module Extension_constructor = Make_attribute_ast(Extension_constructor0)
+
+module Constructor_argument = struct
+  include Make_attribute_ast(Constructor_argument0)
+
+  let make_of_ast ~of_ast_internal ast =
+    match make_of_ast ~of_ast_internal ast with
+    | Some (jast, []) -> Some jast
+    | None -> None
+    | Some (_, _ :: _) ->
+      Misc.fatal_errorf "Constructor arguments should not have attributes"
+end

--- a/vendor/parser-standard/jane_syntax_parsing.mli
+++ b/vendor/parser-standard/jane_syntax_parsing.mli
@@ -98,7 +98,7 @@ module Feature : sig
     | Builtin
 
   (** The component of an attribute or extension name that identifies the
-      feature. This is third component.
+      feature. This is the third component.
   *)
   val extension_component : t -> string
 end
@@ -110,7 +110,6 @@ end
     also why we don't expose any functions for rendering or parsing these names;
     that's all handled internally. *)
 module Embedded_name : sig
-
   (** A nonempty list of name components, without the first two components.
       (That is, without the leading root component that identifies it as part of
       the modular syntax mechanism, and without the next component that
@@ -130,7 +129,32 @@ module Embedded_name : sig
   *)
   val of_feature : Feature.t -> string list -> t
 
+  (** Extract the components from an embedded name; just includes the
+      user-specified components, not the leading or erasability components, as
+      with the [components] type. *)
   val components : t -> components
+
+  (** Create a new "marker attribute".  These are Jane-syntax-style attributes,
+      but exist outside of the full Jane syntax machinery; they can be added
+      directly to syntax nodes, aren't matched on and turned into ASTs, and so
+      on and so forth.  The format of the attribute name is not guaranteed to be
+      stable across compiler versions, but it will end with the specified
+      components as if they were the second part of a [components] value.
+
+      Given [let make, extract, has = marker_attribute_handler comps], then:
+
+      - [make ~loc] creates the specified marker attribute at the [ghost]
+        version of the provided location.
+      - [extract attrs] pulls out the specified marker attribute from [attrs],
+        and returns all the other attributes if it was present.  If the specified
+        marker attribute was not present, returns [None].
+      - [has attrs] returns [true] if the list of attributes contains the
+        specified marker attribute, and [false] otherwise.  It's equivalent to
+        [Option.is_some (extract attrs)]. *)
+  val marker_attribute_handler :
+    string list -> (loc:Location.t -> Parsetree.attribute)
+                 * (Parsetree.attributes -> Parsetree.attributes option)
+                 * (Parsetree.attributes -> bool)
 
   (** Print out the embedded form of a Jane-syntax name, in quotes; for use in
       error messages. *)
@@ -142,7 +166,11 @@ end
     need them. When you add another one, make sure also to add special handling
     in [Ast_iterator] and [Ast_mapper].
 
-*)
+    This module type comes in two varieties: [AST_with_attributes] and
+    [AST_without_attributes].  They reflect whether desugaring an OCaml AST into
+    our extended one should ([with]) or shouldn't ([without]) return the
+    attributes as well.  This choice is recorded in the [with_attributes]
+    type. *)
 module type AST = sig
   (** The AST type (e.g., [Parsetree.expression]) *)
   type ast
@@ -150,7 +178,8 @@ module type AST = sig
   (** Embed a term from one of our novel syntactic features in the AST using the
       given name (in the [Feature.t]) and body (the [ast]).  Any locations in
       the generated AST will be set to [!Ast_helper.default_loc], which should
-      be [ghost]. *)
+      be [ghost].  The list of components should be nonempty; if it's empty, you
+      probably want [make_entire_jane_syntax] instead. *)
   val make_jane_syntax
     :  Feature.t
     -> string list
@@ -159,15 +188,42 @@ module type AST = sig
 
   (** As [make_jane_syntax], but specifically for the AST node corresponding to
       the entire piece of novel syntax (e.g., for a list comprehension, the
-      whole [[x for x in xs]], and not a subcomponent like [for x in xs]).  This
-      sets [Ast_helper.default_loc] locally to the [ghost] version of the
-      provided location, which is why the [ast] is generated from a function
-      call; it is during this call that the location is so set. *)
+      whole [[x for x in xs]], and not a subcomponent like [for x in xs]).  The
+      provided location is used for the location of the resulting AST node.
+      Additionally, [Ast_helper.default_loc] is set locally to the [ghost]
+      version of that location, which is why the [ast] is generated from a
+      function call; it is during this call that the location is so set. *)
   val make_entire_jane_syntax
     :  loc:Location.t
     -> Feature.t
     -> (unit -> ast)
     -> ast
+
+  (** Given a *nested* term from one of our novel syntactic features that has
+      *already* been embedded in the AST by [make_jane_syntax], matches on the
+      name and AST of that embedding to lift it back to the Jane syntax AST.  By
+      "nested", this means the term ought to be a subcomponent of a
+      [make_entire_jane_syntax]-created term, created specifically by
+      [make_jane_syntax] with a nonempty list of components.
+
+      For example, to distinguish between the different terms in the
+      [-extension local] expression AST, we write:
+
+      {[
+        let of_expr =
+          Expression.match_jane_syntax_piece feature @@ fun expr -> function
+          | ["local"] -> Some (Lexp_local expr)
+          | ["exclave"] -> Some (Lexp_exclave expr)
+          | _ -> None
+      ]}
+  *)
+  val match_jane_syntax_piece
+    : Feature.t -> (ast -> string list -> 'a option) -> ast -> 'a
+
+  (** How to attach attributes to the result of [make_of_ast].  Will either
+      return a pair (see [AST_with_attributes]) or will simply be equal to ['a]
+      when there are no attributes ([AST_without_attributes]). *)
+  type 'a with_attributes
 
   (** Build an [of_ast] function. The return value of this function should be
       used to implement [of_ast] in modules satisfying the signature
@@ -190,32 +246,46 @@ module type AST = sig
         extended pattern AST, this function will return [None] if it spots an
         embedding that claims to be from [Language_extension Comprehensions].)
     *)
-    -> (ast -> 'a option)
+    -> (ast -> 'a with_attributes option)
 end
 
+(** An [AST] that keeps track of attributes.  This also includes
+    attribute-manipulating functions. *)
+module type AST_with_attributes = sig
+  include AST with type 'ast with_attributes := 'ast * Parsetree.attributes
+
+  (** Add attributes to an AST term, appending them to the attributes already
+      present. *)
+  val add_attributes : Parsetree.attributes -> ast -> ast
+end
+
+(** An [AST] that does not keep track of attributes. *)
+module type AST_without_attributes =
+  AST with type 'ast with_attributes := 'ast
+
 module Expression :
-  AST with type ast = Parsetree.expression
+  AST_with_attributes with type ast = Parsetree.expression
 
 module Pattern :
-  AST with type ast = Parsetree.pattern
+  AST_with_attributes with type ast = Parsetree.pattern
 
 module Module_type :
-  AST with type ast = Parsetree.module_type
+  AST_with_attributes with type ast = Parsetree.module_type
 
 module Signature_item :
-  AST with type ast = Parsetree.signature_item
+  AST_without_attributes with type ast = Parsetree.signature_item
 
 module Structure_item :
-  AST with type ast = Parsetree.structure_item
+  AST_without_attributes with type ast = Parsetree.structure_item
 
 module Core_type :
-  AST with type ast = Parsetree.core_type
+  AST_with_attributes with type ast = Parsetree.core_type
 
 module Constructor_argument :
-  AST with type ast = Parsetree.core_type
+  AST_without_attributes with type ast = Parsetree.core_type
 
 module Extension_constructor :
-  AST with type ast = Parsetree.extension_constructor
+  AST_with_attributes with type ast = Parsetree.extension_constructor
 
 (** Require that an extension is enabled for at least the provided level, or
     else throw an exception (of an abstract type) at the provided location
@@ -225,28 +295,6 @@ module Extension_constructor :
     require both [Comprehensions] and [Immutable_arrays]). *)
 val assert_extension_enabled :
   loc:Location.t -> 'a Language_extension.t -> 'a -> unit
-
-(* CR-someday nroberts: An earlier version of this revealed less of its
-   implementation in its name: it was called [match_jane_syntax], and
-   was a function from ast to ast. This has some advantages (less revealing
-   of the Jane Syntax encoding) but I felt it important to document the caller's
-   responsibility to plumb through uninterpreted attributes.
-
-   Given that it only has one callsite currently, we decided to keep this
-   approach for now, but we could revisit this decision if we use it more
-   often.
-*)
-(** Extracts the first attribute (in list order) that was inserted by the
-    Jane Syntax framework, and returns the rest of the attributes in the
-    same relative order as was input.
-
-    This can be used by [Jane_syntax] to peel off individual attributes in
-    order to process a Jane Syntax element that consists of multiple
-    nested ASTs.
-*)
-val find_and_remove_jane_syntax_attribute
-  :  Parsetree.attributes
-  -> (Embedded_name.t * Parsetree.attributes) option
 
 (** Errors around the representation of our extended ASTs.  These should mostly
     just be fatal, but they're needed for one test case

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -48,7 +48,7 @@ let ghost_loc (startpos, endpos) = {
 
 let mktyp ~loc ?attrs d = Typ.mk ~loc:(make_loc loc) ?attrs d
 let mkpat ~loc d = Pat.mk ~loc:(make_loc loc) d
-let mkexp ~loc d = Exp.mk ~loc:(make_loc loc) d
+let mkexp ~loc ?attrs d = Exp.mk ~loc:(make_loc loc) ?attrs d
 let mkmty ~loc ?attrs d = Mty.mk ~loc:(make_loc loc) ?attrs d
 let mksig ~loc d = Sig.mk ~loc:(make_loc loc) d
 let mkmod ~loc ?attrs d = Mod.mk ~loc:(make_loc loc) ?attrs d
@@ -64,8 +64,6 @@ let pstr_type ((nr, ext), tys) =
   (Pstr_type (nr, tys), ext)
 let pstr_exception (te, ext) =
   (Pstr_exception te, ext)
-let pstr_include (body, ext) =
-  (Pstr_include body, ext)
 let pstr_recmodule (ext, bindings) =
   (Pstr_recmodule bindings, ext)
 
@@ -80,8 +78,6 @@ let psig_typesubst ((nr, ext), tys) =
   (Psig_typesubst tys, ext)
 let psig_exception (te, ext) =
   (Psig_exception te, ext)
-let psig_include (body, ext) =
-  (Psig_include body, ext)
 
 let mkctf ~loc ?attrs ?docs d =
   Ctf.mk ~loc:(make_loc loc) ?attrs ?docs d
@@ -150,103 +146,47 @@ let neg_string f =
 let mkuminus ~oploc name arg =
   match name, arg.pexp_desc with
   | "-", Pexp_constant(Pconst_integer (n,m)) ->
-      Pexp_constant(Pconst_integer(neg_string n,m))
+      Pexp_constant(Pconst_integer(neg_string n,m)), arg.pexp_attributes
   | ("-" | "-."), Pexp_constant(Pconst_float (f, m)) ->
-      Pexp_constant(Pconst_float(neg_string f, m))
+      Pexp_constant(Pconst_float(neg_string f, m)), arg.pexp_attributes
   | _ ->
-      Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg])
+      Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg]), []
 
 let mkuplus ~oploc name arg =
   let desc = arg.pexp_desc in
   match name, desc with
   | "+", Pexp_constant(Pconst_integer _)
-  | ("+" | "+."), Pexp_constant(Pconst_float _) -> desc
+  | ("+" | "+."), Pexp_constant(Pconst_float _) -> desc, arg.pexp_attributes
   | _ ->
-      Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg])
+      Pexp_apply(mkoperator ~loc:oploc ("~" ^ name), [Nolabel, arg]), []
+module Local_syntax_category = struct
+  type _ t =
+    | Type : core_type t
+    | Expression : expression t
+    | Pattern : pattern t
+    | Synthesized_constraint : expression t
+end
 
+let local_if : type ast. ast Local_syntax_category.t -> _ -> _ -> ast -> ast =
+  fun cat is_local sloc x ->
+  if is_local then
+    let make : loc:_ -> attrs:_ -> ast = match cat with
+      | Type       -> Jane_syntax.Local.type_of (Ltyp_local x)
+      | Expression -> Jane_syntax.Local.expr_of (Lexp_local x)
+      | Pattern    -> Jane_syntax.Local.pat_of  (Lpat_local x)
+      | Synthesized_constraint ->
+        Jane_syntax.Local.expr_of (Lexp_constrain_local x)
+    in
+    make ~loc:(make_loc sloc) ~attrs:[]
+  else
+    x
 
-let local_ext_loc = mknoloc "extension.local"
-
-let local_attr =
-  Attr.mk ~loc:Location.none local_ext_loc (PStr [])
-
-let local_extension =
-  Exp.mk ~loc:Location.none (Pexp_extension(local_ext_loc, PStr []))
-
-let include_functor_ext_loc = mknoloc "extension.include_functor"
-
-let include_functor_attr =
-  Attr.mk ~loc:Location.none include_functor_ext_loc (PStr [])
-
-let mkexp_stack ~loc exp =
-  ghexp ~loc (Pexp_apply(local_extension, [Nolabel, exp]))
-
-let mkpat_stack pat =
-  {pat with ppat_attributes = local_attr :: pat.ppat_attributes}
-
-let mktyp_stack typ =
-  {typ with ptyp_attributes = local_attr :: typ.ptyp_attributes}
-
-let wrap_exp_stack exp =
-  {exp with pexp_attributes = local_attr :: exp.pexp_attributes}
-
-let mkexp_local_if p ~loc exp =
-  if p then mkexp_stack ~loc exp else exp
-
-let mkpat_local_if p pat =
-  if p then mkpat_stack pat else pat
-
-let mktyp_local_if p typ =
-  if p then mktyp_stack typ else typ
-
-let wrap_exp_local_if p exp =
-  if p then wrap_exp_stack exp else exp
-
-let exclave_ext_loc loc = mkloc "extension.exclave" loc
-
-let exclave_extension loc =
-  Exp.mk ~loc:Location.none
-    (Pexp_extension(exclave_ext_loc loc, PStr []))
-
-let mkexp_exclave ~loc ~kwd_loc exp =
-  ghexp ~loc (Pexp_apply(exclave_extension (make_loc kwd_loc), [Nolabel, exp]))
-
-let curry_attr =
-  Attr.mk ~loc:Location.none (mknoloc "extension.curry") (PStr [])
-
-let is_curry_attr attr =
-  attr.attr_name.txt = "extension.curry"
-
-let mktyp_curry typ =
-  {typ with ptyp_attributes = curry_attr :: typ.ptyp_attributes}
-
-let maybe_curry_typ typ =
-  match typ.ptyp_desc with
-  | Ptyp_arrow _ ->
-      if List.exists is_curry_attr typ.ptyp_attributes then typ
-      else mktyp_curry typ
-  | _ -> typ
-
-let global_loc loc = mkloc "extension.global" loc
-
-let global_attr loc =
-  Attr.mk ~loc:Location.none (global_loc loc) (PStr [])
-
-let mkld_global ld loc =
-  { ld with pld_attributes = global_attr loc :: ld.pld_attributes }
-
-let mkld_global_maybe gbl ld loc =
-  match gbl with
-  | Global -> mkld_global ld loc
-  | Nothing -> ld
-
-let mkcty_global cty loc =
-  { cty with ptyp_attributes = global_attr loc :: cty.ptyp_attributes }
-
-let mkcty_global_maybe gbl cty loc =
-  match gbl with
-  | Global -> mkcty_global cty loc
-  | Nothing -> cty
+let global_if global_flag sloc carg =
+  match global_flag with
+  | Global ->
+      Jane_syntax.Local.constr_arg_of ~loc:(make_loc sloc) (Lcarg_global carg)
+  | Nothing ->
+      carg
 
 (* TODO define an abstraction boundary between locations-as-pairs
    and locations-as-Location.t; it should be clear when we move from
@@ -765,7 +705,7 @@ let check_layout loc id =
 
 (* Unboxed literals *)
 
-(* CR layouts v2: The [unboxed_*] functions will both be improved and lose
+(* CR layouts v2.5: The [unboxed_*] functions will both be improved and lose
    their explicit assert once we have real unboxed literals in Jane syntax; they
    may also get re-inlined at that point *)
 let unboxed_literals_extension = Language_extension.Layouts
@@ -1677,10 +1617,18 @@ structure_item:
         { let (ext, l) = $1 in (Pstr_class l, ext) }
     | class_type_declarations
         { let (ext, l) = $1 in (Pstr_class_type l, ext) }
-    | include_statement(module_expr)
-        { pstr_include $1 }
     )
     { $1 }
+  | include_statement(module_expr)
+      { let is_functor, incl, ext = $1 in
+        let item =
+          if is_functor
+          then Jane_syntax.Include_functor.str_item_of ~loc:(make_loc $sloc)
+                 (Ifstr_include_functor incl)
+          else mkstr ~loc:$sloc (Pstr_include incl)
+        in
+        wrap_str_ext ~loc:$sloc item ext
+      }
 ;
 
 (* A single module binding. *)
@@ -1756,26 +1704,27 @@ module_binding_body:
 
 (* Shared material between structures and signatures. *)
 
-include_and_functor_attr:
+include_maybe_functor:
   | INCLUDE %prec below_FUNCTOR
-      { [] }
+      { false }
   | INCLUDE FUNCTOR
-      { [include_functor_attr] }
+      { true }
 ;
 
 (* An [include] statement can appear in a structure or in a signature,
    which is why this definition is parameterized. *)
 %inline include_statement(thing):
-  attrs0 = include_and_functor_attr
+  is_functor = include_maybe_functor
   ext = ext
   attrs1 = attributes
   thing = thing
   attrs2 = post_item_attributes
   {
-    let attrs = attrs0 @ attrs1 @ attrs2 in
+    let attrs = attrs1 @ attrs2 in
     let loc = make_loc $sloc in
     let docs = symbol_docs $sloc in
-    Incl.mk thing ~attrs ~loc ~docs, ext
+    let incl = Incl.mk thing ~attrs ~loc ~docs in
+    is_functor, incl, ext
   }
 ;
 
@@ -1932,14 +1881,24 @@ signature_item:
         { let (body, ext) = $1 in (Psig_modtypesubst body, ext) }
     | open_description
         { let (body, ext) = $1 in (Psig_open body, ext) }
-    | include_statement(module_type)
-        { psig_include $1 }
     | class_descriptions
         { let (ext, l) = $1 in (Psig_class l, ext) }
     | class_type_declarations
         { let (ext, l) = $1 in (Psig_class_type l, ext) }
     )
     { $1 }
+  | include_statement(module_type)
+      { let is_functor, incl, ext = $1 in
+        let item =
+          if is_functor
+          then Jane_syntax.Include_functor.sig_item_of ~loc:(make_loc $sloc)
+                 (Ifsig_include_functor incl)
+          else mksig ~loc:$sloc (Psig_include incl)
+        in
+        wrap_sig_ext ~loc:$sloc item ext
+      }
+
+;
 
 (* A module declaration. *)
 %inline module_declaration:
@@ -2448,29 +2407,36 @@ seq_expr:
 ;
 labeled_simple_pattern:
     QUESTION LPAREN optional_local label_let_pattern opt_default RPAREN
-      { (Optional (fst $4), $5, mkpat_local_if $3 (snd $4)) }
+      { (Optional (fst $4), $5, local_if Pattern $3 $loc($3) (snd $4)) }
   | QUESTION label_var
       { (Optional (fst $2), None, snd $2) }
   | OPTLABEL LPAREN optional_local let_pattern opt_default RPAREN
-      { (Optional $1, $5, mkpat_local_if $3 $4) }
+      { (Optional $1, $5, local_if Pattern $3 $loc($3) $4) }
   | OPTLABEL pattern_var
       { (Optional $1, None, $2) }
   | TILDE LPAREN optional_local label_let_pattern RPAREN
-      { (Labelled (fst $4), None, mkpat_local_if $3 (snd $4)) }
+      { (Labelled (fst $4), None,
+         local_if Pattern $3 $loc($3) (snd $4)) }
   | TILDE label_var
       { (Labelled (fst $2), None, snd $2) }
   | LABEL simple_pattern
       { (Labelled $1, None, $2) }
   | LABEL LPAREN LOCAL pattern RPAREN
-      { (Labelled $1, None, mkpat_stack $4) }
+      { (Labelled $1, None,
+         Jane_syntax.Local.pat_of ~loc:(make_loc $loc($3)) ~attrs:[]
+           (Lpat_local $4) ) }
   | simple_pattern
       { (Nolabel, None, $1) }
   | LPAREN LOCAL let_pattern RPAREN
-      { (Nolabel, None, mkpat_stack $3) }
+      { (Nolabel, None,
+         Jane_syntax.Local.pat_of ~loc:(make_loc $loc($2)) ~attrs:[]
+           (Lpat_local $3)) }
   | LABEL LPAREN poly_pattern RPAREN
       { (Labelled $1, None, $3) }
   | LABEL LPAREN LOCAL poly_pattern RPAREN
-      { (Labelled $1, None, mkpat_stack $4) }
+      { (Labelled $1, None,
+         Jane_syntax.Local.pat_of ~loc:(make_loc $loc($3)) ~attrs:[]
+           (Lpat_local $4)) }
   | LPAREN poly_pattern RPAREN
       { (Nolabel, None, $2) }
 ;
@@ -2577,9 +2543,11 @@ expr:
   *)
 /* END AVOID */
   | LOCAL seq_expr
-     { mkexp_stack ~loc:$sloc $2 }
+      { Jane_syntax.Local.expr_of ~loc:(make_loc $sloc) ~attrs:[]
+          (Lexp_local $2) }
   | EXCLAVE seq_expr
-     { mkexp_exclave ~loc:$sloc ~kwd_loc:($loc($1)) $2 }
+     { Jane_syntax.Local.expr_of ~loc:(make_loc $sloc) ~attrs:[]
+          (Lexp_exclave $2) }
 ;
 %inline expr_attrs:
   | LET MODULE ext_attributes mkrhs(module_name) module_binding_body IN seq_expr
@@ -2618,6 +2586,12 @@ expr:
       { Pexp_assert $3, $2 }
   | LAZY ext_attributes simple_expr %prec below_HASH
       { Pexp_lazy $3, $2 }
+  | subtractive expr %prec prec_unary_minus
+      { let desc, attrs = mkuminus ~oploc:$loc($1) $1 $2 in
+        desc, (None, attrs) }
+  | additive expr %prec prec_unary_plus
+      { let desc, attrs = mkuplus ~oploc:$loc($1) $1 $2 in
+        desc, (None, attrs) }
 ;
 %inline do_done_expr:
   | DO e = seq_expr DONE
@@ -2636,10 +2610,6 @@ expr:
       { Pexp_variant($1, Some $2) }
   | e1 = expr op = op(infix_operator) e2 = expr
       { mkinfix e1 op e2 }
-  | subtractive expr %prec prec_unary_minus
-      { mkuminus ~oploc:$loc($1) $1 $2 }
-  | additive expr %prec prec_unary_plus
-      { mkuplus ~oploc:$loc($1) $1 $2 }
 ;
 
 simple_expr:
@@ -2703,7 +2673,9 @@ comprehension_clause_binding:
   | attributes LOCAL pattern IN expr
       { Jane_syntax.Comprehensions.
           { pattern    = $3
-          ; iterator   = In (mkexp_stack ~loc:$sloc (* ~kwd_loc:($loc($2)) *) $5)
+          ; iterator   = In (Jane_syntax.Local.expr_of
+                               ~loc:(make_loc $sloc) ~attrs:[]
+                               (Lexp_local $5))
           ; attributes = $1
           }
       }
@@ -2894,24 +2866,29 @@ let_binding_body_no_punning:
           | _ -> assert false
         in
         let loc = Location.(t.ptyp_loc.loc_start, t.ptyp_loc.loc_end) in
+        let local_loc = $loc($1) in
         let typ = ghtyp ~loc (Ptyp_poly([],t)) in
         let patloc = ($startpos($2), $endpos($3)) in
         let pat =
-          mkpat_local_if $1 (ghpat ~loc:patloc (Ppat_constraint(v, typ)))
+          local_if Pattern $1 local_loc
+            (ghpat ~loc:patloc (Ppat_constraint(v, typ)))
         in
         let exp =
-          mkexp_local_if $1 ~loc:$sloc
-            (wrap_exp_local_if $1 (mkexp_constraint ~loc:$sloc $5 $3))
+          local_if Expression $1 $sloc
+            (mkexp_constraint
+              ~loc:$sloc
+              (local_if Synthesized_constraint $1 $sloc $5)
+              $3)
         in
         (pat, exp) }
   | optional_local let_ident COLON poly(core_type) EQUAL seq_expr
       { let patloc = ($startpos($2), $endpos($4)) in
         let pat =
-          mkpat_local_if $1
+          local_if Pattern $1 $loc($1)
             (ghpat ~loc:patloc
                (Ppat_constraint($2, ghtyp ~loc:($loc($4)) $4)))
         in
-        let exp = mkexp_local_if $1 ~loc:$sloc $6 in
+        let exp = local_if Expression $1 $sloc $6 in
         (pat, exp) }
   | let_ident COLON TYPE lident_list DOT core_type EQUAL seq_expr
       { let exp, poly =
@@ -2924,7 +2901,8 @@ let_binding_body_no_punning:
       { let loc = ($startpos($1), $endpos($3)) in
         (ghpat ~loc (Ppat_constraint($1, $3)), $5) }
   | LOCAL let_ident local_strict_binding
-      { ($2, mkexp_stack ~loc:$sloc $3) }
+      { ($2, Jane_syntax.Local.expr_of ~loc:(make_loc $sloc) ~attrs:[]
+               (Lexp_local $3)) }
 ;
 let_binding_body:
   | let_binding_body_no_punning
@@ -3007,7 +2985,11 @@ local_fun_binding:
     local_strict_binding
       { $1 }
   | type_constraint EQUAL seq_expr
-      { wrap_exp_stack (mkexp_constraint ~loc:$sloc $3 $1) }
+      { mkexp_constraint
+          ~loc:$sloc
+          (Jane_syntax.Local.expr_of ~loc:(make_loc $sloc) ~attrs:[]
+             (Lexp_constrain_local $3))
+          $1 }
 ;
 local_strict_binding:
     EQUAL seq_expr
@@ -3576,7 +3558,7 @@ generalized_constructor_arguments:
 
 %inline atomic_type_gbl:
   gbl = global_flag cty = atomic_type {
-  mkcty_global_maybe gbl cty (make_loc $loc(gbl))
+  global_if gbl $loc(gbl) cty
 }
 ;
 
@@ -3596,9 +3578,13 @@ label_declaration:
     mutable_or_global_flag mkrhs(label) COLON poly_type_no_attr attributes
       { let info = symbol_info $endpos in
         let mut, gbl = $1 in
-        mkld_global_maybe gbl
-          (Type.field $2 $4 ~mut ~attrs:$5 ~loc:(make_loc $sloc) ~info)
-          (make_loc $loc($1)) }
+        Type.field
+          $2
+          (global_if gbl $loc($1) $4)
+          ~mut
+          ~attrs:$5
+          ~loc:(make_loc $sloc)
+          ~info }
 ;
 label_declaration_semi:
     mutable_or_global_flag mkrhs(label) COLON poly_type_no_attr attributes
@@ -3609,9 +3595,13 @@ label_declaration_semi:
           | None -> symbol_info $endpos
        in
        let mut, gbl = $1 in
-       mkld_global_maybe gbl
-         (Type.field $2 $4 ~mut ~attrs:($5 @ $7) ~loc:(make_loc $sloc) ~info)
-         (make_loc $loc($1)) }
+       Type.field
+         $2
+         (global_if gbl $loc($1) $4)
+         ~mut
+         ~attrs:($5 @ $7)
+         ~loc:(make_loc $sloc)
+         ~info }
 ;
 
 /* Type Extensions */
@@ -3787,7 +3777,7 @@ strict_function_type:
       domain = extra_rhs(param_type)
       MINUSGREATER
       codomain = strict_function_type
-        { Ptyp_arrow(label, mktyp_local_if local domain, codomain) }
+        { Ptyp_arrow(label, local_if Type local $loc(local) domain, codomain) }
     )
     { $1 }
   | mktyp(
@@ -3799,8 +3789,10 @@ strict_function_type:
       codomain = tuple_type
       %prec MINUSGREATER
         { Ptyp_arrow(label,
-            mktyp_local_if arg_local domain,
-            mktyp_local_if ret_local (maybe_curry_typ codomain)) }
+            local_if Type arg_local $loc(arg_local) domain,
+            local_if Type ret_local $loc(ret_local)
+              (Jane_syntax.Builtin.mark_curried
+                 ~loc:(make_loc $loc(codomain)) codomain)) }
     )
     { $1 }
 ;


### PR DESCRIPTION
This reverts commit 5cbea4253dccff9ba237f940b20b600f0b096947.

The result is identical to commit d0a8a393b79033afb032396673fe29cf3322c7b1.

This reenables #32.  This isn't ready to merge yet, we still need to roll out some internal ppxlib changes.