### PR TITLE
Add a mode for rewriting `[@local]`, `[%local]`, `[@ocaml.global]`, etc. to their keyword forms (`local_`, `global_`, etc.)

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -774,7 +774,7 @@ module rec In_ctx : sig
 
   val sub_pat : ctx:T.t -> pattern -> pattern xt
 
-  val sub_exp : ctx:T.t -> expression -> expression xt
+  val sub_exp : Conf.t -> ctx:T.t -> expression -> expression xt
 
   val sub_cl : ctx:T.t -> class_expr -> class_expr xt
 
@@ -798,7 +798,7 @@ end = struct
 
   let sub_pat ~ctx pat = check parenze_pat {ctx; ast= pat}
 
-  let sub_exp ~ctx exp = check parenze_exp {ctx; ast= exp}
+  let sub_exp conf ~ctx exp = check (parenze_exp conf) {ctx; ast= exp}
 
   let sub_cl ~ctx cl = {ctx; ast= cl}
 
@@ -817,7 +817,7 @@ and Requires_sub_terms : sig
   val is_simple :
     Conf.t -> (expression In_ctx.xt -> int) -> expression In_ctx.xt -> bool
 
-  val exposed_right_exp : cls -> expression -> bool
+  val exposed_right_exp : Conf.t -> cls -> expression -> bool
 
   val prec_ast : T.t -> Prec.t option
 
@@ -829,11 +829,11 @@ and Requires_sub_terms : sig
 
   val parenze_cty : class_type In_ctx.xt -> bool
 
-  val parenze_cl : class_expr In_ctx.xt -> bool
+  val parenze_cl : Conf.t -> class_expr In_ctx.xt -> bool
 
   val parenze_pat : pattern In_ctx.xt -> bool
 
-  val parenze_exp : expression In_ctx.xt -> bool
+  val parenze_exp : Conf.t -> expression In_ctx.xt -> bool
 
   val parenze_nested_exp : expression In_ctx.xt -> bool
 end = struct
@@ -1568,7 +1568,7 @@ end = struct
      |Pexp_variant (_, None) ->
         true
     | Pexp_cons l ->
-        List.for_all l ~f:(fun e -> is_simple c width (sub_exp ~ctx e))
+        List.for_all l ~f:(fun e -> is_simple c width (sub_exp c ~ctx e))
         && fit_margin c (width xexp)
     | Pexp_construct (_, Some e0) | Pexp_variant (_, Some e0) ->
         Exp.is_trivial e0
@@ -1595,7 +1595,7 @@ end = struct
         && List.for_all e1N ~f:(snd >> Exp.is_trivial)
         && fit_margin c (width xexp)
     | Pexp_extension (_, PStr [{pstr_desc= Pstr_eval (e0, []); _}]) ->
-        is_simple c width (sub_exp ~ctx e0)
+        is_simple c width (sub_exp c ~ctx e0)
     | Pexp_extension (_, (PStr [] | PTyp _)) -> true
     | _ -> false
 
@@ -2069,11 +2069,11 @@ end = struct
     (* exponential without memoization *)
     let memo = Hashtbl.Poly.create () in
     register_reset (fun () -> Hashtbl.clear memo) ;
-    fun cls exp ->
+    fun c cls exp ->
       let exposed_ () =
         let continue subexp =
-          (not (parenze_exp (sub_exp ~ctx:(Exp exp) subexp)))
-          && exposed_right_exp cls subexp
+          (not (parenze_exp c (sub_exp c ~ctx:(Exp exp) subexp)))
+          && exposed_right_exp c cls subexp
         in
         let exposed_extension eexp =
           (* Inlined because we're closed over [memo] *)
@@ -2146,26 +2146,26 @@ end = struct
   and exposed_right_cl =
     let memo = Hashtbl.Poly.create () in
     register_reset (fun () -> Hashtbl.clear memo) ;
-    fun cls cl ->
+    fun c cls cl ->
       let exposed_ () =
         match cl.pcl_desc with
         | Pcl_apply (_, args) ->
             let exp = snd (List.last_exn args) in
-            (not (parenze_exp (sub_exp ~ctx:(Cl cl) exp)))
-            && exposed_right_exp cls exp
+            (not (parenze_exp c (sub_exp c ~ctx:(Cl cl) exp)))
+            && exposed_right_exp c cls exp
         | Pcl_fun (_, _, _, e) ->
-            (not (parenze_cl (sub_cl ~ctx:(Cl cl) e)))
-            && exposed_right_cl cls e
+            (not (parenze_cl c (sub_cl ~ctx:(Cl cl) e)))
+            && exposed_right_cl c cls e
         | _ -> false
       in
       Cl.mem_cls cls cl
       || Hashtbl.find_or_add memo (cls, cl) ~default:exposed_
 
-  and mark_parenzed_inner_nested_match exp =
+  and mark_parenzed_inner_nested_match c exp =
     let exposed_ () =
       let continue subexp =
-        if not (parenze_exp (sub_exp ~ctx:(Exp exp) subexp)) then
-          mark_parenzed_inner_nested_match subexp ;
+        if not (parenze_exp c (sub_exp c ~ctx:(Exp exp) subexp)) then
+          mark_parenzed_inner_nested_match c subexp ;
         false
       in
       let exposed_extension eexp =
@@ -2207,12 +2207,12 @@ end = struct
         | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases)
           ->
             List.iter cases ~f:(fun case ->
-                mark_parenzed_inner_nested_match case.pc_rhs ) ;
+                mark_parenzed_inner_nested_match c case.pc_rhs ) ;
             true
         | _ -> continue e )
       | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases) ->
           List.iter cases ~f:(fun case ->
-              mark_parenzed_inner_nested_match case.pc_rhs ) ;
+              mark_parenzed_inner_nested_match c case.pc_rhs ) ;
           true
       | Pexp_indexop_access {pia_rhs= rhs; _} -> (
         match rhs with Some e -> continue e | None -> false )
@@ -2234,7 +2234,7 @@ end = struct
 
   (** [parenze_exp {ctx; ast}] holds when expression [ast] should be
       parenthesized in context [ctx]. *)
-  and parenze_exp ({ctx; ast= exp} as xexp) =
+  and parenze_exp c ({ctx; ast= exp} as xexp) =
     let parenze () =
       let is_right_infix_arg ctx_desc exp =
         match ctx_desc with
@@ -2253,8 +2253,8 @@ end = struct
         match ctx with
         | Exp {pexp_desc; _} ->
             if is_right_infix_arg pexp_desc exp then Exp.is_sequence exp
-            else exposed_right_exp Non_apply exp
-        | _ -> exposed_right_exp Non_apply exp )
+            else exposed_right_exp c Non_apply exp
+        | _ -> exposed_right_exp c Non_apply exp )
     in
     let rec ifthenelse pexp_desc =
       match pexp_desc with
@@ -2276,7 +2276,7 @@ end = struct
         , _ )
         when lhs == exp ->
           true
-      | _ when lhs == exp -> exposed_right_exp Let_match exp
+      | _ when lhs == exp -> exposed_right_exp c Let_match exp
       | _ when rhs == exp -> false
       | _ -> failwith "exp must be lhs or rhs from the parent expression"
     in
@@ -2330,21 +2330,25 @@ end = struct
           { pexp_desc=
               Pexp_apply
                 ( { pexp_desc=
-                      Pexp_extension ({txt= "extension.local"; _}, PStr [])
+                      Pexp_extension ({txt= extension_local; _}, PStr [])
                   ; _ }
                 , [(Nolabel, _)] )
           ; _ }
-      , _ ) ->
+      , _ )
+      when Conf.is_jane_street_local_annotation c "local"
+             ~test:extension_local ->
         false
     | ( Exp
           { pexp_desc=
               Pexp_apply
                 ( { pexp_desc=
-                      Pexp_extension ({txt= "extension.exclave"; _}, PStr [])
+                      Pexp_extension ({txt= extension_exclave; _}, PStr [])
                   ; _ }
                 , [(Nolabel, _)] )
           ; _ }
-      , _ ) ->
+      , _ )
+      when Conf.is_jane_street_local_annotation c "exclave"
+             ~test:extension_exclave ->
         false
     | _, {pexp_desc= Pexp_infix _; pexp_attributes= _ :: _; _} -> true
     | ( Str
@@ -2475,18 +2479,18 @@ end = struct
          |Pexp_try (_, cases) ->
             if !leading_nested_match_parens then
               List.iter cases ~f:(fun {pc_rhs; _} ->
-                  mark_parenzed_inner_nested_match pc_rhs ) ;
+                  mark_parenzed_inner_nested_match c pc_rhs ) ;
             List.exists cases ~f:(fun {pc_rhs; _} -> pc_rhs == exp)
-            && exposed_right_exp Match exp
+            && exposed_right_exp c Match exp
         | Pexp_ifthenelse (eN, _)
           when List.exists eN ~f:(fun x -> x.if_cond == exp) ->
             false
         | Pexp_ifthenelse (eN, None) when (List.last_exn eN).if_body == exp
           ->
-            exposed_right_exp Then exp
+            exposed_right_exp c Then exp
         | Pexp_ifthenelse (eN, _)
           when List.exists eN ~f:(fun x -> x.if_body == exp) ->
-            exposed_right_exp ThenElse exp
+            exposed_right_exp c ThenElse exp
         | Pexp_ifthenelse (_, Some els) when els == exp ->
             Exp.is_sequence exp
         | Pexp_apply (({pexp_desc= Pexp_new _; _} as exp2), _)
@@ -2507,7 +2511,7 @@ end = struct
         | Pexp_record (flds, _)
           when List.exists flds ~f:(fun (_, _, e0) ->
                    Option.exists e0 ~f:(fun x -> x == exp) ) ->
-            exposed_right_exp Non_apply exp
+            exposed_right_exp c Non_apply exp
             (* Non_apply is perhaps pessimistic *)
         | Pexp_record (_, Some ({pexp_desc= Pexp_prefix _; _} as e0))
           when e0 == exp ->
@@ -2562,12 +2566,12 @@ end = struct
 
   (** [parenze_cl {ctx; ast}] holds when class expr [ast] should be
       parenthesized in context [ctx]. *)
-  and parenze_cl ({ctx; ast= cl} as xcl) =
+  and parenze_cl c ({ctx; ast= cl} as xcl) =
     assert_check_cl xcl ;
     match ambig_prec (sub_ast ~ctx (Cl cl)) with
     | `No_prec_ctx -> false
     | `Ambiguous -> true
-    | _ -> exposed_right_cl Non_apply cl
+    | _ -> exposed_right_cl c Non_apply cl
 
   let parenze_nested_exp {ctx; ast= exp} =
     let infix_prec ast =

--- a/lib/Ast.mli
+++ b/lib/Ast.mli
@@ -149,7 +149,7 @@ val sub_cty : ctx:t -> class_type -> class_type xt
 val sub_pat : ctx:t -> pattern -> pattern xt
 (** Construct a pattern-in-context. *)
 
-val sub_exp : ctx:t -> expression -> expression xt
+val sub_exp : Conf.t -> ctx:t -> expression -> expression xt
 (** Construct a expression-in-context. *)
 
 val sub_cl : ctx:t -> class_expr -> class_expr xt
@@ -174,7 +174,7 @@ val is_simple : Conf.t -> (expression xt -> int) -> expression xt -> bool
 (** 'Classes' of expressions which are parenthesized differently. *)
 type cls = Let_match | Match | Non_apply | Sequence | Then | ThenElse
 
-val exposed_right_exp : cls -> expression -> bool
+val exposed_right_exp : Conf.t -> cls -> expression -> bool
 (** [exposed_right_exp cls exp] holds if there is a right-most subexpression
     of [exp] which is of class [cls] and is not parenthesized. *)
 
@@ -190,7 +190,7 @@ val parenze_cty : class_type xt -> bool
 (** [parenze_cty xcty] holds when class_type-in-context [xcty] should be
     parenthesized. *)
 
-val parenze_cl : class_expr xt -> bool
+val parenze_cl : Conf.t -> class_expr xt -> bool
 (** [parenze_cl xcl] holds when class-in-context [xcl] should be
     parenthesized. *)
 
@@ -198,7 +198,7 @@ val parenze_pat : pattern xt -> bool
 (** [parenze_pat xpat] holds when pattern-in-context [xpat] should be
     parenthesized. *)
 
-val parenze_exp : expression xt -> bool
+val parenze_exp : Conf.t -> expression xt -> bool
 (** [parenze_exp xexp] holds when expression-in-context [xexp] should be
     parenthesized. *)
 

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -258,7 +258,8 @@ let default =
       ; quiet= elt false
       ; range= elt @@ Range.make ?range:None
       ; disable_conf_attrs= elt false
