### PR TITLE
Fix CI: do the format check before calling dune subst

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -37,13 +37,13 @@ jobs:
       - name: Opam dependencies
         run: opam install --deps-only -t .
 
+      - name: Self-formatting test
+        run: opam exec -- dune build @fmt
+
       - name: Build
         run: |
           opam exec -- dune subst
           opam exec -- dune build -p ocamlformat-lib,ocamlformat
-
-      - name: Self-formatting test
-        run: opam exec -- dune build @fmt
 
       - name: Runtest
         run: opam exec -- dune runtest


### PR DESCRIPTION
`dune subst` adds a version tag to `dune-project` which breaks the formatting check.