### PR TITLE
Fix two labeled tuple bugs.

### DIFF
--- a/test/passing/tests/labeled_tuples_regressions.ml
+++ b/test/passing/tests/labeled_tuples_regressions.ml
@@ -19,3 +19,54 @@ let foo a =
     , ~q:M.(A)
     , ~r:M.(A 42) ) -> false
 ;;
+
+let bar =
+  ( ~a:foo
+  , ~b:42
+  , ~c:(let x = 18 in
+        x)
+  , ~d:(function
+         | x -> x)
+  , ~e:(fun x -> x)
+  , ~f:(foo 42)
+  , ~g:(match () with
+        | () -> ())
+  , ~h:(try () with
+        | _ -> ())
+  , ~i:(1, 2)
+  , ~j:(~x:1, ~y:2)
+  , ~k:None
+  , ~l:(Some 42)
+  , ~m:`A
+  , ~n:(`B 42)
+  , ~o:{ x = 42; z = false }
+  , ~p:foo.lbl
+  , ~q:((foo 42).lbl)
+  , ~r:(foo.lbl <- 42)
+  , ~s:[| 1; 2 |]
+  , ~t:[: 1; 2 :]
+  , ~u:[ 1; 2 ]
+  , ~v:[ a for a = 1 to 10 ]
+  , ~w:(if true then true else false)
+  , ~x:(();
+        ())
+  , ~y:(while true do
+          ()
+        done)
+  , ~z:(for i = 1 to 2 do
+          ()
+        done)
+  , ~z:(42 : int)
+  , ~y:(42 :> int)
+  , ~x:(42 : int :> bool)
+  , ~w:foo#bar
+  , ~v:foo #~# bar
+  , ~u:(new M.c)
+  , ~t:(x <- 2)
+  , ~s:{<x = 42; y = false>}
+  , ~r:(let module M = N in
+       ())
+  , ~q:(let exception Ex in
+       ())
+  , ~p:(assert true) )
+;;

--- a/test/passing/tests/labeled_tuples_regressions.ml
+++ b/test/passing/tests/labeled_tuples_regressions.ml
@@ -70,3 +70,12 @@ let bar =
        ())
   , ~p:(assert true) )
 ;;
+
+(* Labeled tuples in function return positions:  Parens are needed iff
+   the first element is labeled AND the return is `local_` *)
+module type S = sig
+  val t1 : unit -> int * y:bool
+  val t2 : unit -> local_ int * y:bool
+  val t3 : unit -> x:int * y:bool
+  val t4 : unit -> local_ (x:int * y:bool)
+end


### PR DESCRIPTION
### Bug one

`(), ~x:(fun y -> y)` was being misformatted as `(), ~x:fun y -> y`, which doesn't parse.  I thought this was avoided by the precedence changes in the original labeled tuples PR, but I was wrong.

Now that I've added similar logic and tests to labeled tuple patterns and expressions to make parenthesization coherent, you might ask whether I should pre-emptively do it for types.  I believe this isn't needed because labeled tuple type elements use the same non-terminal as normal tuple type elements (`atomic_type`, see [here](https://github.com/ocaml-flambda/flambda-backend/blob/77a13f274813048f2fbd4ad3d16e8b2755b85403/ocaml/parsing/parser.mly#L4390)).  On the other hand, when parsing [patterns](https://github.com/ocaml-flambda/flambda-backend/blob/77a13f274813048f2fbd4ad3d16e8b2755b85403/ocaml/parsing/parser.mly#L3556) and [expressions](https://github.com/ocaml-flambda/flambda-backend/blob/77a13f274813048f2fbd4ad3d16e8b2755b85403/ocaml/parsing/parser.mly#L3367), a different parser is used for the labeled and unlabeled cases (`pattern` vs `simple_pattern`, and  `expr` vs `simple_expr`).

### Bug two

`unit -> local_ (x:int * y:bool)` was being misformatted as `unit -> local_ x:int * y:bool`, which doesn't parse.

The parens are needed only if the return is `local_` _and_ the tuple's first element is labeled.  This is a limitation in the parser.  The way ocamlformat handles `local_` makes the location of the fix awkward, but ultimately fairly understandable.  Hopefully one day we'll rework the `local_` printing.