-      ; version_check= elt true } }
+      ; version_check= elt true
+      ; rewrite_old_style_jane_street_local_annotations= elt false } }
 
 module V = struct
   let v0_12 = Version.make ~major:0 ~minor:12 ~patch:None
@@ -1463,6 +1464,23 @@ module Operational = struct
       (fun conf elt -> update conf ~f:(fun f -> {f with version_check= elt}))
       (fun conf -> conf.opr_opts.version_check)
 
+  let rewrite_old_style_jane_street_local_annotations =
+    let doc =
+      "Rewrite all Jane Street annotations for use with the local mode, \
+       such as \"[%local]\" or \"[@ocaml.global]\", into their \
+       pretty-printed syntactic form, such as \"local_\" or \"global_\".  \
+       THIS OPTION WILL CHANGE THE RESULTING AST."
+    in
+    Decl.flag ~default
+      ~names:["rewrite-old-style-jane-street-local-annotations"]
+      ~doc ~kind
+      (fun conf elt ->
+        update conf ~f:(fun f ->
+            {f with rewrite_old_style_jane_street_local_annotations= elt} )
+        )
+      (fun conf ->
+        conf.opr_opts.rewrite_old_style_jane_street_local_annotations )
+
   let options : Store.t =
     Store.
       [ elt comment_check
@@ -1474,7 +1492,8 @@ module Operational = struct
       ; elt quiet
       ; elt range
       ; elt disable_conf_attrs
-      ; elt version_check ]
+      ; elt version_check
+      ; elt rewrite_old_style_jane_street_local_annotations ]
 end
 
 let options = Operational.options @ Formatting.options @ options
@@ -1581,6 +1600,13 @@ let parse_state_attr attr =
   | Ok ("enable", _) -> Some `Enable
   | Ok ("disable", _) -> Some `Disable
   | _ -> None
+
+let is_jane_street_local_annotation config name ~test =
+  String.equal test ("extension." ^ name)
+  ||
+  if config.opr_opts.rewrite_old_style_jane_street_local_annotations.v then
+    String.equal test name || String.equal test ("ocaml." ^ name)
+  else false
 
 let print_config = Decl.print_config options
 

--- a/lib/Conf.mli
+++ b/lib/Conf.mli
@@ -25,6 +25,8 @@ val update_state : t -> [`Enable | `Disable] -> t
 
 val parse_state_attr : Parsetree.attribute -> [`Enable | `Disable] option
 
+val is_jane_street_local_annotation : t -> string -> test:string -> bool
+
 val parse_line :
      t
   -> ?version_check:bool

--- a/lib/Conf_t.ml
+++ b/lib/Conf_t.ml
@@ -129,7 +129,8 @@ type opr_opts =
   ; quiet: bool elt
   ; range: (string -> Range.t) elt
   ; disable_conf_attrs: bool elt
-  ; version_check: bool elt }
+  ; version_check: bool elt
+  ; rewrite_old_style_jane_street_local_annotations: bool elt }
 
 type t =
   { fmt_opts: fmt_opts

--- a/lib/Conf_t.mli
+++ b/lib/Conf_t.mli
@@ -132,7 +132,8 @@ type opr_opts =
   ; quiet: bool elt
   ; range: (string -> Range.t) elt
   ; disable_conf_attrs: bool elt
-  ; version_check: bool elt }
+  ; version_check: bool elt
+  ; rewrite_old_style_jane_street_local_annotations: bool elt }
 
 type t =
   { fmt_opts: fmt_opts

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -123,7 +123,7 @@ let fmt_expressions c width sub_exp exprs fmt_expr p loc =
   | `Fit_or_vertical ->
       fmt_elements_collection c p Exp.location loc fmt_expr exprs
   | `Wrap ->
-      let is_simple x = is_simple c.conf width (sub_exp x) in
+      let is_simple x = is_simple c.conf width (sub_exp c.conf x) in
       let break x1 x2 = not (is_simple x1 && is_simple x2) in
       let grps = List.group exprs ~break in
       let fmt_grp ~first:first_grp ~last:last_grp exprs =
@@ -542,12 +542,14 @@ let fmt_type_var s =
   $ fmt_if (String.length s > 1 && Char.equal s.[1] '\'') " "
   $ str s
 
-let split_global_flags_from_attrs atrs =
+let split_global_flags_from_attrs conf atrs =
   match
     List.partition_map atrs ~f:(fun a ->
-        match a.attr_name.txt with
-        | "extension.global" -> First `Global
-        | _ -> Second a )
+        if
+          Conf.is_jane_street_local_annotation conf "global"
+            ~test:a.attr_name.txt
+        then First `Global
+        else Second a )
   with
   | [`Global], atrs -> (true, atrs)
   | _ -> (false, atrs)
@@ -701,7 +703,7 @@ and fmt_payload c ctx pld =
   | PTyp typ -> fmt ":@ " $ fmt_core_type c (sub_typ ~ctx typ)
   | PPat (pat, exp) ->
       let fmt_when exp =
-        str " when " $ fmt_expression c (sub_exp ~ctx exp)
+        str " when " $ fmt_expression c (sub_exp c.conf ~ctx exp)
       in
       fmt "?@ " $ fmt_pattern c (sub_pat ~ctx pat) $ opt exp fmt_when
 
@@ -735,7 +737,7 @@ and type_constr_and_body c xbody =
   let ctx = Exp body in
   let fmt_cstr_and_xbody typ exp =
     ( Some (fmt_type_cstr c ~constraint_ctx:`Fun (sub_typ ~ctx typ))
-    , sub_exp ~ctx exp )
+    , sub_exp c.conf ~ctx exp )
   in
   match xbody.ast.pexp_desc with
   | Pexp_constraint (exp, typ) ->
@@ -784,7 +786,9 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   in
   let ptyp_attributes =
     List.filter ptyp_attributes ~f:(fun a ->
-        not (String.equal a.attr_name.txt "extension.global") )
+        not
+          (Conf.is_jane_street_local_annotation c.conf "global"
+             ~test:a.attr_name.txt ) )
   in
   update_config_maybe_disabled c ptyp_loc ptyp_attributes
   @@ fun c ->
@@ -835,7 +839,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_arrow (ctl, ct2) ->
       Cmts.relocate c.cmts ~src:ptyp_loc
         ~before:(List.hd_exn ctl).pap_type.ptyp_loc ~after:ct2.ptyp_loc ;
