### PR TITLE
Add support for unboxed ints

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -547,6 +547,9 @@ let layout_to_string = function
   | Immediate64 -> "immediate64"
   | Immediate -> "immediate"
   | Float64 -> "float64"
+  | Word -> "word"
+  | Bits32 -> "bits32"
+  | Bits64 -> "bits64"
 
 let fmt_layout_str ~c ~loc string =
   fmt "@ :@ " $ Cmts.fmt c loc @@ str string

--- a/test/passing/tests/unboxed_types.ml
+++ b/test/passing/tests/unboxed_types.ml
@@ -39,3 +39,69 @@ type ('a : float64) t = 'a
 type ('b, 'a : float64) t
 
 type ('b : float64, 'a : immediate) t
+
+type t : bits32
+
+type t = int32#
+
+type t = int32# * int32#
+
+type t = int32# t2
+
+type t = int32 #t2
+
+type t = (int, int32#) either
+
+type t = (int32#, int) either
+
+type t = (int32#, int32#) either
+
+type ('a : bits32) t = 'a
+
+type ('b, 'a : bits32) t
+
+type ('b : bits32, 'a : immediate) t
+
+type t : bits64
+
+type t = int64#
+
+type t = int64# * int64#
+
+type t = int64# t2
+
+type t = int64 #t2
+
+type t = (int, int64#) either
+
+type t = (int64#, int) either
+
+type t = (int64#, int64#) either
+
+type ('a : bits64) t = 'a
+
+type ('b, 'a : bits64) t
+
+type ('b : bits64, 'a : immediate) t
+
+type t : word
+
+type t = nativeint#
+
+type t = nativeint# * nativeint#
+
+type t = nativeint# t2
+
+type t = int64 #t2
+
+type t = (int, nativeint#) either
+
+type t = (nativeint#, int) either
+
+type t = (nativeint#, nativeint#) either
+
+type ('a : word) t = 'a
+
+type ('b, 'a : word) t
+
+type ('b : word, 'a : immediate) t

--- a/vendor/parser-extended/asttypes.mli
+++ b/vendor/parser-extended/asttypes.mli
@@ -70,6 +70,9 @@ type const_layout =
   | Immediate64
   | Immediate
   | Float64
+  | Word
+  | Bits32
+  | Bits64
 
 type layout_annotation = const_layout loc
 type ty_var = string option loc * layout_annotation option

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -712,6 +712,9 @@ let check_layout ~loc id : const_layout =
   | "immediate64" -> Immediate64
   | "immediate" -> Immediate
   | "float64" -> Float64
+  | "word" -> Word
+  | "bits32" -> Bits32
+  | "bits64" -> Bits64
   | _ -> expecting_loc loc "layout"
 %}
 

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -207,6 +207,9 @@ let layout_to_string = function
   | Immediate64 -> "immediate64"
   | Immediate -> "immediate"
   | Float64 -> "float64"
+  | Word -> "word"
+  | Bits32 -> "bits32"
+  | Bits64 -> "bits64"
 
 let fmt_layout_opt ppf l = Format.fprintf ppf "%s"
   (Option.value ~default:"none" (Option.map (fun l -> layout_to_string l.txt) l))

--- a/vendor/parser-standard/asttypes.mli
+++ b/vendor/parser-standard/asttypes.mli
@@ -62,6 +62,9 @@ type const_layout =
   | Immediate64
   | Immediate
   | Float64
+  | Word
+  | Bits32
+  | Bits64
 
 type layout_annotation = const_layout loc
 

--- a/vendor/parser-standard/jane_syntax.ml
+++ b/vendor/parser-standard/jane_syntax.ml
@@ -777,6 +777,9 @@ end = struct
         | Immediate64 -> "immediate64"
         | Immediate -> "immediate"
         | Float64 -> "float64"
+        | Word -> "word"
+        | Bits32 -> "bits32"
+        | Bits64 -> "bits64"
 
       (* CR layouts v1.5: revise when moving layout recognition away from parser*)
       let of_string = function
@@ -786,6 +789,9 @@ end = struct
         | "immediate" -> Some Immediate
         | "immediate64" -> Some Immediate64
         | "float64" -> Some Float64
+        | "word" -> Some Word
+        | "bits32" -> Some Bits32
+        | "bits64" -> Some Bits64
         | _ -> None
     end)
   (*******************************************************)

--- a/vendor/parser-standard/printast.ml
+++ b/vendor/parser-standard/printast.ml
@@ -26,6 +26,9 @@ let const_layout_to_string = function
   | Immediate64 -> "immediate64"
   | Void -> "void"
   | Float64 -> "float64"
+  | Word -> "word"
+  | Bits32 -> "bits32"
+  | Bits64 -> "bits64"
 
 let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in


### PR DESCRIPTION
Add support to parse `int32#`, `int64#`, `nativeint#` as types and recognize `bits32`, `bits64`, `word` as valid layouts.