### PR TITLE
Fix bug in parsing arrows caused by labeled tuple changes

### DIFF
--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3432,6 +3432,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to labeled_tuples_regressions.mli.stdout
+   (with-stderr-to labeled_tuples_regressions.mli.stderr
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --max-iters=3 %{dep:tests/labeled_tuples_regressions.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/labeled_tuples_regressions.mli labeled_tuples_regressions.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/labeled_tuples_regressions.mli.err labeled_tuples_regressions.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to labelled_args-414.ml.stdout
    (with-stderr-to labelled_args-414.ml.stderr
      (run %{bin:ocamlformat} --margin-check --ocaml-version=4.14.0 %{dep:tests/labelled_args.ml})))))

--- a/test/passing/tests/labeled_tuples_regressions.mli
+++ b/test/passing/tests/labeled_tuples_regressions.mli
@@ -1,0 +1,6 @@
+(* https://github.com/janestreet/ocamlformat/pull/49 *)
+val f
+  :  foo:int * very_long_type_name_so_we_get_multiple_lines
+  -> (* cmt *)
+     bar:('long_type_var_1, 'long_type_var_2) Long_module_name.t
+  -> additional_somewhat_long_type_name

--- a/test/passing/tests/labeled_tuples_regressions.mli.opts
+++ b/test/passing/tests/labeled_tuples_regressions.mli.opts
@@ -1,0 +1,2 @@
+--profile=janestreet
+--max-iters=3

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -3949,7 +3949,12 @@ strict_function_or_labeled_tuple_type:
              pap_type = mktyp_modes unique_local domain
            }
            in
-           Ptyp_arrow([arrow_type], codomain) }
+           let params, codomain =
+             match codomain.ptyp_attributes, codomain.ptyp_desc with
+             | [], Ptyp_arrow (params, codomain) -> params, codomain
+             | _, _ -> [], codomain
+           in
+           Ptyp_arrow(arrow_type :: params, codomain) }
     )
     { $1 }
   | mktyp(


### PR DESCRIPTION
The ocamlformat parser has a little special logic to collapse curried function types into multi-argument function types.  I missed this special logic while creating similar cases for the original labeled tuples PR, leading to a unintended diff.  This fixes the bug and adds a test.