-      let xt1N, ctx = Sugar.decompose_arrow ctx ctl ct2 in
+      let xt1N, ctx = Sugar.decompose_arrow c.conf ctx ctl ct2 in
       let indent =
         if Poly.(c.conf.fmt_opts.break_separators.v = `Before) then 2 else 0
       in
@@ -1404,7 +1408,7 @@ and fmt_fun_args c args =
     the first returned value belongs to a box of level N. *)
 and fmt_body c ?ext ({ast= body; _} as xbody) =
   let ctx = Exp body in
-  let parens = parenze_exp xbody in
+  let parens = parenze_exp c.conf xbody in
   match body with
   | {pexp_desc= Pexp_function cs; pexp_attributes; pexp_loc; _} ->
       ( ( update_config_maybe_disabled c pexp_loc pexp_attributes
@@ -1419,21 +1423,26 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
         fmt_cases c ctx cs $ fmt_if parens ")" $ Cmts.fmt_after c pexp_loc )
   | { pexp_desc=
         Pexp_apply
-          ( { pexp_desc= Pexp_extension ({txt= "extension.local"; _}, PStr [])
+          ( { pexp_desc= Pexp_extension ({txt= extension_local; _}, PStr [])
             ; _ }
           , [(Nolabel, sbody)] )
-    ; _ } ->
+    ; _ }
+    when Conf.is_jane_street_local_annotation c.conf "local"
+           ~test:extension_local ->
       ( fmt " local_"
-      , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp ~ctx sbody) )
+      , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp c.conf ~ctx sbody)
+      )
   | { pexp_desc=
         Pexp_apply
-          ( { pexp_desc=
-                Pexp_extension ({txt= "extension.exclave"; _}, PStr [])
+          ( { pexp_desc= Pexp_extension ({txt= extension_exclave; _}, PStr [])
             ; _ }
           , [(Nolabel, sbody)] )
-    ; _ } ->
+    ; _ }
+    when Conf.is_jane_street_local_annotation c.conf "exclave"
+           ~test:extension_exclave ->
       ( fmt " exclave_"
-      , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp ~ctx sbody) )
+      , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp c.conf ~ctx sbody)
+      )
   | _ -> (noop, fmt_expression c ~eol:(fmt "@;<1000 0>") xbody)
 
 and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
@@ -1448,22 +1457,24 @@ and fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x =
   Params.parens_if parens c.conf
     (hovbox 0
        ( Params.parens_if inner_wrap c.conf
-           ( fmt_expression c (sub_exp ~ctx pia_lhs)
+           ( fmt_expression c (sub_exp c.conf ~ctx pia_lhs)
            $ str "."
            $ ( match pia_kind with
              | Builtin idx ->
-                 wrap_paren (fmt_expression c (sub_exp ~ctx idx))
+                 wrap_paren (fmt_expression c (sub_exp c.conf ~ctx idx))
              | Dotop (path, op, [idx]) ->
                  opt path (fun x -> fmt_longident_loc c x $ str ".")
                  $ str op
-                 $ wrap_paren (fmt_expression c (sub_exp ~ctx idx))
+                 $ wrap_paren (fmt_expression c (sub_exp c.conf ~ctx idx))
              | Dotop (path, op, idx) ->
                  opt path (fun x -> fmt_longident_loc c x $ str ".")
                  $ str op
                  $ wrap_paren
-                     (list idx ";@ " (sub_exp ~ctx >> fmt_expression c)) )
+                     (list idx ";@ "
+                        (sub_exp c.conf ~ctx >> fmt_expression c) ) )
            $ opt pia_rhs (fun e ->
-                 fmt_assign_arrow c $ fmt_expression c (sub_exp ~ctx e) ) )
+                 fmt_assign_arrow c
+                 $ fmt_expression c (sub_exp c.conf ~ctx e) ) )
        $ fmt_atrs ) )
 
 (** Format [Pexp_fun] or [Pexp_newtype]. [wrap_intro] wraps up to after the
@@ -1481,7 +1492,7 @@ and fmt_fun ?force_closing_paren
     let cmts = Cmts.fmt_before ?eol c ast.pexp_loc in
     if has_label then (false, noop, cmts) else (has_cmts, cmts, noop)
   in
-  let xargs, xbody = Sugar.fun_ c.cmts xast in
+  let xargs, xbody = Sugar.fun_ c.conf c.cmts xast in
   let fmt_cstr, xbody = type_constr_and_body c xbody in
   let body =
     let box =
@@ -1558,7 +1569,7 @@ and expression_width c xe =
 
 and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
   let fmt_arg c ~first:_ ~last (lbl, arg) =
-    let ({ast; _} as xarg) = sub_exp ~ctx arg in
+    let ({ast; _} as xarg) = sub_exp c.conf ~ctx arg in
     let box =
       match ast.pexp_desc with
       | Pexp_fun _ | Pexp_function _ -> Some false
@@ -1580,7 +1591,7 @@ and fmt_args_grouped ?epi:(global_epi = noop) c ctx args =
     $ fmt_if_k (not last) (break 1 0)
   in
   let is_simple (lbl, x) =
-    let xexp = sub_exp ~ctx x in
+    let xexp = sub_exp c.conf ~ctx x in
     let output =
       Cmts.preserve
         ~cache_key:(Arg (lbl, x))
@@ -1626,7 +1637,7 @@ and fmt_sequence c ?ext ~has_attr parens width xexp fmt_atrs =
   let break (_, xexp1) (_, xexp2) =
     not (is_simple xexp1 && is_simple xexp2)
   in
-  let elts = Sugar.sequence c.cmts xexp in
+  let elts = Sugar.sequence c.conf c.cmts xexp in
   ( match elts with
   | (None, _) :: (first_ext, _) :: _ ->
       let compare {txt= x; _} {txt= y; _} = String.compare x y in
@@ -1691,8 +1702,8 @@ and fmt_infix_op_args c ~parens xexp op_args =
   in
   let fmt_arg very_last xarg =
     let parens =
-      ((not very_last) && exposed_right_exp Ast.Non_apply xarg.ast)
-      || parenze_exp xarg
+      ((not very_last) && exposed_right_exp c.conf Ast.Non_apply xarg.ast)
+      || parenze_exp c.conf xarg
     in
     let box =
       match xarg.ast.pexp_desc with
@@ -1759,7 +1770,7 @@ and fmt_match c ~parens ?ext ctx xexp cs e0 keyword =
            $ fmt_extension_suffix c ext
            $ fmt_attributes c xexp.ast.pexp_attributes
            $ fmt "@;<1 2>"
-           $ fmt_expression c (sub_exp ~ctx e0)
+           $ fmt_expression c (sub_exp c.conf ~ctx e0)
            $ fmt "@ with" )
        $ fmt "@ " $ fmt_cases c ctx cs ) )
 
@@ -1782,7 +1793,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   let fmt_cmts = Cmts.fmt c ?eol pexp_loc in
   let fmt_atrs = fmt_attributes c ~pre:Space pexp_attributes in
   let has_attr = not (List.is_empty pexp_attributes) in
-  let parens = Option.value parens ~default:(parenze_exp xexp) in
+  let parens = Option.value parens ~default:(parenze_exp c.conf xexp) in
   let ctx = Exp exp in
   let fmt_args_grouped ?epi e0 a1N =
     fmt_args_grouped c ctx ?epi ((Nolabel, e0) :: a1N)
@@ -1805,13 +1816,16 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       ; pstr_loc= _ } as pld ) ] )
         ; _ }
       , e2 ) ->
-      let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx:(Str pld) call) in
+      let xargs, xbody =
+        Sugar.fun_ c.conf c.cmts (sub_exp c.conf ~ctx:(Str pld) call)
+      in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
       let is_simple x = is_simple c.conf (expression_width c) x in
       let break xexp1 xexp2 = not (is_simple xexp1 && is_simple xexp2) in
       let grps =
         List.group
-          (List.map ~f:snd (Sugar.sequence c.cmts (sub_exp ~ctx e2)))
+          (List.map ~f:snd
+             (Sugar.sequence c.conf c.cmts (sub_exp c.conf ~ctx e2)) )
           ~break
       in
       let fmt_grp grp = list grp " ;@ " (fmt_expression c) in
@@ -1839,11 +1853,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                           Pstr_eval (({pexp_desc= Pexp_fun _; _} as retn), [])
                       ; pstr_loc= _ } as pld ) ] )
         ; _ } ) ->
-      let xargs, xbody = Sugar.fun_ c.cmts (sub_exp ~ctx:(Str pld) retn) in
+      let xargs, xbody =
+        Sugar.fun_ c.conf c.cmts (sub_exp c.conf ~ctx:(Str pld) retn)
+      in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
       hvbox 0
         (Params.Exp.wrap c.conf ~parens
-           ( fmt_expression c (sub_exp ~ctx e0)
+           ( fmt_expression c (sub_exp c.conf ~ctx e0)
            $ fmt "@\n"
            $ Cmts.fmt c loc (fmt "|>@\n")
            $ hvbox c.conf.fmt_opts.extension_indent.v
@@ -1856,7 +1872,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                       )
                   $ fmt "@ " $ fmt_expression c xbody ) ) ) )
   | Pexp_infix ({txt= ":="; loc}, r, v)
-    when is_simple c.conf (expression_width c) (sub_exp ~ctx r) ->
+    when is_simple c.conf (expression_width c) (sub_exp c.conf ~ctx r) ->
       let cmts_before =
         let adj =
           fmt_if
@@ -1870,15 +1886,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         (hovbox 0
            ( match c.conf.fmt_opts.assignment_operator.v with
            | `Begin_line ->
-               hvbox 0 (fmt_expression c (sub_exp ~ctx r) $ cmts_before)
+               hvbox 0
+                 (fmt_expression c (sub_exp c.conf ~ctx r) $ cmts_before)
                $ fmt "@;<1 2>:= " $ cmts_after
-               $ hvbox 2 (fmt_expression c (sub_exp ~ctx v))
+               $ hvbox 2 (fmt_expression c (sub_exp c.conf ~ctx v))
            | `End_line ->
                hvbox 0
-                 ( hvbox 0 (fmt_expression c (sub_exp ~ctx r) $ cmts_before)
+                 ( hvbox 0
+                     (fmt_expression c (sub_exp c.conf ~ctx r) $ cmts_before)
                  $ str " :=" )
                $ fmt "@;<1 2>" $ cmts_after
-               $ hvbox 2 (fmt_expression c (sub_exp ~ctx v)) ) )
+               $ hvbox 2 (fmt_expression c (sub_exp c.conf ~ctx v)) ) )
   | Pexp_prefix ({txt= ("~-" | "~-." | "~+" | "~+.") as op; loc}, e1) ->
       let op =
         if Location.width loc = String.length op - 1 then
@@ -1888,23 +1906,24 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let spc = fmt_if (Exp.exposed_left e1) "@ " in
       Params.parens_if parens c.conf
         ( Cmts.fmt c pexp_loc
-          @@ hvbox 2 (str op $ spc $ fmt_expression c (sub_exp ~ctx e1))
+          @@ hvbox 2
+               (str op $ spc $ fmt_expression c (sub_exp c.conf ~ctx e1))
         $ fmt_atrs )
   | Pexp_infix (({txt= id; _} as op), l, ({pexp_desc= Pexp_ident _; _} as r))
     when Std_longident.String_id.is_hash_getter id ->
       Params.parens_if parens c.conf
-        ( fmt_expression c (sub_exp ~ctx l)
+        ( fmt_expression c (sub_exp c.conf ~ctx l)
         $ hvbox 0 (fmt_str_loc c op)
-        $ fmt_expression c (sub_exp ~ctx r) )
+        $ fmt_expression c (sub_exp c.conf ~ctx r) )
   | Pexp_infix
       (op, l, ({pexp_desc= Pexp_fun _; pexp_loc; pexp_attributes; _} as r))
     when not c.conf.fmt_opts.break_infix_before_func.v ->
       (* side effects of Cmts.fmt c.cmts before Sugar.fun_ is important *)
       let cmts_before = Cmts.fmt_before c pexp_loc in
       let cmts_after = Cmts.fmt_after c pexp_loc in
-      let xr = sub_exp ~ctx r in
-      let parens_r = parenze_exp xr in
-      let xargs, xbody = Sugar.fun_ c.cmts xr in
+      let xr = sub_exp c.conf ~ctx r in
+      let parens_r = parenze_exp c.conf xr in
+      let xargs, xbody = Sugar.fun_ c.conf c.cmts xr in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
       let indent_wrap = if parens then -2 else 0 in
       let pre_body, body = fmt_body c ?ext xbody in
@@ -1919,7 +1938,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             (wrap_if has_attr "(" ")"
                ( hvbox 2
                    ( hvbox indent_wrap
-                       ( fmt_expression ~indent_wrap c (sub_exp ~ctx l)
+                       ( fmt_expression ~indent_wrap c (sub_exp c.conf ~ctx l)
                        $ fmt "@;"
                        $ hovbox 2
                            ( hvbox 0
@@ -1942,13 +1961,13 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     when not c.conf.fmt_opts.break_infix_before_func.v ->
       let cmts_before = Cmts.fmt_before c pexp_loc in
       let cmts_after = Cmts.fmt_after c pexp_loc in
-      let xr = sub_exp ~ctx r in
-      let parens_r = parenze_exp xr in
+      let xr = sub_exp c.conf ~ctx r in
+      let parens_r = parenze_exp c.conf xr in
       let indent = Params.function_indent c.conf ~ctx in
       Params.parens_if parens c.conf
         (hvbox indent
            ( hvbox 0
-               ( fmt_expression c (sub_exp ~ctx l)
+               ( fmt_expression c (sub_exp c.conf ~ctx l)
                $ fmt "@;"
                $ hovbox 2
                    ( hvbox 0
@@ -1959,7 +1978,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            $ fmt "@ " $ fmt_cases c (Exp r) cs $ fmt_if parens_r " )"
            $ cmts_after ) )
   | Pexp_infix _ ->
-      let op_args = Sugar.Exp.infix c.cmts (prec_ast (Exp exp)) xexp in
+      let op_args =
+        Sugar.Exp.infix c.conf c.cmts (prec_ast (Exp exp)) xexp
+      in
       let inner_wrap = parens || has_attr in
       let outer_wrap =
         match ctx0 with
@@ -2004,22 +2025,25 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
               ( fmt_infix_op_args ~parens:inner_wrap c xexp infix_op_args
               $ fmt_atrs ) ) )
   | Pexp_apply
-      ( {pexp_desc= Pexp_extension ({txt= "extension.local"; _}, PStr []); _}
-      , [(Nolabel, sbody)] ) ->
+      ( {pexp_desc= Pexp_extension ({txt= extension_local; _}, PStr []); _}
+      , [(Nolabel, sbody)] )
+    when Conf.is_jane_street_local_annotation c.conf "local"
+           ~test:extension_local ->
       Params.parens_if parens c.conf
-        (fmt "local_@ " $ fmt_expression c (sub_exp ~ctx sbody))
+        (fmt "local_@ " $ fmt_expression c (sub_exp c.conf ~ctx sbody))
   | Pexp_apply
-      ( { pexp_desc= Pexp_extension ({txt= "extension.exclave"; _}, PStr [])
-        ; _ }
-      , [(Nolabel, sbody)] ) ->
+      ( {pexp_desc= Pexp_extension ({txt= extension_exclave; _}, PStr []); _}
+      , [(Nolabel, sbody)] )
+    when Conf.is_jane_street_local_annotation c.conf "exclave"
+           ~test:extension_exclave ->
       Params.parens_if parens c.conf
-        (fmt "exclave_@ " $ fmt_expression c (sub_exp ~ctx sbody))
+        (fmt "exclave_@ " $ fmt_expression c (sub_exp c.conf ~ctx sbody))
   | Pexp_prefix (op, e) ->
       let has_cmts = Cmts.has_before c.cmts e.pexp_loc in
       hvbox 2
         (Params.Exp.wrap c.conf ~parens
            ( fmt_str_loc c op $ fmt_if has_cmts "@,"
-           $ fmt_expression c ~box (sub_exp ~ctx e)
+           $ fmt_expression c ~box (sub_exp c.conf ~ctx e)
            $ fmt_atrs ) )
   | Pexp_apply (e0, e1N1) -> (
       let wrap =
@@ -2029,10 +2053,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       | (lbl, ({pexp_desc= Pexp_fun (_, _, _, eN1_body); _} as eN1))
         :: rev_args_before
         when List.for_all rev_args_before ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp c.conf ~ctx eI) ) ->
           (* Last argument is a [fun _ ->]. *)
           let args_before = List.rev rev_args_before in
-          let xlast_arg = sub_exp ~ctx eN1 in
+          let xlast_arg = sub_exp c.conf ~ctx eN1 in
           let args =
             let break_body =
               match eN1_body.pexp_desc with
@@ -2064,7 +2088,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
             ; _ } as eN ) )
         :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp c.conf ~ctx eI) ) ->
           let force =
             if Location.is_single_line pexp_loc c.conf.fmt_opts.margin.v then
               Fit
@@ -2089,12 +2113,12 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            (sub_pat ~ctx pc_lhs)
                        $ fmt "@ ->" )
                    $ fmt "@ "
-                   $ cbox 0 (fmt_expression c (sub_exp ~ctx pc_rhs))
+                   $ cbox 0 (fmt_expression c (sub_exp c.conf ~ctx pc_rhs))
                    $ closing_paren c ~force $ Cmts.fmt_after c pexp_loc )
                $ fmt_atrs ) )
       | (lbl, ({pexp_desc= Pexp_function cs; pexp_loc; _} as eN)) :: rev_e1N
         when List.for_all rev_e1N ~f:(fun (_, eI) ->
-                 is_simple c.conf (fun _ -> 0) (sub_exp ~ctx eI) ) ->
+                 is_simple c.conf (fun _ -> 0) (sub_exp c.conf ~ctx eI) ) ->
           let e1N = List.rev rev_e1N in
           let ctx'' = Exp eN in
           let default_indent =
@@ -2137,7 +2161,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         (Params.parens_if parens c.conf
            ( p.box
                (fmt_expressions c (expression_width c) (sub_exp ~ctx) e1N
-                  (sub_exp ~ctx >> fmt_expression c)
+                  (sub_exp c.conf ~ctx >> fmt_expression c)
                   p pexp_loc )
            $ fmt_atrs ) )
   | Pexp_list e1N ->
@@ -2152,14 +2176,15 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                (fmt_expressions c (expression_width c) (sub_exp ~ctx) e1N
                   (fun e ->
                     let fmt_cmts = Cmts.fmt c ~eol:cmt_break e.pexp_loc in
-                    fmt_cmts @@ (sub_exp ~ctx >> fmt_expression c) e )
+                    fmt_cmts @@ (sub_exp c.conf ~ctx >> fmt_expression c) e
+                    )
                   p pexp_loc )
            $ fmt_atrs ) )
   | Pexp_assert e0 ->
       let paren_body =
         if Exp.is_symbol e0 || Exp.is_monadic_binding e0 then
           not (List.is_empty e0.pexp_attributes)
-        else parenze_exp (sub_exp ~ctx e0)
+        else parenze_exp c.conf (sub_exp c.conf ~ctx e0)
       in
       hovbox 0
         (Params.parens_if parens c.conf
@@ -2168,7 +2193,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                   ( str "assert"
                   $ fmt_extension_suffix c ext
                   $ fmt_or paren_body " (@," "@ "
-                  $ fmt_expression c ~parens:false (sub_exp ~ctx e0) )
+                  $ fmt_expression c ~parens:false (sub_exp c.conf ~ctx e0)
+                  )
               $ fmt_if_k paren_body (closing_paren c)
               $ fmt_atrs ) ) )
   | Pexp_constant const ->
@@ -2179,7 +2205,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
   | Pexp_constraint (e, t) ->
       hvbox 2
         ( wrap_fits_breaks ~space:false c.conf "(" ")"
-            ( fmt_expression c (sub_exp ~ctx e)
+            ( fmt_expression c (sub_exp c.conf ~ctx e)
             $ fmt "@ : "
             $ fmt_core_type c (sub_typ ~ctx t) )
         $ fmt_atrs )
@@ -2201,8 +2227,10 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ( hvbox indent_wrap
             (fmt_infix_op_args c ~parens xexp
                (List.mapi l ~f:(fun i e ->
-                    (false, noop, noop, (fmt_if (i > 0) "::", sub_exp ~ctx e)) )
-               ) )
+                    ( false
+                    , noop
+                    , noop
+                    , (fmt_if (i > 0) "::", sub_exp c.conf ~ctx e) ) ) ) )
         $ fmt_atrs )
   | Pexp_construct (({txt= Lident "::"; loc= _} as lid), Some arg) ->
       let opn, cls =
@@ -2216,27 +2244,27 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         ( hvbox 2
             ( wrap_k opn cls (fmt_longident_loc c lid)
             $ fmt "@ "
-            $ fmt_expression c (sub_exp ~ctx arg) )
+            $ fmt_expression c (sub_exp c.conf ~ctx arg) )
         $ fmt_atrs )
   | Pexp_construct (lid, Some arg) ->
       Params.parens_if parens c.conf
         ( hvbox 2
             ( fmt_longident_loc c lid $ fmt "@ "
-            $ fmt_expression c (sub_exp ~ctx arg) )
+            $ fmt_expression c (sub_exp c.conf ~ctx arg) )
         $ fmt_atrs )
   | Pexp_variant (s, arg) ->
       hvbox 2
         (Params.parens_if parens c.conf
            ( variant_var c s
-           $ opt arg (fmt "@ " >$ (sub_exp ~ctx >> fmt_expression c))
+           $ opt arg (fmt "@ " >$ (sub_exp c.conf ~ctx >> fmt_expression c))
            $ fmt_atrs ) )
   | Pexp_field (exp, lid) ->
       hvbox 2
         (Params.parens_if parens c.conf
-           ( fmt_expression c (sub_exp ~ctx exp)
+           ( fmt_expression c (sub_exp c.conf ~ctx exp)
            $ fmt "@,." $ fmt_longident_loc c lid $ fmt_atrs ) )
   | Pexp_newtype _ | Pexp_fun _ ->
-      let xargs, xbody = Sugar.fun_ c.cmts xexp in
+      let xargs, xbody = Sugar.fun_ c.conf c.cmts xexp in
       let fmt_cstr, xbody = type_constr_and_body c xbody in
       let body_is_function =
         match xbody.ast.pexp_desc with Pexp_function _ -> true | _ -> false
@@ -2294,13 +2322,14 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       let cnd_exps =
         let with_conds =
           List.map if_branches ~f:(fun x ->
-              ( Some (sub_exp ~ctx x.if_cond)
-              , sub_exp ~ctx x.if_body
+              ( Some (sub_exp c.conf ~ctx x.if_cond)
+              , sub_exp c.conf ~ctx x.if_body
               , x.if_attrs ) )
         in
         match else_ with
         | Some x ->
-            List.rev ((None, sub_exp ~ctx x, []) :: List.rev with_conds)
+            List.rev
+              ((None, sub_exp c.conf ~ctx x, []) :: List.rev with_conds)
         | None -> with_conds
       in
       hvbox 0
@@ -2309,7 +2338,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                (list_fl cnd_exps
                   (fun ~first ~last (xcond, xbch, pexp_attributes) ->
                     let symbol_parens = Exp.is_symbol xbch.ast in
-                    let parens_bch = parenze_exp xbch && not symbol_parens in
+                    let parens_bch =
+                      parenze_exp c.conf xbch && not symbol_parens
+                    in
                     let parens_exp = false in
                     let p =
                       Params.get_if_then_else c.conf ~first ~last ~parens_bch
@@ -2336,15 +2367,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         $ fmt_atrs )
   | Pexp_let (lbs, body) ->
       let bindings =
-        Sugar.Let_binding.of_let_bindings c.cmts ~ctx lbs.lbs_bindings
+        Sugar.Let_binding.of_let_bindings c.conf c.cmts ~ctx lbs.lbs_bindings
       in
-      let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
+      let fmt_expr = fmt_expression c (sub_exp c.conf ~ctx body) in
       let ext = lbs.lbs_extension in
       fmt_let_bindings c ~ctx ?ext ~parens ~fmt_atrs ~fmt_expr ~has_attr
         lbs.lbs_rec bindings body
   | Pexp_letop {let_; ands; body} ->
-      let bd = Sugar.Let_binding.of_binding_ops c.cmts ~ctx (let_ :: ands) in
-      let fmt_expr = fmt_expression c (sub_exp ~ctx body) in
+      let bd =
+        Sugar.Let_binding.of_binding_ops c.conf c.cmts ~ctx (let_ :: ands)
+      in
+      let fmt_expr = fmt_expression c (sub_exp c.conf ~ctx body) in
       fmt_let_bindings c ~ctx ?ext ~parens ~fmt_atrs ~fmt_expr ~has_attr
         Nonrecursive bd body
   | Pexp_letexception (ext_cstr, exp) ->
@@ -2361,7 +2394,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        (pre $ fmt_extension_constructor c ctx ext_cstr) )
                 $ fmt "@ in" )
             $ fmt "@;<1000 0>"
-            $ fmt_expression c (sub_exp ~ctx exp) )
+            $ fmt_expression c (sub_exp c.conf ~ctx exp) )
         $ fmt_atrs )
   | Pexp_letmodule (name, pmod, exp) ->
       let keyword = "let module" in
@@ -2391,7 +2424,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                 (fmt_module c ctx keyword ~eqty:":" name xargs (Some xbody)
                    xmty [] ~epi:(str "in") ~can_sparse ?ext ~rec_flag:false )
             $ fmt "@;<1000 0>"
-            $ fmt_expression c (sub_exp ~ctx exp) )
+            $ fmt_expression c (sub_exp c.conf ~ctx exp) )
         $ fmt_atrs )
   | Pexp_open (lid, e0) ->
       let can_skip_parens_extension attrs : Extensions.Expression.t -> _ =
@@ -2425,7 +2458,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                    ( fmt_longident_loc c lid $ str "."
                    $ fmt_if inner_parens "(" )
                $ fmt "@;<0 2>"
-               $ fmt_expression c (sub_exp ~ctx e0)
+               $ fmt_expression c (sub_exp c.conf ~ctx e0)
                $ fmt_if_k inner_parens (closing_paren c) )
            $ fmt_atrs ) )
   | Pexp_letopen
@@ -2457,7 +2490,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                          $ Cmts.fmt_after c popen_loc
                          $ str " in" )
                      $ break 1000 0
-                     $ fmt_expression c (sub_exp ~ctx e0) ) ) )
+                     $ fmt_expression c (sub_exp c.conf ~ctx e0) ) ) )
            $ fmt_atrs ) )
   | Pexp_try (e0, [{pc_lhs; pc_guard; pc_rhs}])
     when Poly.(
@@ -2465,11 +2498,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            && c.conf.fmt_opts.break_cases.v <> `All
            && c.conf.fmt_opts.break_cases.v <> `Vertical ) ->
       (* side effects of Cmts.fmt_before before [fmt_pattern] is important *)
-      let xpc_rhs = sub_exp ~ctx pc_rhs in
+      let xpc_rhs = sub_exp c.conf ~ctx pc_rhs in
       let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in
       let parens_here, parens_for_exp =
         if c.conf.fmt_opts.leading_nested_match_parens.v then (false, None)
-        else (parenze_exp xpc_rhs, Some false)
+        else (parenze_exp c.conf xpc_rhs, Some false)
       in
       Params.Exp.wrap c.conf ~parens ~disambiguate:true
         (hvbox 2
@@ -2478,7 +2511,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                $ fmt_extension_suffix c ext
                $ fmt_attributes c pexp_attributes
                $ fmt "@;<1 2>"
-               $ fmt_expression c (sub_exp ~ctx e0) )
+               $ fmt_expression c (sub_exp c.conf ~ctx e0) )
            $ break 1 (-2)
            $ hvbox 0
                ( hvbox 0
@@ -2488,7 +2521,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                            (sub_pat ~ctx pc_lhs)
                        $ opt pc_guard (fun g ->
                              fmt "@ when "
-                             $ fmt_expression c (sub_exp ~ctx g) )
+                             $ fmt_expression c (sub_exp c.conf ~ctx g) )
                        $ fmt "@ ->" $ fmt_if parens_here " (" ) )
                $ fmt "@;<1 2>"
                $ cbox 0 (fmt_expression c ?parens:parens_for_exp xpc_rhs) )
@@ -2533,7 +2566,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         let typ1 = Option.map typ1 ~f:(sub_typ ~ctx) in
         let typ2 = Option.map typ2 ~f:(sub_typ ~ctx) in
         let rhs =
-          Option.map exp ~f:(fun e -> fmt_expression c (sub_exp ~ctx e))
+          Option.map exp ~f:(fun e ->
+              fmt_expression c (sub_exp c.conf ~ctx e) )
         in
         hvbox 0 @@ fmt_record_field c ?typ1 ?typ2 ?rhs lid
       in
@@ -2552,7 +2586,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       hvbox_if has_attr 0
         ( p1.box
             ( opt default (fun d ->
-                  hvbox 2 (fmt_expression c (sub_exp ~ctx d) $ fmt "@;<1 -2>")
+                  hvbox 2
+                    ( fmt_expression c (sub_exp c.conf ~ctx d)
+                    $ fmt "@;<1 -2>" )
                   $ str "with" $ p2.break_after_with )
             $ fmt_fields )
         $ fmt_atrs )
@@ -2566,7 +2602,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                   , _ )
             ; pstr_loc= _ } ] )
     when Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc
-         && List.length (Sugar.sequence c.cmts xexp) > 1 ->
+         && List.length (Sugar.sequence c.conf c.cmts xexp) > 1 ->
       fmt_sequence ~has_attr c parens (expression_width c) xexp fmt_atrs ~ext
   | Pexp_sequence _ ->
       fmt_sequence ~has_attr c parens (expression_width c) xexp fmt_atrs ?ext
@@ -2574,9 +2610,9 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       hvbox 0
         (Params.Exp.wrap c.conf ~parens
            ( Params.parens_if has_attr c.conf
-               ( fmt_expression c (sub_exp ~ctx e1)
+               ( fmt_expression c (sub_exp c.conf ~ctx e1)
                $ str "." $ fmt_longident_loc c lid $ fmt_assign_arrow c
-               $ fmt_expression c (sub_exp ~ctx e2) )
+               $ fmt_expression c (sub_exp c.conf ~ctx e2) )
            $ fmt_atrs ) )
   | Pexp_tuple es ->
       let parens =
@@ -2607,7 +2643,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                (Params.wrap_tuple ~parens:inner_wrap ~no_parens_if_break
                   c.conf
                   (list es (Params.comma_sep c.conf)
-                     (sub_exp ~ctx >> fmt_expression c) ) )
+                     (sub_exp c.conf ~ctx >> fmt_expression c) ) )
            $ fmt_atrs ) )
   | Pexp_lazy e ->
       hvbox 2
@@ -2615,7 +2651,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
            ( str "lazy"
            $ fmt_extension_suffix c ext
            $ fmt "@ "
-           $ fmt_expression c (sub_exp ~ctx e)
+           $ fmt_expression c (sub_exp c.conf ~ctx e)
            $ fmt_atrs ) )
   | Pexp_extension
       ( ext
@@ -2640,7 +2676,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       hvbox 0
         (Params.parens_if outer_parens c.conf
            ( fmt_expression c ~box ?eol ~parens:inner_parens ~ext
-               (sub_exp ~ctx:(Str str) e1)
+               (sub_exp c.conf ~ctx:(Str str) e1)
            $ fmt_atrs ) )
   | Pexp_extension
       ( ext
@@ -2654,7 +2690,8 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
     when List.is_empty pexp_attributes
          && Source.extension_using_sugar ~name:ext ~payload:e1.pexp_loc ->
       hvbox 0
-        ( fmt_expression c ~box ?eol ~parens ~ext (sub_exp ~ctx:(Str str) e1)
+        ( fmt_expression c ~box ?eol ~parens ~ext
+            (sub_exp c.conf ~ctx:(Str str) e1)
         $ fmt_atrs )
   | Pexp_extension ext ->
       hvbox 0
@@ -2674,19 +2711,19 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        $ hovbox 0
                            ( fmt_pattern c (sub_pat ~ctx p1)
                            $ fmt "@ =@;<1 2>"
-                           $ fmt_expression c (sub_exp ~ctx e1)
+                           $ fmt_expression c (sub_exp c.conf ~ctx e1)
                            $ fmt_direction_flag dir
-                           $ fmt_expression c (sub_exp ~ctx e2) )
+                           $ fmt_expression c (sub_exp c.conf ~ctx e2) )
                        $ fmt "@;do" )
                    $ fmt "@;<1000 0>"
-                   $ fmt_expression c (sub_exp ~ctx e3) )
+                   $ fmt_expression c (sub_exp c.conf ~ctx e3) )
                $ fmt "@;<1000 0>done" )
            $ fmt_atrs ) )
   | Pexp_coerce (e1, t1, t2) ->
       hvbox 2
         (Params.parens_if (parens && has_attr) c.conf
            ( wrap_fits_breaks ~space:false c.conf "(" ")"
-               ( fmt_expression c (sub_exp ~ctx e1)
+               ( fmt_expression c (sub_exp c.conf ~ctx e1)
                $ opt t1 (fmt "@ : " >$ (sub_typ ~ctx >> fmt_core_type c))
                $ fmt "@ :> "
                $ fmt_core_type c (sub_typ ~ctx t2) )
@@ -2700,17 +2737,17 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
                        ( str "while"
                        $ fmt_extension_suffix c ext
                        $ fmt "@;<1 2>"
-                       $ fmt_expression c (sub_exp ~ctx e1)
+                       $ fmt_expression c (sub_exp c.conf ~ctx e1)
                        $ fmt "@;do" )
                    $ fmt "@;<1000 0>"
-                   $ fmt_expression c (sub_exp ~ctx e2) )
+                   $ fmt_expression c (sub_exp c.conf ~ctx e2) )
                $ fmt "@;<1000 0>done" )
            $ fmt_atrs ) )
   | Pexp_unreachable -> str "."
   | Pexp_send (exp, meth) ->
       hvbox 2
         (Params.parens_if parens c.conf
-           ( fmt_expression c (sub_exp ~ctx exp)
+           ( fmt_expression c (sub_exp c.conf ~ctx exp)
            $ fmt "@,#" $ fmt_str_loc c meth $ fmt_atrs ) )
   | Pexp_new {txt; loc} ->
       Cmts.fmt c loc
@@ -2736,7 +2773,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         | _ ->
             Cmts.fmt c ~eol loc @@ fmt_longident txt
             $ str " = "
-            $ fmt_expression c (sub_exp ~ctx f)
+            $ fmt_expression c (sub_exp c.conf ~ctx f)
       in
       match l with
       | [] ->
@@ -2753,7 +2790,7 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
         (Params.Exp.wrap c.conf ~parens
            ( Params.parens_if has_attr c.conf
                ( fmt_str_loc c name $ fmt_assign_arrow c
-               $ hvbox 2 (fmt_expression c (sub_exp ~ctx expr)) )
+               $ hvbox 2 (fmt_expression c (sub_exp c.conf ~ctx expr)) )
            $ fmt_atrs ) )
   | Pexp_indexop_access x ->
       fmt_indexop_access c ctx ~fmt_atrs ~has_attr ~parens x
@@ -2790,11 +2827,11 @@ and fmt_expression c ?(box = true) ?pro ?epi ?eol ?parens ?(indent_wrap = 0)
       in
       wrap_beginend
       @@ fmt_expression c ~box ?pro ?epi ?eol ~parens:false ~indent_wrap ?ext
-           (sub_exp ~ctx e)
+           (sub_exp c.conf ~ctx e)
   | Pexp_parens e ->
       hvbox 0
       @@ fmt_expression c ~box ?pro ?epi ?eol ~parens:true ~indent_wrap ?ext
-           (sub_exp ~ctx e)
+           (sub_exp c.conf ~ctx e)
       $ fmt_atrs
 
 and fmt_expression_extension c ~pexp_loc ~fmt_atrs ~has_attr ~parens ~ctx :
@@ -2826,13 +2863,13 @@ and fmt_expression_extension c ~pexp_loc ~fmt_atrs ~has_attr ~parens ~ctx :
         (Params.parens_if parens c.conf
            ( p.box
                (fmt_expressions c (expression_width c) (sub_exp ~ctx) e1N
-                  (sub_exp ~ctx >> fmt_expression c)
+                  (sub_exp c.conf ~ctx >> fmt_expression c)
                   p pexp_loc )
            $ fmt_atrs ) )
 
 and fmt_comprehension c ~ctx Extensions.Comprehensions.{body; clauses} =
   hvbox 0 (* Don't indent the clauses to the right of the body *)
-    ( fmt_expression c (sub_exp ~ctx body)
+    ( fmt_expression c (sub_exp c.conf ~ctx body)
     $ sequence (List.map clauses ~f:(fmt_comprehension_clause ~ctx c)) )
 
 and fmt_comprehension_clause c ~ctx
@@ -2848,7 +2885,9 @@ and fmt_comprehension_clause c ~ctx
             (if first then "for" else "and")
             (fmt_comprehension_binding ~ctx) )
   | When cond ->
-      subclause "when" (fun c xt -> fmt_expression c xt) (sub_exp ~ctx cond)
+      subclause "when"
+        (fun c xt -> fmt_expression c xt)
+        (sub_exp c.conf ~ctx cond)
 
 and fmt_comprehension_binding c ~ctx
     Extensions.Comprehensions.{pattern; iterator; attributes} =
@@ -2862,10 +2901,10 @@ and fmt_comprehension_iterator c ~ctx :
     Extensions.Comprehensions.iterator -> _ = function
   | Range {start; stop; direction} ->
       fmt "=@;<1 0>"
-      $ fmt_expression c (sub_exp ~ctx start)
+      $ fmt_expression c (sub_exp c.conf ~ctx start)
       $ fmt_direction_flag direction
-      $ fmt_expression c (sub_exp ~ctx stop)
-  | In seq -> fmt "in@;<1 0>" $ fmt_expression c (sub_exp ~ctx seq)
+      $ fmt_expression c (sub_exp c.conf ~ctx stop)
+  | In seq -> fmt "in@;<1 0>" $ fmt_expression c (sub_exp c.conf ~ctx seq)
 
 and fmt_let_bindings c ~ctx ?ext ~parens ~has_attr ~fmt_atrs ~fmt_expr
     rec_flag bindings body =
@@ -2988,7 +3027,7 @@ and fmt_class_expr c ?eol ({ast= exp; _} as xexp) =
   let {pcl_desc; pcl_loc; pcl_attributes} = exp in
   update_config_maybe_disabled c pcl_loc pcl_attributes
   @@ fun c ->
-  let parens = parenze_cl xexp in
+  let parens = parenze_cl c.conf xexp in
   let ctx = Cl exp in
   let fmt_args_grouped e0 a1N =
     (* TODO: consider [e0] when grouping *)
@@ -3008,7 +3047,7 @@ and fmt_class_expr c ?eol ({ast= exp; _} as xexp) =
            ( fmt_class_structure c ~ctx ?ext:None pcstr_self pcstr_fields
            $ fmt_atrs ) )
   | Pcl_fun _ ->
-      let xargs, xbody = Sugar.cl_fun c.cmts xexp in
+      let xargs, xbody = Sugar.cl_fun c.conf c.cmts xexp in
       hvbox
         (if Option.is_none eol then 2 else 1)
         (Params.parens_if parens c.conf
@@ -3031,7 +3070,7 @@ and fmt_class_expr c ?eol ({ast= exp; _} as xexp) =
         | _ -> c.conf.fmt_opts.indent_after_in.v
       in
       let bindings =
-        Sugar.Let_binding.of_let_bindings c.cmts ~ctx lbs.lbs_bindings
+        Sugar.Let_binding.of_let_bindings c.conf c.cmts ~ctx lbs.lbs_bindings
       in
       let fmt_expr = fmt_class_expr c (sub_cl ~ctx body) in
       let has_attr = not (List.is_empty pcl_attributes) in
@@ -3083,26 +3122,26 @@ and fmt_class_field_kind c ctx = function
             $ fmt_core_type ~pro:"." ~pro_space:false c (sub_typ ~ctx t)
           , noop
           , fmt "@;<1 2>="
-          , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
+          , fmt "@ " $ fmt_expression c (sub_exp c.conf ~ctx e) )
       | None ->
           ( fmt "@ : " $ fmt_core_type c (sub_typ ~ctx poly)
           , noop
           , fmt "@;<1 2>="
-          , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) ) )
+          , fmt "@ " $ fmt_expression c (sub_exp c.conf ~ctx e) ) )
   | Cfk_concrete (_, {pexp_desc= Pexp_poly (e, poly); pexp_loc; _}) ->
       let xargs, xbody =
         match poly with
         | None ->
-            Sugar.fun_ c.cmts ~will_keep_first_ast_node:false
-              (sub_exp ~ctx e)
-        | Some _ -> ([], sub_exp ~ctx e)
+            Sugar.fun_ c.conf c.cmts ~will_keep_first_ast_node:false
+              (sub_exp c.conf ~ctx e)
+        | Some _ -> ([], sub_exp c.conf ~ctx e)
       in
       let ty, e =
         match (xbody.ast, poly) with
         | {pexp_desc= Pexp_constraint (e, t); pexp_loc; _}, None ->
             Cmts.relocate c.cmts ~src:pexp_loc ~before:t.ptyp_loc
               ~after:e.pexp_loc ;
-            (Some t, sub_exp ~ctx e)
+            (Some t, sub_exp c.conf ~ctx e)
         | {pexp_desc= Pexp_constraint _; _}, Some _ -> (poly, xbody)
         | _, poly -> (poly, xbody)
       in
@@ -3123,7 +3162,7 @@ and fmt_class_field_kind c ctx = function
       ( opt ty (fun t -> fmt "@ : " $ fmt_core_type c (sub_typ ~ctx t))
       , noop
       , fmt "@;<1 2>="
-      , fmt "@ " $ fmt_expression c (sub_exp ~ctx e) )
+      , fmt "@ " $ fmt_expression c (sub_exp c.conf ~ctx e) )
 
 and fmt_class_field c ctx cf =
   protect c (Clf cf)
@@ -3179,7 +3218,8 @@ and fmt_class_field c ctx cf =
       $ str " = "
       $ fmt_core_type c (sub_typ ~ctx t2)
   | Pcf_initializer e ->
-      str "initializer" $ break 1 2 $ fmt_expression c (sub_exp ~ctx e)
+      str "initializer" $ break 1 2
+      $ fmt_expression c (sub_exp c.conf ~ctx e)
   | Pcf_attribute attr -> fmt_floating_attributes_and_docstrings c [attr]
   | Pcf_extension ext -> fmt_item_extension c ctx ext
 
@@ -3229,7 +3269,7 @@ and fmt_cases c ctx cs = list_fl cs (fmt_case c ctx)
 
 and fmt_case c ctx ~first ~last case =
   let {pc_lhs; pc_guard; pc_rhs} = case in
-  let xrhs = sub_exp ~ctx pc_rhs in
+  let xrhs = sub_exp c.conf ~ctx pc_rhs in
   let indent =
     match
       (c.conf.fmt_opts.cases_matching_exp_indent.v, (ctx, pc_rhs.pexp_desc))
@@ -3249,7 +3289,7 @@ and fmt_case c ctx ~first ~last case =
   let parens_branch, parens_for_exp =
     if align_nested_match then (false, Some false)
     else if c.conf.fmt_opts.leading_nested_match_parens.v then (false, None)
-    else (parenze_exp xrhs && not symbol_parens, Some false)
+    else (parenze_exp c.conf xrhs && not symbol_parens, Some false)
   in
   (* side effects of Cmts.fmt_before before [fmt_lhs] is important *)
   let leading_cmt = Cmts.fmt_before c pc_lhs.ppat_loc in
@@ -3272,8 +3312,8 @@ and fmt_case c ctx ~first ~last case =
           ( hvbox 0
               ( fmt_pattern c ~pro:p.bar ~parens:paren_lhs xlhs
               $ opt pc_guard (fun g ->
-                    fmt "@;<1 2>when " $ fmt_expression c (sub_exp ~ctx g) )
-              )
+                    fmt "@;<1 2>when "
+                    $ fmt_expression c (sub_exp c.conf ~ctx g) ) )
           $ p.break_before_arrow $ str "->" $ p.break_after_arrow
           $ p.open_paren_branch )
       $ p.break_after_opening_paren
@@ -3486,7 +3526,7 @@ and fmt_label_declaration c ctx ?(last = false) decl =
              (fits_breaks ~level:5 "" ";") )
           (str ";")
   in
-  let is_global, atrs = split_global_flags_from_attrs atrs in
+  let is_global, atrs = split_global_flags_from_attrs c.conf atrs in
   hovbox 0
     ( Cmts.fmt_before c pld_loc
     $ hvbox 4
@@ -3537,7 +3577,7 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
 
 and fmt_core_type_gf c ctx typ =
   let {ptyp_attributes; _} = typ in
-  let is_global, _ = split_global_flags_from_attrs ptyp_attributes in
+  let is_global, _ = split_global_flags_from_attrs c.conf ptyp_attributes in
   fmt_if is_global "global_ " $ fmt_core_type c (sub_typ ~ctx typ)
 
 and fmt_constructor_arguments ?vars c ctx ~pre = function
@@ -3901,7 +3941,7 @@ and fmt_class_exprs ?ext c ctx cls =
          let xargs, xbody =
            match cl.pci_expr.pcl_attributes with
            | [] ->
-               Sugar.cl_fun c.cmts ~will_keep_first_ast_node:false
+               Sugar.cl_fun c.conf c.cmts ~will_keep_first_ast_node:false
                  (sub_cl ~ctx cl.pci_expr)
            | _ -> ([], sub_cl ~ctx cl.pci_expr)
          in
@@ -4314,7 +4354,7 @@ and fmt_module_expr ?(dock_struct = true) c ({ast= m; _} as xmod) =
             ( hvbox 2
                 (wrap_fits_breaks ~space:false c.conf "(" ")"
                    ( str "val "
-                   $ fmt_expression c (sub_exp ~ctx e)
+                   $ fmt_expression c (sub_exp c.conf ~ctx e)
                    $ opt ty1 (fun x -> break 1 2 $ package_type ": " x)
                    $ opt ty2 (fun x -> break 1 2 $ package_type ":> " x) ) )
             $ fmt_attributes_and_docstrings c pmod_attributes ) }
@@ -4382,7 +4422,7 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
   | Pstr_eval (exp, atrs) ->
       let doc, atrs = doc_atrs atrs in
       fmt_docstring c doc
-      $ cbox 0 ~name:"eval" (fmt_expression c (sub_exp ~ctx exp))
+      $ cbox 0 ~name:"eval" (fmt_expression c (sub_exp c.conf ~ctx exp))
       $ fmt_item_attributes c ~pre:Space atrs
   | Pstr_exception extn_constr ->
       let pre = str "exception" $ fmt_extension_suffix c ext $ fmt "@ " in
@@ -4423,7 +4463,9 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
       let fmt_item c ctx ~prev ~next b =
         let first = Option.is_none prev in
         let last = Option.is_none next in
-        let b = Sugar.Let_binding.of_let_binding c.cmts ~ctx ~first b in
+        let b =
+          Sugar.Let_binding.of_let_binding c.conf c.cmts ~ctx ~first b
+        in
         let epi =
           match c.conf.fmt_opts.let_binding_spacing.v with
           | `Compact -> None
@@ -4723,7 +4765,7 @@ let fmt_file (type a) ~ctx ~fmt_code ~debug (fragment : a Extended_ast.t)
       compose_module ~f:Fn.id
         (fmt_module_type c (sub_mty ~ctx:(Mty mty) mty))
   | Expression, e ->
-      fmt_expression c (sub_exp ~ctx:(Str (Ast_helper.Str.eval e)) e)
+      fmt_expression c (sub_exp c.conf ~ctx:(Str (Ast_helper.Str.eval e)) e)
   | Repl_file, l -> fmt_repl_file c ctx l
   | Documentation, d -> Fmt_odoc.fmt ~fmt_code:(c.fmt_code c.conf) d
 

--- a/lib/Normalize_extended_ast.mli
+++ b/lib/Normalize_extended_ast.mli
@@ -9,8 +9,6 @@
 (*                                                                        *)
 (**************************************************************************)
 
-val ast : 'a Extended_ast.t -> ignore_doc_comments:bool -> Conf.t -> 'a -> 'a
-
 val dedup_cmts : 'a Extended_ast.t -> 'a -> Cmt.t list -> Cmt.t list
 (** Remove comments that duplicate docstrings (or other comments). *)
 

--- a/lib/Normalize_extended_ast.mli
+++ b/lib/Normalize_extended_ast.mli
@@ -9,6 +9,8 @@
 (*                                                                        *)
 (**************************************************************************)
 
+val ast : 'a Extended_ast.t -> ignore_doc_comments:bool -> Conf.t -> 'a -> 'a
+
 val dedup_cmts : 'a Extended_ast.t -> 'a -> Cmt.t list -> Cmt.t list
 (** Remove comments that duplicate docstrings (or other comments). *)
 

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -14,10 +14,11 @@ open Asttypes
 open Ast
 open Extended_ast
 
-let check_local_attr attrs =
+let check_local_attr conf attrs =
   match
     List.partition_tf attrs ~f:(fun attr ->
-        String.equal attr.attr_name.txt "extension.local" )
+        Conf.is_jane_street_local_annotation conf "local"
+          ~test:attr.attr_name.txt )
   with
   | [], _ -> (attrs, false)
   | _ :: _, rest -> (rest, true)
