### PR TITLE
Enable CI on push to jane branch

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - jane
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - jane
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
The CI tests are not currently running on the jane branch. This PR fixes that.