### PR TITLE
A more comprehensive fix for comments on local syntax

### DIFF
--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -37,6 +37,10 @@ val relocate :
     locations) comments before [src] to [before] and comments after [src] to
     [after]. *)
 
+val relocate_all_to_after : t -> src:Location.t -> after:Location.t -> unit
+(** [relocate_all_to_after src after] moves (changes the association with
+    locations) comments before and after [src] all to after [after]. *)
+
 val relocate_wrongfully_attached_cmts :
   t -> Source.t -> Extended_ast.expression -> unit
 (** [relocate_wrongfully_attached_cmts] relocates wrongfully attached

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -888,7 +888,9 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_arrow (args, ret_typ) ->
       Cmts.relocate c.cmts ~src:ptyp_loc
         ~before:(List.hd_exn args).pap_type.ptyp_loc ~after:ret_typ.ptyp_loc ;
-      let args, ret_typ, ctx = Sugar.decompose_arrow ctx args ret_typ in
+      let args, ret_typ, ctx =
+        Sugar.decompose_arrow c.cmts ctx args ret_typ
+      in
       let indent =
         match pro with
         | Some pro when c.conf.fmt_opts.ocp_indent_compat.v ->
@@ -1394,7 +1396,9 @@ and fmt_pattern_extension ~ext:_ c ~pro:_ ~parens:_ ~box:_ ~ctx0 ~ctx
 
 and fmt_fun_args c args =
   let fmt_fun_arg (a : function_param) =
-    let a = {a with pparam_desc= Sugar.remove_local_attrs a.pparam_desc} in
+    let a =
+      {a with pparam_desc= Sugar.remove_local_attrs c.cmts a.pparam_desc}
+    in
     let ctx = Fp a in
     Cmts.fmt c a.pparam_loc
     @@
@@ -3710,7 +3714,7 @@ and fmt_label_declaration c ctx ?(last = false) decl =
   let global_attr_opt, atrs = split_global_flags_from_attrs atrs in
   ( match global_attr_opt with
   | Some attr ->
-      Cmts.relocate c.cmts ~src:attr.attr_loc ~before:pld_type.ptyp_loc
+      Cmts.relocate_all_to_after c.cmts ~src:attr.attr_loc
         ~after:pld_type.ptyp_loc
   | None -> () ) ;
   hovbox 0
@@ -3773,7 +3777,7 @@ and fmt_core_type_gf c ctx typ =
   let global_attr_opt, _ = split_global_flags_from_attrs ptyp_attributes in
   ( match global_attr_opt with
   | Some attr ->
-      Cmts.relocate c.cmts ~src:attr.attr_loc ~before:typ.ptyp_loc
+      Cmts.relocate_all_to_after c.cmts ~src:attr.attr_loc
         ~after:typ.ptyp_loc
   | None -> () ) ;
   fmt_if (Option.is_some global_attr_opt) "global_ "

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -14,7 +14,8 @@ open Asttypes
 open Extended_ast
 
 val decompose_arrow :
-     Ast.t
+     Cmts.t
+  -> Ast.t
   -> arrow_param list
   -> core_type
   -> (arrow_param * bool) list * (arrow_param * bool) * Ast.t
@@ -42,7 +43,7 @@ val cl_fun :
     and the body of the function [exp]. [will_keep_first_ast_node] is set by
     default, otherwise the [exp] is returned without modification. *)
 
-val remove_local_attrs : function_param_desc -> function_param_desc
+val remove_local_attrs : Cmts.t -> function_param_desc -> function_param_desc
 
 module Exp : sig
   val infix :

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -115,22 +115,30 @@ let[@local always] upstream_local_attr_always_short x = x
 
 let[@local maybe] upstream_local_attr_maybe_short x = x
 
-let f x = (* a *) local_
+let f x = (* a *) (* b *) local_ (* c *) (* d *)
   let y = 1 in
   x + y
 
-let f x = (* a *) exclave_
+let f x = (* a *) (* b *) exclave_ (* c *) (* d *)
   let y = 1 in
   x + y
 
-let x = (* a *) local_
+let x = (* a *) (* b *) local_ (* c *) (* d *)
   let y = 1 in
   y
 
-let x = (* a *) exclave_
+let x = (* a *) (* b *) exclave_ (* c *) (* d *)
   let y = 1 in
   y
 
 module type S = S -> S -> S
 (* this is here to make sure we pass the AST equality checks even when the
    extended AST is different *)