@@ -29,16 +30,16 @@ let check_local_attr attrs =
    this to pass some internal ocamlformat sanity checks. It's not the
    cleanest solution in a vacuum, but is perhaps the one that will cause the
    fewest merge conflicts in the future. *)
-let decompose_arrow ctx ctl ct2 =
+let decompose_arrow conf ctx ctl ct2 =
   let pull_out_local ap =
     let ptyp_attributes, local =
-      check_local_attr ap.pap_type.ptyp_attributes
+      check_local_attr conf ap.pap_type.ptyp_attributes
     in
     ({ap with pap_type= {ap.pap_type with ptyp_attributes}}, local)
   in
   let args = List.map ~f:pull_out_local ctl in
   let ((res_ap, _) as res) =
-    let ptyp_attributes, local = check_local_attr ct2.ptyp_attributes in
+    let ptyp_attributes, local = check_local_attr conf ct2.ptyp_attributes in
     let ap =
       { pap_label= Nolabel
       ; pap_loc= ct2.ptyp_loc
@@ -58,7 +59,7 @@ type arg_kind =
   | Val of bool * arg_label * pattern xt * expression xt option
   | Newtypes of string loc list
 
-let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
+let fun_ conf cmts ?(will_keep_first_ast_node = true) xexp =
   let rec fun_ ?(will_keep_first_ast_node = false) ({ast= exp; _} as xexp) =
     let ctx = Exp exp in
     let {pexp_desc; pexp_loc; pexp_attributes; _} = exp in
@@ -68,9 +69,9 @@ let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
           if not will_keep_first_ast_node then
             Cmts.relocate cmts ~src:pexp_loc ~before:pattern.ppat_loc
               ~after:body.pexp_loc ;
-          let xargs, xbody = fun_ (sub_exp ~ctx body) in
+          let xargs, xbody = fun_ (sub_exp conf ~ctx body) in
           let islocal, pat =
-            match check_local_attr pattern.ppat_attributes with
+            match check_local_attr conf pattern.ppat_attributes with
             | _, false -> (false, sub_pat ~ctx pattern)
             | ppat_attributes, true ->
                 let pattern = {pattern with ppat_attributes} in
@@ -81,14 +82,15 @@ let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
                 in
                 (true, sub_pat ~ctx pattern)
           in
-          ( Val (islocal, label, pat, Option.map default ~f:(sub_exp ~ctx))
+          ( Val
+              (islocal, label, pat, Option.map default ~f:(sub_exp conf ~ctx))
             :: xargs
           , xbody )
       | Pexp_newtype (name, body) ->
           if not will_keep_first_ast_node then
             Cmts.relocate cmts ~src:pexp_loc ~before:body.pexp_loc
               ~after:body.pexp_loc ;
-          let xargs, xbody = fun_ (sub_exp ~ctx body) in
+          let xargs, xbody = fun_ (sub_exp conf ~ctx body) in
           let xargs =
             match xargs with
             | Newtypes names :: xargs -> Newtypes (name :: names) :: xargs
@@ -100,7 +102,7 @@ let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
   in
   fun_ ~will_keep_first_ast_node xexp
 
-let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
+let cl_fun ?(will_keep_first_ast_node = true) conf cmts xexp =
   let rec fun_ ?(will_keep_first_ast_node = false) ({ast= exp; _} as xexp) =
     let ctx = Cl exp in
     let {pcl_desc; pcl_loc; pcl_attributes; _} = exp in
@@ -112,7 +114,7 @@ let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
               ~after:body.pcl_loc ;
           let xargs, xbody = fun_ (sub_cl ~ctx body) in
           let islocal, pat =
-            match check_local_attr pattern.ppat_attributes with
+            match check_local_attr conf pattern.ppat_attributes with
             | _, false -> (false, sub_pat ~ctx pattern)
             | ppat_attributes, true ->
                 let pattern = {pattern with ppat_attributes} in
@@ -123,7 +125,8 @@ let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
                 in
                 (true, sub_pat ~ctx pattern)
           in
-          ( Val (islocal, label, pat, Option.map default ~f:(sub_exp ~ctx))
+          ( Val
+              (islocal, label, pat, Option.map default ~f:(sub_exp conf ~ctx))
             :: xargs
           , xbody )
       | _ -> ([], xexp)
@@ -132,7 +135,7 @@ let cl_fun ?(will_keep_first_ast_node = true) cmts xexp =
   fun_ ~will_keep_first_ast_node xexp
 
 module Exp = struct
-  let infix cmts prec xexp =
+  let infix conf cmts prec xexp =
     let assoc = Option.value_map prec ~default:Assoc.Non ~f:Assoc.of_prec in
     let rec infix_ ?(relocate = true) xop xexp =
       let ctx = Exp xexp.ast in
@@ -141,7 +144,7 @@ module Exp = struct
         , {pexp_desc= Pexp_infix ({txt= op; loc}, e1, e2); pexp_loc= src; _}
         )
         when Option.equal Prec.equal prec (prec_ast ctx) ->
-          let op_args1 = infix_ None (sub_exp ~ctx e1) in
+          let op_args1 = infix_ None (sub_exp conf ~ctx e1) in
           let before =
             match op_args1 with
             | (Some {loc; _}, _) :: _ -> loc
@@ -149,12 +152,14 @@ module Exp = struct
             | _ -> loc
           in
           if relocate then Cmts.relocate cmts ~src ~before ~after:e2.pexp_loc ;
-          op_args1 @ [(Some {txt= op; loc}, sub_exp ~ctx e2)]
+          op_args1 @ [(Some {txt= op; loc}, sub_exp conf ~ctx e2)]
       | ( Right
         , {pexp_desc= Pexp_infix ({txt= op; loc}, e1, e2); pexp_loc= src; _}
         )
         when Option.equal Prec.equal prec (prec_ast ctx) ->
-          let op_args2 = infix_ (Some {txt= op; loc}) (sub_exp ~ctx e2) in
+          let op_args2 =
+            infix_ (Some {txt= op; loc}) (sub_exp conf ~ctx e2)
+          in
           let before =
             match xop with Some op -> op.loc | None -> e1.pexp_loc
           in
@@ -164,13 +169,13 @@ module Exp = struct
             | None -> e1.pexp_loc
           in
           if relocate then Cmts.relocate cmts ~src ~before ~after ;
-          (xop, sub_exp ~ctx e1) :: op_args2
+          (xop, sub_exp conf ~ctx e1) :: op_args2
       | _ -> [(xop, xexp)]
     in
     infix_ None ~relocate:false xexp
 end
 
-let sequence cmts xexp =
+let sequence conf cmts xexp =
   let rec sequence_ ?(allow_attribute = true) ({ast= exp; _} as xexp) =
     let ctx = Exp exp in
     let {pexp_desc; pexp_loc; _} = exp in
@@ -195,12 +200,16 @@ let sequence cmts xexp =
             ~after:e2.pexp_loc ;
           Cmts.relocate cmts ~src:pexp_loc ~before:e1.pexp_loc
             ~after:e2.pexp_loc ;
-          if Ast.exposed_right_exp Ast.Let_match e1 then
-            [(None, sub_exp ~ctx e1); (Some ext, sub_exp ~ctx e2)]
+          if Ast.exposed_right_exp conf Ast.Let_match e1 then
+            [(None, sub_exp conf ~ctx e1); (Some ext, sub_exp conf ~ctx e2)]
           else
-            let l1 = sequence_ ~allow_attribute:false (sub_exp ~ctx e1) in
+            let l1 =
+              sequence_ ~allow_attribute:false (sub_exp conf ~ctx e1)
+            in
             let l2 =
-              match sequence_ ~allow_attribute:false (sub_exp ~ctx e2) with
+              match
+                sequence_ ~allow_attribute:false (sub_exp conf ~ctx e2)
+              with
               | [] -> []
               | (_, e2) :: l2 -> (Some ext, e2) :: l2
             in
@@ -211,12 +220,12 @@ let sequence cmts xexp =
         else (
           Cmts.relocate cmts ~src:pexp_loc ~before:e1.pexp_loc
             ~after:e2.pexp_loc ;
-          if Ast.exposed_right_exp Ast.Let_match e1 then
-            [(None, sub_exp ~ctx e1); (None, sub_exp ~ctx e2)]
+          if Ast.exposed_right_exp conf Ast.Let_match e1 then
+            [(None, sub_exp conf ~ctx e1); (None, sub_exp conf ~ctx e2)]
           else
             List.append
-              (sequence_ ~allow_attribute:false (sub_exp ~ctx e1))
-              (sequence_ ~allow_attribute:false (sub_exp ~ctx e2)) )
+              (sequence_ ~allow_attribute:false (sub_exp conf ~ctx e1))
+              (sequence_ ~allow_attribute:false (sub_exp conf ~ctx e2)) )
     | _ -> [(None, xexp)]
   in
   sequence_ xexp
@@ -268,16 +277,16 @@ let mod_with pmty =
   let l_rev, m = mod_with_ pmty in
   (List.rev l_rev, m)
 
-let rec polynewtype_ cmts pvars body relocs =
+let rec polynewtype_ conf cmts pvars body relocs =
   let ctx = Exp body in
   match (pvars, body.pexp_desc) with
   | [], Pexp_constraint (exp, typ) ->
       let relocs = (body.pexp_loc, exp.pexp_loc) :: relocs in
-      Some (sub_typ ~ctx typ, sub_exp ~ctx exp, relocs)
+      Some (sub_typ ~ctx typ, sub_exp conf ~ctx exp, relocs)
   | pvar :: pvars, Pexp_newtype (nvar, exp)
     when String.equal pvar.txt nvar.txt ->
       let relocs = (nvar.loc, pvar.loc) :: relocs in
-      polynewtype_ cmts pvars exp relocs
+      polynewtype_ conf cmts pvars exp relocs
   | _ -> None
 
 (** [polynewtype cmts pat exp] returns expression of a type-constrained
@@ -292,11 +301,13 @@ let rec polynewtype_ cmts pvars body relocs =
     {[
       let f : type r s. r s t = e
     ]} *)
-let polynewtype cmts pat body =
+let polynewtype conf cmts pat body =
   let ctx = Pat pat in
   match pat.ppat_desc with
   | Ppat_constraint (pat2, {ptyp_desc= Ptyp_poly (pvars, _); _}) -> (
-    match polynewtype_ cmts pvars body [(pat.ppat_loc, pat2.ppat_loc)] with
+    match
+      polynewtype_ conf cmts pvars body [(pat.ppat_loc, pat2.ppat_loc)]
+    with
     | Some (typ, exp, relocs) ->
         List.iter relocs ~f:(fun (src, dst) ->
             Cmts.relocate cmts ~src ~before:dst ~after:dst ) ;
@@ -342,34 +353,38 @@ module Let_binding = struct
 
         let (x : string) = local_ "hi" (* Don't surgar *)
       ]} *)
