### PR TITLE
Fix the broken labeled tuple test

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2395,7 +2395,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       pro
       $ hvbox
           (Params.Indent.exp_constraint c.conf)
-          (Params.parens_if parens c.conf
+          (Params.parens_if (parens && has_attr) c.conf
              ( wrap_fits_breaks ~space:false c.conf "(" ")"
                  ( fmt_expression c (sub_exp ~ctx e)
                  $ fmt "@ : "


### PR DESCRIPTION
#56 and #55 had some bad interactions causing a test to fail.

This PR fixes that by only adding the second pair of parentheses around `Pexp_constraint` if there are attributes present.