+
+let f ((* a *) (* b *)local_ (* c *) (* d *)a) ~foo:((* e *) (* f *)local_(* g *) (* h *) b) ?foo:(local_ c = 1) ~(local_ d) = ()
+type 'a r = {mutable a: 'a; b: 'a; (* a *) (* b *)global_ (* c *) (* d *)c: 'a}
+
+type 'a r =
+  | Foo of (* a *) (* b *)global_(* c *) (* d *) 'a
+  | Bar of 'a * (* e *) (* f *)global_ (* g *) (* h *)'a
+  | Baz of global_ int * string * (* i *) (* j *) global_ (* k *) (* l *)'a

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -124,28 +124,85 @@ let[@local maybe] upstream_local_attr_maybe_short x = x
 
 let f x =
   (* a *)
+  (* b *)
   local_
+  (* c *)
+  (* d *)
   let y = 1 in
   x + y
 
 let f x =
   (* a *)
+  (* b *)
   exclave_
+  (* c *)
+  (* d *)
   let y = 1 in
   x + y
 
 let x =
   (* a *)
+  (* b *)
   local_
+  (* c *)
+  (* d *)
   let y = 1 in
   y
 
 let x =
   (* a *)
+  (* b *)
   exclave_
+  (* c *)
+  (* d *)
   let y = 1 in
   y
 
 module type S = functor (_ : S) (_ : S) -> S
 (* this is here to make sure we pass the AST equality checks even when the
    extended AST is different *)
+
+let f
+    (local_ (* a *)
+            (* b *)
+            (* c *)
+            (* d *)
+      a )
+    ~foo:(local_ (* e *)
+                 (* f *)
+                 (* g *)
+                 (* h *)
+      b ) ?foo:(local_ c = 1) ~(local_ d) =
+  ()
+
+type 'a r =
+  { mutable a: 'a
+  ; b: 'a
+  ; (* a *)
+    (* b *)
+    global_ (* c *)
+            (* d *) c:
+      'a }
+
+type 'a r =
+  | Foo of
+      global_ (* a *)
+              (* b *)
+              (* c *)
+              (* d *)
+      'a
+  | Bar of
+      'a
+      * global_ (* e *)
+                (* f *)
+                (* g *)
+                (* h *)
+      'a
+  | Baz of
+      global_ int
+      * string
+      * global_ (* i *)
+                (* j *)
+                (* k *)
+                (* l *)
+      'a

--- a/test/passing/tests/local_rewrite_regressions.ml
+++ b/test/passing/tests/local_rewrite_regressions.ml
@@ -6,3 +6,20 @@ module With_length : sig
     ; length : int [@global]
     }
 end = struct end
+
+val find_last : 'a t -> f:(('a -> bool)(* a *)(* b *)[@local](* c *)) -> 'a option
+let find_last : 'a t -> f:(('a -> bool)(* a *)[@local](* b *)) -> 'a option = assert false
+type t = (string[@local]) -> (string(* a *)[@local](* b *))
+
+
+type global_long_attrs =
+  | Foo of { s : string(* a *)(* b *)[@ocaml.global](* c *)(* d *); b: int }
+  | Bar of (string(* e *)(* f *)[@ocaml.global](* g *)(* h *))
+
+let local_long_ext = (* a *)(* b *)[%ocaml.local](* c *)(* d *) ()
+
+let () =
+  let g = (* a *)[%local](* b *) (fun a b c -> 1) in
+  ()
+
+let f (x(* a *)[@local](* b *)) = x

--- a/test/passing/tests/local_rewrite_regressions.ml.ref
+++ b/test/passing/tests/local_rewrite_regressions.ml.ref
@@ -4,3 +4,66 @@ module With_length : sig
     ; global_ length : int
     }
 end = struct end
+
+val find_last
+  :  'a t
+  -> f:
+       local_ ('a
+               -> bool
+                  (* a *)
+                  (* b *)
+                  (* c *))
+  -> 'a option
+
+let find_last
+  :  'a t
+  -> f:
+       local_ ('a
+               -> bool
+                  (* a *)
+                  (* b *))
+  -> 'a option
+  =
+  assert false
+;;
+
+type t = local_ string -> local_ string
+(* a *)
+(* b *)
+
+type global_long_attrs =
+  | Foo of
+      { global_ s : string
+          (* a *)
+          (* b *)
+          (* c *)
+          (* d *)
+      ; b : int
+      }
+  | Bar of global_ string
+(* e *)
+(* f *)
+(* g *)
+(* h *)
+
+let local_long_ext =
+  (* a *)
+  (* b *)
+  local_
+  (* c *)
+  (* d *)
+  ()
+;;
+
+let () =
+  let g = (* a *) local_ (* b *) fun a b c -> 1 in
+  ()
+;;
+
+let f
+  (local_ x
+    (* a *)
+    (* b *))
+  =
+  x
+;;

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -253,15 +253,15 @@ let mktyp_modes modes =
   in
   mktyp_local_if is_local
 