-  let local_pattern_can_be_sugared ~body_loc lb_pat =
+  let local_pattern_can_be_sugared conf ~body_loc lb_pat =
     match lb_pat.ppat_desc with
     | Ppat_var _ -> true
     | Ppat_constraint (_, {ptyp_desc= Ptyp_poly (_ :: _, _); _}) ->
-        snd (check_local_attr lb_pat.ppat_attributes)
+        snd (check_local_attr conf lb_pat.ppat_attributes)
     | Ppat_constraint ({ppat_desc= Ppat_var _; ppat_loc= constr_loc; _}, _)
       ->
         Location.compare_start body_loc constr_loc < 0
     | _ -> false
 
-  let type_cstr cmts ~ctx lb_pat lb_exp lb_is_pun =
+  let type_cstr conf cmts ~ctx lb_pat lb_exp lb_is_pun =
     let is_local_pattern, ctx, lb_pat, lb_exp =
       match lb_exp.pexp_desc with
       | Pexp_apply
-          ( { pexp_desc= Pexp_extension ({txt= "extension.local"; _}, PStr [])
+          ( { pexp_desc= Pexp_extension ({txt= extension_local; _}, PStr [])
             ; _ }
-          , [(Nolabel, sbody)] ) ->
+          , [(Nolabel, sbody)] )
+        when Conf.is_jane_street_local_annotation conf "local"
+               ~test:extension_local ->
           let is_local_pattern, sbody =
             (* The pattern part must still be rewritten as the parser
                duplicated the type annotations and extensions into the
                pattern and the expression. *)
-            if local_pattern_can_be_sugared ~body_loc:sbody.pexp_loc lb_pat
+            if
+              local_pattern_can_be_sugared conf ~body_loc:sbody.pexp_loc
+                lb_pat
             then
-              let sattrs, _ = check_local_attr sbody.pexp_attributes in
+              let sattrs, _ = check_local_attr conf sbody.pexp_attributes in
               (true, {sbody with pexp_attributes= sattrs})
             else (false, lb_exp)
           in
-          let pattrs, _ = check_local_attr lb_pat.ppat_attributes in
+          let pattrs, _ = check_local_attr conf lb_pat.ppat_attributes in
           let pat = {lb_pat with ppat_attributes= pattrs} in
           let fake_ctx =
             Lb
@@ -382,8 +397,8 @@ module Let_binding = struct
           ( is_local_pattern
           , fake_ctx
           , sub_pat ~ctx:fake_ctx pat
-          , sub_exp ~ctx:fake_ctx sbody )
-      | _ -> (false, ctx, sub_pat ~ctx lb_pat, sub_exp ~ctx lb_exp)
+          , sub_exp conf ~ctx:fake_ctx sbody )
+      | _ -> (false, ctx, sub_pat ~ctx lb_pat, sub_exp conf ~ctx lb_exp)
     in
     let ({ast= pat; _} as xpat) =
       match (lb_pat.ast.ppat_desc, lb_exp.ast.pexp_desc) with
