### PR TITLE
In an if-then with no else, the body should have parens if local_

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2120,6 +2120,13 @@ end = struct
         | Pexp_function cases | Pexp_match (_, cases) | Pexp_try (_, cases)
           ->
             continue (List.last_exn cases).pc_rhs
+        | Pexp_apply
+            ( { pexp_desc=
+                  Pexp_extension ({txt= "extension.local"; _}, PStr [])
+              ; _ }
+            , [(Nolabel, _)] )
+          when match cls with Then -> true | _ -> false ->
+            true
         | Pexp_apply (_, args) -> continue (snd (List.last_exn args))
         | Pexp_tuple es -> continue (List.last_exn es)
         | Pexp_array _ | Pexp_list _ | Pexp_coerce _ | Pexp_constant _

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -63,3 +63,7 @@ let x = exclave_ ("hi" : string)
 let x : 'a . 'a -> 'a = local_ "hi"
 let x : 'a . 'a -> 'a = exclave_ "hi"
 let local_ f : 'a. 'a -> 'a = "hi"
+
+let foo () =
+  if true then (local_ ());
+  ()

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -67,3 +67,7 @@ let x : 'a. 'a -> 'a = local_ "hi"
 let x : 'a. 'a -> 'a = exclave_ "hi"
 
 let local_ f : 'a. 'a -> 'a = "hi"
+
+let foo () =
+  if true then (local_ ()) ;
+  ()


### PR DESCRIPTION
This code:
```ocaml
let foo () =
  if true then (local_ ()); ()
```
Was being misformatted as:
```ocaml
let foo () =
  if true then local_ (); ()
```
tripping the round-trip check.

Now we keep the parens.

(It's hard to do this only if the `if` is to the left of a semi-colon.  So, instead, this PR just always parenthesizes the `then` branch of an `if` with no `else` when it begins with `local_`.  These parens would be unnecessary if it is not followed by a semicolon, but I believe this should approximately never happen in real code.)