### PR TITLE
Fix parenthesization of labeled tuple patterns

### DIFF
--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3432,6 +3432,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to labeled_tuples_regressions.ml.stdout
+   (with-stderr-to labeled_tuples_regressions.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --profile=janestreet --max-iters=3 %{dep:tests/labeled_tuples_regressions.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/labeled_tuples_regressions.ml labeled_tuples_regressions.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/labeled_tuples_regressions.ml.err labeled_tuples_regressions.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to labeled_tuples_regressions.mli.stdout
    (with-stderr-to labeled_tuples_regressions.mli.stderr
      (run %{bin:ocamlformat} --margin-check --profile=janestreet --max-iters=3 %{dep:tests/labeled_tuples_regressions.mli})))))

--- a/test/passing/tests/labeled_tuples_regressions.ml
+++ b/test/passing/tests/labeled_tuples_regressions.ml
@@ -15,5 +15,7 @@ let foo a =
     , ~m:(lazy _)
     , ~n:(module M)
     , ~o:(exception _)
-    , ~p:[%bar baz] ) -> false
+    , ~p:[%bar baz]
+    , ~q:M.(A)
+    , ~r:M.(A 42) ) -> false
 ;;

--- a/test/passing/tests/labeled_tuples_regressions.ml
+++ b/test/passing/tests/labeled_tuples_regressions.ml
@@ -1,0 +1,19 @@
+let foo a =
+  match a with
+  | ( ~a:None
+    , ~b:(Some _)
+    , ~c:[ 1; 2 ]
+    , ~d:(3 :: [])
+    , ~e:{ x : _; y : _ }
+    , ~f:42
+    , ~g:_
+    , ~h:`Baz
+    , ~i:(`Bar _)
+    , ~j:(1 | 2)
+    , ~k:[| 1; 2 |]
+    , ~l:(3 : int)
+    , ~m:(lazy _)
+    , ~n:(module M)
+    , ~o:(exception _)
+    , ~p:[%bar baz] ) -> false
+;;

--- a/test/passing/tests/labeled_tuples_regressions.ml.opts
+++ b/test/passing/tests/labeled_tuples_regressions.ml.opts
@@ -1,0 +1,2 @@
+--profile=janestreet
+--max-iters=3


### PR DESCRIPTION
The previous version would attempt to format:

```ocaml
let foo x =
  match x with
  | ~a:(Some _), ~b -> false
  | _ -> true
```
as
```ocaml
let foo x =
  match x with
  | ~a:Some _, ~b -> false
  | _ -> true
```
The parens are required by the parser, so the updated version doesn't parse, causing ocamlformat to blow up.