@@ -409,14 +424,14 @@ module Let_binding = struct
     let pat_is_extension {ppat_desc; _} =
       match ppat_desc with Ppat_extension _ -> true | _ -> false
     in
-    let ({ast= body; _} as xbody) = sub_exp ~ctx lb_exp.ast in
+    let ({ast= body; _} as xbody) = sub_exp conf ~ctx lb_exp.ast in
     let pat, typ, exp =
       if
         (not (List.is_empty xbody.ast.pexp_attributes))
         || pat_is_extension pat
       then (xpat, `None [], xbody)
       else
-        match polynewtype cmts pat body with
+        match polynewtype conf cmts pat body with
         | Some (xpat, pvars, xtyp, xbody) ->
             (xpat, `Polynewtype (pvars, xtyp), xbody)
         | None -> (
@@ -429,7 +444,7 @@ module Let_binding = struct
             let xargs, ({ast= body; _} as xbody) =
               match pat with
               | {ppat_desc= Ppat_var _; ppat_attributes= []; _} ->
-                  fun_ cmts ~will_keep_first_ast_node:false xbody
+                  fun_ conf cmts ~will_keep_first_ast_node:false xbody
               | _ -> ([], xbody)
             in
             let ctx = Exp body in
@@ -451,27 +466,31 @@ module Let_binding = struct
                 in
                 ( xpat
                 , `Other (xargs, sub_typ ~ctx:typ_ctx typ)
-                , sub_exp ~ctx:exp_ctx exp )
+                , sub_exp conf ~ctx:exp_ctx exp )
             (* The type constraint is always printed before the declaration
                for functions, for other value bindings we preserve its
                position. *)
             | Pexp_constraint (exp, typ), _ when not (List.is_empty xargs) ->
                 Cmts.relocate cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
-                (xpat, `Other (xargs, sub_typ ~ctx typ), sub_exp ~ctx exp)
+                ( xpat
+                , `Other (xargs, sub_typ ~ctx typ)
+                , sub_exp conf ~ctx exp )
             | Pexp_coerce (exp, typ1, typ2), _
               when Source.type_constraint_is_first typ2 exp.pexp_loc ->
                 Cmts.relocate cmts ~src:body.pexp_loc ~before:exp.pexp_loc
                   ~after:exp.pexp_loc ;
                 let typ1 = Option.map typ1 ~f:(sub_typ ~ctx) in
-                (xpat, `Coerce (typ1, sub_typ ~ctx typ2), sub_exp ~ctx exp)
+                ( xpat
+                , `Coerce (typ1, sub_typ ~ctx typ2)
+                , sub_exp conf ~ctx exp )
             | _ -> (xpat, `None xargs, xbody) )
     in
     (is_local_pattern, pat, typ, exp)
 
