### PR TITLE
Fix bug caused by comments before local_ at the beginning of bindings.

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1426,9 +1426,12 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
           ( { pexp_desc= Pexp_extension ({txt= extension_local; _}, PStr [])
             ; _ }
           , [(Nolabel, sbody)] )
+    ; pexp_loc
     ; _ }
     when Conf.is_jane_street_local_annotation c.conf "local"
-           ~test:extension_local ->
+           ~test:extension_local
+         (* Don't wipe away comments before [local_]. *)
+         && not (Cmts.has_before c.cmts pexp_loc) ->
       ( fmt " local_"
       , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp c.conf ~ctx sbody)
       )
@@ -1437,9 +1440,12 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
           ( { pexp_desc= Pexp_extension ({txt= extension_exclave; _}, PStr [])
             ; _ }
           , [(Nolabel, sbody)] )
+    ; pexp_loc
     ; _ }
     when Conf.is_jane_street_local_annotation c.conf "exclave"
-           ~test:extension_exclave ->
+           ~test:extension_exclave
+         (* Don't wipe away comments before [exclave_]. *)
+         && not (Cmts.has_before c.cmts pexp_loc) ->
       ( fmt " exclave_"
       , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp c.conf ~ctx sbody)
       )

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -353,7 +353,10 @@ module Let_binding = struct
 
         let (x : string) = local_ "hi" (* Don't surgar *)
       ]} *)
-  let local_pattern_can_be_sugared conf ~body_loc lb_pat =
+  let local_pattern_can_be_sugared conf ~body_loc lb_pat exp_loc cmts =
+    (not (Cmts.has_before cmts exp_loc))
+    (* Don't wipe away comments before [local_]. *)
+    &&
     match lb_pat.ppat_desc with
     | Ppat_var _ -> true
     | Ppat_constraint (_, {ptyp_desc= Ptyp_poly (_ :: _, _); _}) ->
@@ -378,7 +381,7 @@ module Let_binding = struct
                pattern and the expression. *)
             if
               local_pattern_can_be_sugared conf ~body_loc:sbody.pexp_loc
-                lb_pat
+                lb_pat lb_exp.pexp_loc cmts
             then
               let sattrs, _ = check_local_attr conf sbody.pexp_attributes in
               (true, {sbody with pexp_attributes= sattrs})

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -105,3 +105,23 @@ let[@local never] upstream_local_attr_never_short x = x
 let[@local always] upstream_local_attr_always_short x = x
 
 let[@local maybe] upstream_local_attr_maybe_short x = x
+
+let f x =
+  (* a *)
+  let y = 1 in
+  x + y
+
+let f x =
+  (* a *)
+  let y = 1 in
+  x + y
+
+let x =
+  (* a *)
+  let y = 1 in
+  y
+
+let x =
+  (* a *)
+  let y = 1 in
+  y

--- a/test/passing/tests/local-rewritten.ml.ref
+++ b/test/passing/tests/local-rewritten.ml.ref
@@ -107,3 +107,27 @@ let[@local never] upstream_local_attr_never_short x = x
 let[@local always] upstream_local_attr_always_short x = x
 
 let[@local maybe] upstream_local_attr_maybe_short x = x
+
+let f x =
+  (* a *)
+  local_
+  let y = 1 in
+  x + y
+
+let f x =
+  (* a *)
+  exclave_
+  let y = 1 in
+  x + y
+
+let x =
+  (* a *)
+  local_
+  let y = 1 in
+  y
+
+let x =
+  (* a *)
+  exclave_
+  let y = 1 in
+  y

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -105,3 +105,19 @@ let[@local never] upstream_local_attr_never_short x = x
 let[@local always] upstream_local_attr_always_short x = x
 
 let[@local maybe] upstream_local_attr_maybe_short x = x
+
+let f x = (* a *) local_
+  let y = 1 in
+  x + y
+
+let f x = (* a *) exclave_
+  let y = 1 in
+  x + y
+
+let x = (* a *) local_
+  let y = 1 in
+  y
+
+let x = (* a *) exclave_
+  let y = 1 in
+  y

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -109,3 +109,27 @@ let[@local never] upstream_local_attr_never_short x = x
 let[@local always] upstream_local_attr_always_short x = x
 
 let[@local maybe] upstream_local_attr_maybe_short x = x
+
+let f x =
+  (* a *)
+  local_
+  let y = 1 in
+  x + y
+
+let f x =
+  (* a *)
+  exclave_
+  let y = 1 in
+  x + y
+
+let x =
+  (* a *)
+  local_
+  let y = 1 in
+  y
+
+let x =
+  (* a *)
+  exclave_
+  let y = 1 in
+  y


### PR DESCRIPTION
Comments that appear before `local_` in a value declaration were being dropped, causing a change to the AST (see added examples in [test/passing/tests/local.ml].

This was caused by two separate code paths, one for formatting `local_` and `exclave_` on the same line as the equal sign in a value declaration, and the other for translating to the `let local_ x =` syntax sugar.