-let exclave_ext_loc loc = mkloc "extension.exclave" loc
+let exclave_ext_loc = mknoloc "extension.exclave"
 
-let exclave_extension loc =
+let exclave_extension =
   Exp.mk ~loc:Location.none
-    (Pexp_extension(exclave_ext_loc loc, PStr []))
+    (Pexp_extension(exclave_ext_loc, PStr []))
 
-let mkexp_exclave ~loc ~kwd_loc exp =
+let mkexp_exclave ~loc exp =
   if Erase_jane_syntax.should_erase () then exp else
-  ghexp ~loc (Pexp_apply(exclave_extension (make_loc kwd_loc), [Nolabel, exp]))
+  ghexp ~loc (Pexp_apply(exclave_extension, [Nolabel, exp]))
 
 let curry_attr =
   Attr.mk ~loc:Location.none (mknoloc "extension.curry") (PStr [])
@@ -280,27 +280,27 @@ let maybe_curry_typ typ =
       else mktyp_curry typ
   | _ -> typ
 
-let global_loc loc = mkloc "extension.global" loc
+let global_loc = mknoloc "extension.global"
 
-let global_attr loc =
-  Attr.mk ~loc:Location.none (global_loc loc) (PStr [])
+let global_attr =
+  Attr.mk ~loc:Location.none (global_loc) (PStr [])
 
-let mkld_global ld loc =
+let mkld_global ld =
   if Erase_jane_syntax.should_erase () then ld else
-  { ld with pld_attributes = global_attr loc :: ld.pld_attributes }
+  { ld with pld_attributes = global_attr :: ld.pld_attributes }
 
-let mkld_global_maybe gbl ld loc =
+let mkld_global_maybe gbl ld =
   match gbl with
-  | Global -> mkld_global ld loc
+  | Global -> mkld_global ld
   | Nothing -> ld
 
-let mkcty_global cty loc =
+let mkcty_global cty =
   if Erase_jane_syntax.should_erase () then cty else
-  { cty with ptyp_attributes = global_attr loc :: cty.ptyp_attributes }
+  { cty with ptyp_attributes = global_attr :: cty.ptyp_attributes }
 
-let mkcty_global_maybe gbl cty loc =
+let mkcty_global_maybe gbl cty =
   match gbl with
-  | Global -> mkcty_global cty loc
+  | Global -> mkcty_global cty
   | Nothing -> cty
 
 (* TODO define an abstraction boundary between locations-as-pairs
@@ -2487,7 +2487,7 @@ expr:
   | LOCAL seq_expr
      { mkexp_stack ~loc:$sloc $2 }
   | EXCLAVE seq_expr
-     { mkexp_exclave ~loc:$sloc ~kwd_loc:($loc($1)) $2 }
+     { mkexp_exclave ~loc:$sloc $2 }
 ;
 %inline expr_attrs:
   | LET MODULE ext_attributes mkrhs(module_name) functor_args module_binding_body IN seq_expr
@@ -3662,7 +3662,7 @@ generalized_constructor_arguments:
 
 %inline atomic_type_gbl:
   gbl = global_flag cty = atomic_type {
-  mkcty_global_maybe gbl cty (make_loc $loc(gbl))
+  mkcty_global_maybe gbl cty
 }
 ;
 
@@ -3683,8 +3683,7 @@ label_declaration:
       { let info = symbol_info $endpos in
         let mut, gbl = $1 in
         mkld_global_maybe gbl
-          (Type.field $2 $4 ~mut ~attrs:$5 ~loc:(make_loc $sloc) ~info)
-          (make_loc $loc($1)) }
+          (Type.field $2 $4 ~mut ~attrs:$5 ~loc:(make_loc $sloc) ~info) }
 ;
 label_declaration_semi:
     mutable_or_global_flag mkrhs(label) COLON poly_type_no_attr attributes
@@ -3696,8 +3695,7 @@ label_declaration_semi:
        in
        let mut, gbl = $1 in
        mkld_global_maybe gbl
-         (Type.field $2 $4 ~mut ~attrs:($5 @ $7) ~loc:(make_loc $sloc) ~info)
-         (make_loc $loc($1)) }
+         (Type.field $2 $4 ~mut ~attrs:($5 @ $7) ~loc:(make_loc $sloc) ~info) }
 ;
 
 /* Type Extensions */


### PR DESCRIPTION
This is a followup to #50 and fixes a few more places where comments on local syntax get dropped.