-  let of_let_binding cmts ~ctx ~first lb =
+  let of_let_binding conf cmts ~ctx ~first lb =
     let islocal, pat, typ, exp =
-      type_cstr cmts ~ctx lb.lb_pattern lb.lb_expression lb.lb_is_pun
+      type_cstr conf cmts ~ctx lb.lb_pattern lb.lb_expression lb.lb_is_pun
     in
     { lb_op= Location.{txt= (if first then "let" else "and"); loc= none}
     ; lb_pat= pat
@@ -482,13 +501,13 @@ module Let_binding = struct
     ; lb_local= islocal
     ; lb_loc= lb.lb_loc }
 
-  let of_let_bindings cmts ~ctx =
-    List.mapi ~f:(fun i -> of_let_binding cmts ~ctx ~first:(i = 0))
+  let of_let_bindings conf cmts ~ctx =
+    List.mapi ~f:(fun i -> of_let_binding conf cmts ~ctx ~first:(i = 0))
 
-  let of_binding_ops cmts ~ctx bos =
+  let of_binding_ops conf cmts ~ctx bos =
     List.map bos ~f:(fun bo ->
         let islocal, pat, typ, exp =
-          type_cstr cmts ~ctx bo.pbop_pat bo.pbop_exp false
+          type_cstr conf cmts ~ctx bo.pbop_pat bo.pbop_exp false
         in
         { lb_op= bo.pbop_op
         ; lb_pat= pat

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -14,7 +14,11 @@ open Asttypes
 open Extended_ast
 
 val decompose_arrow :
-  Ast.t -> arrow_param list -> core_type -> (arrow_param * bool) list * Ast.t
+     Conf.t
+  -> Ast.t
+  -> arrow_param list
+  -> core_type
+  -> (arrow_param * bool) list * Ast.t
 (** [decompose_arrow ctl ct2] returns a list of arrow params, where the last
     is a dummy param corresponding to ct2 (the return type) and a bool
     indicating the presence of a local attribute (which has been removed).
@@ -26,38 +30,44 @@ type arg_kind =
   | Newtypes of string loc list
 
 val fun_ :
-     Cmts.t
+     Conf.t
+  -> Cmts.t
   -> ?will_keep_first_ast_node:bool
   -> expression Ast.xt
   -> arg_kind list * expression Ast.xt
-(** [fun_ cmts will_keep_first_ast_node exp] returns the list of arguments
-    and the body of the function [exp]. [will_keep_first_ast_node] is set by
-    default, otherwise the [exp] is returned without modification. *)
+(** [fun_ conf cmts will_keep_first_ast_node exp] returns the list of
+    arguments and the body of the function [exp]. [will_keep_first_ast_node]
+    is set by default, otherwise the [exp] is returned without modification. *)
 
 val cl_fun :
      ?will_keep_first_ast_node:bool
+  -> Conf.t
   -> Cmts.t
   -> class_expr Ast.xt
   -> arg_kind list * class_expr Ast.xt
-(** [cl_fun will_keep_first_ast_node cmts exp] returns the list of arguments
-    and the body of the function [exp]. [will_keep_first_ast_node] is set by
-    default, otherwise the [exp] is returned without modification. *)
+(** [cl_fun conf will_keep_first_ast_node cmts exp] returns the list of
+    arguments and the body of the function [exp]. [will_keep_first_ast_node]
+    is set by default, otherwise the [exp] is returned without modification. *)
 
 module Exp : sig
   val infix :
-       Cmts.t
+       Conf.t
+    -> Cmts.t
     -> Prec.t option
     -> expression Ast.xt
     -> (string loc option * expression Ast.xt) list
-  (** [infix cmts prec exp] returns the infix operator and the list of
+  (** [infix conf cmts prec exp] returns the infix operator and the list of
       operands applied to this operator from expression [exp]. [prec] is the
       precedence of the infix operator. *)
 end
 
 val sequence :
-  Cmts.t -> expression Ast.xt -> (label loc option * expression Ast.xt) list
-(** [sequence cmts exp] returns the list of expressions (with the optional
-    extension) from a sequence of expressions [exp]. *)
+     Conf.t
+  -> Cmts.t
+  -> expression Ast.xt
+  -> (label loc option * expression Ast.xt) list
+(** [sequence conf cmts exp] returns the list of expressions (with the
+    optional extension) from a sequence of expressions [exp]. *)
 
 val functor_type :
      Cmts.t
@@ -101,9 +111,12 @@ module Let_binding : sig
     ; lb_local: bool
     ; lb_loc: Location.t }
 
-  val of_let_binding : Cmts.t -> ctx:Ast.t -> first:bool -> let_binding -> t
+  val of_let_binding :
+    Conf.t -> Cmts.t -> ctx:Ast.t -> first:bool -> let_binding -> t
 
-  val of_let_bindings : Cmts.t -> ctx:Ast.t -> let_binding list -> t list
+  val of_let_bindings :
+    Conf.t -> Cmts.t -> ctx:Ast.t -> let_binding list -> t list
 
-  val of_binding_ops : Cmts.t -> ctx:Ast.t -> binding_op list -> t list
+  val of_binding_ops :
+    Conf.t -> Cmts.t -> ctx:Ast.t -> binding_op list -> t list
 end

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -32,7 +32,8 @@ type t =
   ; ignore_invalid_options: bool
   ; ocp_indent_config: bool
   ; config: (string * string) list
-  ; erase_jane_syntax: bool }
+  ; erase_jane_syntax: bool
+  ; rewrite_old_style_jane_street_local_annotations: bool }
 
 let default =
   { lib_conf= Conf.default
@@ -50,7 +51,8 @@ let default =
   ; ignore_invalid_options= false
   ; ocp_indent_config= false
   ; config= []
-  ; erase_jane_syntax= false }
+  ; erase_jane_syntax= false
+  ; rewrite_old_style_jane_street_local_annotations= false }
 
 let global_conf = ref default
 

--- a/ocamlformat-help.txt
+++ b/ocamlformat-help.txt
@@ -600,6 +600,9 @@ OPTIONS
        --no-quiet
            Unset quiet.
 
+       --no-rewrite-old-style-jane-street-local-annotations
+           Unset rewrite-old-style-jane-street-local-annotations.
+
        --no-version-check
            Unset version-check.
 
@@ -644,6 +647,12 @@ OPTIONS
 
        --repl-file
            Parse input as toplevel phrases with their output.
+
+       --rewrite-old-style-jane-street-local-annotations
+           Rewrite all Jane Street annotations for use with the local mode,
+           such as "[%local]" or "[@ocaml.global]", into their pretty-printed
+           syntactic form, such as "local_" or "global_". THIS OPTION WILL
+           CHANGE THE RESULTING AST. The flag is unset by default.
 
        --root=DIR
            Root of the project. If specified, only take into account

--- a/test/cli/print_config.t
+++ b/test/cli/print_config.t
@@ -15,6 +15,7 @@ No redundant values:
   range=<whole input>
   disable-conf-attrs=false
   version-check=true
+  rewrite-old-style-jane-street-local-annotations=false
   assignment-operator=end-line (profile conventional (file .ocamlformat:1))
   break-before-in=fit-or-vertical (profile conventional (file .ocamlformat:1))
   break-cases=fit (profile conventional (file .ocamlformat:1))
@@ -94,6 +95,7 @@ Redundant values from the conventional profile:
   range=<whole input>
   disable-conf-attrs=false
   version-check=true
+  rewrite-old-style-jane-street-local-annotations=false
   assignment-operator=end-line (profile conventional (file .ocamlformat:1))
   break-before-in=fit-or-vertical (profile conventional (file .ocamlformat:1))
   break-cases=fit (profile conventional (file .ocamlformat:1))
@@ -173,6 +175,7 @@ Redundant values from the ocamlformat profile:
   range=<whole input>
   disable-conf-attrs=false
   version-check=true
+  rewrite-old-style-jane-street-local-annotations=false
   assignment-operator=end-line (profile ocamlformat (file .ocamlformat:1))
   break-before-in=fit-or-vertical (profile ocamlformat (file .ocamlformat:1))
   break-cases=nested (profile ocamlformat (file .ocamlformat:1))

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3721,6 +3721,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to local-rewritten.ml.stdout
+   (with-stderr-to local-rewritten.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --rewrite-old-style-jane-street-local-annotations %{dep:tests/local.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local-rewritten.ml.ref local-rewritten.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local-rewritten.ml.err local-rewritten.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to local.ml.stdout
    (with-stderr-to local.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/local.ml})))))

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -30,8 +30,6 @@ type 'a r = Foo of 'a | Bar of 'a * 'a | Baz of int * string * 'a
 
 type ('a, 'b) cfn = a:'a -> ?b:b -> 'a -> int -> 'b
 
-type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
-
 let _ = ()
 
 let _ = ()
@@ -63,3 +61,47 @@ let x : 'a. 'a -> 'a = "hi"
 let x : 'a. 'a -> 'a = "hi"
 
 let f : 'a. 'a -> 'a = "hi"
+
+let foo () =
+  if true then () ;
+  ()
+
+type loc_long_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+type loc_short_attrs = (string[@local]) -> (string[@local])
+
+type global_long_attrs =
+  | Foo of {s: string [@ocaml.global]}
+  | Bar of (string[@ocaml.global])
+
+type global_short_attrs =
+  | Foo of {s: string [@global]}
+  | Bar of (string[@global])
+
+type global_short_attrs =
+  | Foo of {s: string [@global]}
+  | Bar of (string[@global])
+
+let local_long_ext = [%ocaml.local] ()
+
+let local_short_ext = [%local] ()
+
+let exclave_long_ext = [%ocaml.exclave] ()
+
+let exclave_short_ext = [%exclave] ()
+
+let[@ocaml.local] upstream_local_attr_long x = x
+
+let[@ocaml.local never] upstream_local_attr_never_long x = x
+
+let[@ocaml.local always] upstream_local_attr_always_long x = x
+
+let[@ocaml.local maybe] upstream_local_attr_maybe_long x = x
+
+let[@local] upstream_local_attr_short x = x
+
+let[@local never] upstream_local_attr_never_short x = x
+
+let[@local always] upstream_local_attr_always_short x = x
+
+let[@local maybe] upstream_local_attr_maybe_short x = x

--- a/test/passing/tests/local-rewritten.ml.opts
+++ b/test/passing/tests/local-rewritten.ml.opts
@@ -1,0 +1,1 @@
+--rewrite-old-style-jane-street-local-annotations

--- a/test/passing/tests/local-rewritten.ml.ref
+++ b/test/passing/tests/local-rewritten.ml.ref
@@ -70,29 +70,27 @@ let foo () =
   if true then (local_ ()) ;
   ()
 
-type loc_long_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+type loc_long_attrs = local_ string -> local_ string
 
-type loc_short_attrs = (string[@local]) -> (string[@local])
+type loc_short_attrs = local_ string -> local_ string
 
-type global_long_attrs =
-  | Foo of {s: string [@ocaml.global]}
-  | Bar of (string[@ocaml.global])
+type global_long_attrs = Foo of {global_ s: string} | Bar of global_ string
 
 type global_short_attrs =
-  | Foo of {s: string [@global]}
-  | Bar of (string[@global])
+  | Foo of {global_ s: string}
+  | Bar of global_ string
 
 type global_short_attrs =
-  | Foo of {s: string [@global]}
-  | Bar of (string[@global])
+  | Foo of {global_ s: string}
+  | Bar of global_ string
 
-let local_long_ext = [%ocaml.local] ()
+let local_ local_long_ext = ()
 
-let local_short_ext = [%local] ()
+let local_ local_short_ext = ()
 
-let exclave_long_ext = [%ocaml.exclave] ()
+let exclave_long_ext = exclave_ ()
 
-let exclave_short_ext = [%exclave] ()
+let exclave_short_ext = exclave_ ()
 
 let[@ocaml.local] upstream_local_attr_long x = x
 

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -34,8 +34,6 @@ type 'a r =
 type ('a, 'b) cfn =
   a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
 
-type loc_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
-
 let _ = local_ ()
 
 let _ = exclave_ ()
@@ -67,3 +65,43 @@ let local_ f : 'a. 'a -> 'a = "hi"
 let foo () =
   if true then (local_ ());
   ()
+
+type loc_long_attrs = (string[@ocaml.local]) -> (string[@ocaml.local])
+
+type loc_short_attrs = (string[@local]) -> (string[@local])
+
+type global_long_attrs =
+  | Foo of { s : string[@ocaml.global] }
+  | Bar of (string[@ocaml.global])
+
+type global_short_attrs =
+  | Foo of { s : string[@global] }
+  | Bar of (string[@global])
+
+type global_short_attrs =
+  | Foo of { s : string[@global] }
+  | Bar of (string[@global])
+
+let local_long_ext = [%ocaml.local] ()
+
+let local_short_ext = [%local] ()
+
+let exclave_long_ext = [%ocaml.exclave] ()
+
+let exclave_short_ext = [%exclave] ()
+
+let[@ocaml.local] upstream_local_attr_long x = x
+
+let[@ocaml.local never] upstream_local_attr_never_long x = x
+
+let[@ocaml.local always] upstream_local_attr_always_long x = x
+
+let[@ocaml.local maybe] upstream_local_attr_maybe_long x = x
+
+let[@local] upstream_local_attr_short x = x
+
+let[@local never] upstream_local_attr_never_short x = x
+
+let[@local always] upstream_local_attr_always_short x = x
+
+let[@local maybe] upstream_local_attr_maybe_short x = x

--- a/test/passing/tests/print_config.ml.err
+++ b/test/passing/tests/print_config.ml.err
@@ -8,6 +8,7 @@ quiet=false
 range=<whole input>
 disable-conf-attrs=false
 version-check=true
+rewrite-old-style-jane-street-local-annotations=false
 assignment-operator=end-line (profile ocamlformat (file tests/.ocamlformat:1))
 break-before-in=fit-or-vertical (profile ocamlformat (file tests/.ocamlformat:1))
 break-cases=fit (file tests/.ocamlformat:2)

--- a/test/passing/tests/verbose1.ml.err
+++ b/test/passing/tests/verbose1.ml.err
@@ -8,6 +8,7 @@ quiet=false
 range=<whole input>
 disable-conf-attrs=false
 version-check=true
+rewrite-old-style-jane-street-local-annotations=false
 assignment-operator=end-line (profile ocamlformat (file tests/.ocamlformat:1))
 break-before-in=fit-or-vertical (profile ocamlformat (file tests/.ocamlformat:1))
 break-cases=fit (file tests/.ocamlformat:2)


### PR DESCRIPTION
This is enabled by the option `--rewrite-old-style-jane-street-local-annotations`, which is off by default; @ceastlund, I defer to you on if we want to enable it by default or do so in some configurations or just do that as we need it internally.

Also, be aware that this is on top of #37; we don't actually want to merge this until we've merged #37, but we can get it reviewed first.  This means if you're reviewing this PR, skip the first commit (e6b2e26) and review changes from the rest; we've already reviewed up to the contents of e6b2e26 in #32.