### PR TITLE
Erase layout annotations as a part of `--erase-jane-syntax`

### DIFF
--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -317,6 +317,9 @@ let merge_and_sort x y =
   List.rev_append x y
   |> List.sort ~compare:(Comparable.lift Location.compare_start ~f:Cmt.loc)
 
+(* [relocate], [relocate_all_to_before], and [relocate_all_to_after] are very
+   similar in implementation. When fixing bugs, should consider propagating
+   the changes to all three functions. *)
 let relocate (t : t) ~src ~before ~after =
   if t.debug then
     Format.eprintf "relocate %a to %a and %a@\n%!" Location.fmt src
@@ -333,6 +336,9 @@ let relocate (t : t) ~src ~before ~after =
         let s = Set.add s after in
         Set.add s before )
 
+(* [relocate], [relocate_all_to_before], and [relocate_all_to_after] are very
+   similar in implementation. When fixing bugs, should consider propagating
+   the changes to all three functions. *)
 let relocate_all_to_before (t : t) ~src ~before =
   if t.debug then
     Format.eprintf "relocate %a all to %a@\n%!" Location.fmt src Location.fmt
@@ -354,6 +360,9 @@ let relocate_all_to_before (t : t) ~src ~before =
         let s = Set.remove s src in
         Set.add s before )
 
+(* [relocate], [relocate_all_to_before], and [relocate_all_to_after] are very
+   similar in implementation. When fixing bugs, should consider propagating
+   the changes to all three functions. *)
 let relocate_all_to_after (t : t) ~src ~after =
   if t.debug then
     Format.eprintf "relocate %a all to %a@\n%!" Location.fmt src Location.fmt

--- a/lib/Cmts.ml
+++ b/lib/Cmts.ml
@@ -88,6 +88,8 @@ let remaining_comments t =
 
 let remaining_before t loc = Map.find_multi t.cmts_before loc
 
+let remaining_after t loc = Map.find_multi t.cmts_after loc
+
 let remaining_locs t = Set.to_list t.remaining
 
 let restore src ~into =
@@ -310,14 +312,15 @@ let rec place t loc_tree ?prev_loc ?deep_loc locs cmts =
       deep_loc
 
 (** Relocate comments, for Ast transformations such as sugaring. *)
+
+let merge_and_sort x y =
+  List.rev_append x y
+  |> List.sort ~compare:(Comparable.lift Location.compare_start ~f:Cmt.loc)
+
 let relocate (t : t) ~src ~before ~after =
   if t.debug then
     Format.eprintf "relocate %a to %a and %a@\n%!" Location.fmt src
       Location.fmt before Location.fmt after ;
-  let merge_and_sort x y =
-    List.rev_append x y
-    |> List.sort ~compare:(Comparable.lift Location.compare_start ~f:Cmt.loc)
-  in
   update_cmts t `Before
     ~f:(Multimap.update_multi ~src ~dst:before ~f:merge_and_sort) ;
   update_cmts t `After
@@ -330,14 +333,31 @@ let relocate (t : t) ~src ~before ~after =
         let s = Set.add s after in
         Set.add s before )
 
+let relocate_all_to_before (t : t) ~src ~before =
+  if t.debug then
+    Format.eprintf "relocate %a all to %a@\n%!" Location.fmt src Location.fmt
+      before ;
+  t.cmts_before <-
+    Map.change t.cmts_before before ~f:(fun r ->
+        let cmts = remaining_after t src in
+        match (r, cmts) with
+        | Some data, _ -> Some (merge_and_sort data cmts)
+        | None, _ :: _ -> Some cmts
+        | None, [] -> None ) ;
+  t.cmts_after <- Map.remove t.cmts_after src ;
+  update_cmts t `Before
+    ~f:(Multimap.update_multi ~src ~dst:before ~f:merge_and_sort) ;
+  update_cmts t `Within
+    ~f:(Multimap.update_multi ~src ~dst:before ~f:merge_and_sort) ;
+  if t.debug then
+    update_remaining t ~f:(fun s ->
+        let s = Set.remove s src in
+        Set.add s before )
+
 let relocate_all_to_after (t : t) ~src ~after =
   if t.debug then
     Format.eprintf "relocate %a all to %a@\n%!" Location.fmt src Location.fmt
       after ;
-  let merge_and_sort x y =
-    List.rev_append x y
-    |> List.sort ~compare:(Comparable.lift Location.compare_start ~f:Cmt.loc)
-  in
   t.cmts_after <-
     Map.change t.cmts_after after ~f:(fun r ->
         let cmts = remaining_before t src in

--- a/lib/Cmts.mli
+++ b/lib/Cmts.mli
@@ -37,6 +37,10 @@ val relocate :
     locations) comments before [src] to [before] and comments after [src] to
     [after]. *)
 
+val relocate_all_to_before : t -> src:Location.t -> before:Location.t -> unit
+(** [relocate_all_to_before src before] moves (changes the association with
+    locations) comments before and after [src] all to before [before]. *)
+
 val relocate_all_to_after : t -> src:Location.t -> after:Location.t -> unit
 (** [relocate_all_to_after src after] moves (changes the association with
     locations) comments before and after [src] all to after [after]. *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3626,6 +3626,10 @@ and fmt_type_declaration c ?ext ?(pre = "") ?name ?(eq = "=") {ast= decl; _}
     =
   protect c (Td decl)
   @@
+  let decl =
+    if Erase_jane_syntax.should_erase () then decl
+    else Sugar.rewrite_type_declaration_imm_attr_to_layout_annot c.cmts decl
+  in
   let { ptype_name= {txt; loc}
       ; ptype_params
       ; ptype_cstrs

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -252,6 +252,19 @@ let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
           convert_legacy_jane_street_local_annotations ~segment:Type
             typ.ptyp_attributes }
     in
+    let typ =
+      match typ with
+      (* Allow [???#] to [???] change when erasing jane syntax. *)
+      | {ptyp_desc= Ptyp_constr (({txt= Lident s; _} as ident_loc), l); _}
+        when String.is_suffix s ~suffix:"#" && erase_jane_syntax ->
+          { typ with
+            ptyp_desc=
+              Ptyp_constr
+                ( { ident_loc with
+                    txt= Lident (String.chop_suffix_exn s ~suffix:"#") }
+                , l ) }
+      | _ -> typ
+    in
     Ast_mapper.default_mapper.typ m typ
   in
   let structure =

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -111,11 +111,13 @@ let normalize_immediate_annot_and_attrs attr =
      for this to work. Since if we rewrite [@@ocaml.immediate] into
      an annotation and treat that as [@@immediate]. That's an attribute
      change we need to accept. *)
-  | "jane.erasable.layouts.immediate", _ | "ocaml.immediate", _ ->
+  | "jane.erasable.layouts.immediate", PStr [] | "ocaml.immediate", PStr []
+    ->
       { attr with
         attr_name= {attr.attr_name with txt= "immediate"}
       ; attr_payload= PStr [] }
-  | "jane.erasable.layouts.immediate64", _ | "ocaml.immediate64", _ ->
+  | "jane.erasable.layouts.immediate64", PStr []
+   |"ocaml.immediate64", PStr [] ->
       { attr with
         attr_name= {attr.attr_name with txt= "immediate64"}
       ; attr_payload= PStr [] }

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -98,6 +98,8 @@ let is_doc = function
 let is_erasable_jane_syntax attr =
   String.is_prefix ~prefix:"jane.erasable." attr.attr_name.txt
 
+(* Immediate layout annotations should be treated the same as their attribute
+   counterparts *)
 let convert_immediate_annot_to_legacy_attr attr =
   match (attr.attr_name.txt, attr.attr_payload) with
   (* CR layouts: change to something like: {[ | (
@@ -355,10 +357,8 @@ let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
   in
   let type_declaration (m : Ast_mapper.mapper) decl =
     let ptype_attributes =
-      if erase_jane_syntax then
-        decl.ptype_attributes
-        |> List.map ~f:convert_immediate_annot_to_legacy_attr
-      else decl.ptype_attributes
+      decl.ptype_attributes
+      |> List.map ~f:convert_immediate_annot_to_legacy_attr
     in
     Ast_mapper.default_mapper.type_declaration m {decl with ptype_attributes}
   in

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -150,10 +150,10 @@ let rewrite_type_declaration_imm_attr_to_layout_annot cmts decl =
       (* We only do this rewrite if (1.) there's no layout annotation already
          present and (2.) only one immediate attribute is attached *)
       let ptype_layout = Some Location.(mknoloc layout) in
-      Cmts.relocate_all_to_after cmts ~src:attr.attr_name.loc
-        ~after:decl.ptype_name.loc ;
-      Cmts.relocate_all_to_after cmts ~src:attr.attr_loc
-        ~after:decl.ptype_name.loc ;
+      Cmts.relocate_all_to_before cmts ~src:attr.attr_name.loc
+        ~before:decl.ptype_loc ;
+      Cmts.relocate_all_to_before cmts ~src:attr.attr_loc
+        ~before:decl.ptype_loc ;
       {decl with ptype_attributes= remaining_attrs; ptype_layout}
   | _ -> decl
 

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -132,9 +132,9 @@ let remove_local_attrs cmts param =
       Pparam_val (is_local, label, default, {pattern with ppat_attributes})
 
 let get_layout_of_legacy_attr attr =
-  match attr.attr_name.txt with
-  | "ocaml.immediate64" | "immediate64" -> Some Immediate64
-  | "ocaml.immediate" | "immediate" -> Some Immediate
+  match (attr.attr_name.txt, attr.attr_payload) with
+  | ("ocaml.immediate64" | "immediate64"), PStr [] -> Some Immediate64
+  | ("ocaml.immediate" | "immediate"), PStr [] -> Some Immediate
   | _ -> None
 
 let rewrite_type_declaration_imm_attr_to_layout_annot cmts decl =

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -45,6 +45,12 @@ val cl_fun :
 
 val remove_local_attrs : Cmts.t -> function_param_desc -> function_param_desc
 
+val rewrite_type_declaration_imm_attr_to_layout_annot :
+  Cmts.t -> type_declaration -> type_declaration
+(** Rewrites [@@immediate] to [_ : immediate] and do the same for [@@immediate64].
+    This only happens if there's no existing layout annotation AND there's only
+    one immediacy attribute. *)
+
 module Exp : sig
   val infix :
        Cmts.t

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3540,6 +3540,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to layout_annotation_immediate_rewrite.ml.stdout
+   (with-stderr-to layout_annotation_immediate_rewrite.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --max-iter=4 --profile=janestreet %{dep:tests/layout_annotation_immediate_rewrite.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/layout_annotation_immediate_rewrite.ml.ref layout_annotation_immediate_rewrite.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/layout_annotation_immediate_rewrite.ml.err layout_annotation_immediate_rewrite.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to lazy.ml.stdout
    (with-stderr-to lazy.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/lazy.ml})))))

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3504,6 +3504,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to layout_annotation-erased.ml.stdout
+   (with-stderr-to layout_annotation-erased.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --erase-jane-syntax --max-iter=4 %{dep:tests/layout_annotation.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/layout_annotation-erased.ml.ref layout_annotation-erased.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/layout_annotation-erased.ml.err layout_annotation-erased.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to layout_annotation.ml.stdout
    (with-stderr-to layout_annotation.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/layout_annotation.ml})))))

--- a/test/passing/tests/attributes.ml
+++ b/test/passing/tests/attributes.ml
@@ -184,8 +184,7 @@ module type A = sig
 end
 
 module M = struct
-  type t
-  [@@immediate]
+  type t : immediate
   (* ______________________________________ *)
   [@@deriving variants, sexp_of]
 end

--- a/test/passing/tests/attributes.ml.err
+++ b/test/passing/tests/attributes.ml.err
@@ -1,1 +1,1 @@
-Warning: tests/attributes.ml:355 exceeds the margin
+Warning: tests/attributes.ml:354 exceeds the margin

--- a/test/passing/tests/js_source.ml.ocp
+++ b/test/passing/tests/js_source.ml.ocp
@@ -3085,7 +3085,7 @@ let check : type s. (s t, s) pair -> bool = function
 ;;
 
 module type S = sig
-  type t [@@immediate]
+  type t : immediate
 end
 
 module F (M : S) : S = M
@@ -3100,16 +3100,16 @@ module F : functor (M : S) -> S
 
 module A = struct
   (* Abstract types can be immediate *)
-  type t [@@immediate]
+  type t : immediate
 
   (* [@@immediate] tag here is unnecessary but valid since t has it *)
-  type s = t [@@immediate]
+  type s : immediate = t
 
   (* Again, valid alias even without tag *)
   type r = s
 
   (* Mutually recursive declarations work as well *)
-  type p = q [@@immediate]
+  type p : immediate = q
   and q = int
 end
 
@@ -3135,7 +3135,7 @@ module Y = struct
 end
 
 module Z : sig
-  type t [@@immediate]
+  type t : immediate
 end = (Y : X with type t = int)
 
 [%%expect
@@ -3175,7 +3175,7 @@ module Foo : sig type t val x : t ref end
 |}]
 
 module Bar : sig
-  type t [@@immediate]
+  type t : immediate
 
   val x : t ref
 end = struct
@@ -3226,7 +3226,7 @@ val test_bar : unit -> unit = <fun>
 
 (* Cannot directly declare a non-immediate type as immediate *)
 module B = struct
-  type t = string [@@immediate]
+  type t : immediate = string
 end
 
 [%%expect
@@ -3239,7 +3239,7 @@ Error: Types marked with the immediate attribute must be
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
 module C = struct
   type t
-  type s = t [@@immediate]
+  type s : immediate = t
 end
 
 [%%expect
@@ -3251,7 +3251,7 @@ Error: Types marked with the immediate attribute must be
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
 module D : sig
-  type t [@@immediate]
+  type t : immediate
 end = struct
   type t = string
 end
@@ -3294,7 +3294,7 @@ Error: Signature mismatch:
 
 (* Can't use a non-immediate type even if mutually recursive *)
 module E = struct
-  type t = s [@@immediate]
+  type t : immediate = s
   and s = string
 end
 
@@ -9596,8 +9596,8 @@ exception First_exception
 exception Second_exception
 
 module M = struct
-  type t
-  [@@immediate] (* ______________________________________ *)
+  type t : immediate
+  (* ______________________________________ *)
   [@@deriving variants, sexp_of]
 end
 

--- a/test/passing/tests/js_source.ml.ref
+++ b/test/passing/tests/js_source.ml.ref
@@ -3085,7 +3085,7 @@ let check : type s. (s t, s) pair -> bool = function
 ;;
 
 module type S = sig
-  type t [@@immediate]
+  type t : immediate
 end
 
 module F (M : S) : S = M
@@ -3100,16 +3100,16 @@ module F : functor (M : S) -> S
 
 module A = struct
   (* Abstract types can be immediate *)
-  type t [@@immediate]
+  type t : immediate
 
   (* [@@immediate] tag here is unnecessary but valid since t has it *)
-  type s = t [@@immediate]
+  type s : immediate = t
 
   (* Again, valid alias even without tag *)
   type r = s
 
   (* Mutually recursive declarations work as well *)
-  type p = q [@@immediate]
+  type p : immediate = q
   and q = int
 end
 
@@ -3135,7 +3135,7 @@ module Y = struct
 end
 
 module Z : sig
-  type t [@@immediate]
+  type t : immediate
 end = (Y : X with type t = int)
 
 [%%expect
@@ -3175,7 +3175,7 @@ module Foo : sig type t val x : t ref end
 |}]
 
 module Bar : sig
-  type t [@@immediate]
+  type t : immediate
 
   val x : t ref
 end = struct
@@ -3226,7 +3226,7 @@ let () = Printf.printf "With @@immediate: %fs\n" (test test_bar) *)
 
 (* Cannot directly declare a non-immediate type as immediate *)
 module B = struct
-  type t = string [@@immediate]
+  type t : immediate = string
 end
 
 [%%expect
@@ -3239,7 +3239,7 @@ Error: Types marked with the immediate attribute must be
 (* Not guaranteed that t is immediate, so this is an invalid declaration *)
 module C = struct
   type t
-  type s = t [@@immediate]
+  type s : immediate = t
 end
 
 [%%expect
@@ -3251,7 +3251,7 @@ Error: Types marked with the immediate attribute must be
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
 module D : sig
-  type t [@@immediate]
+  type t : immediate
 end = struct
   type t = string
 end
@@ -3294,7 +3294,7 @@ Error: Signature mismatch:
 
 (* Can't use a non-immediate type even if mutually recursive *)
 module E = struct
-  type t = s [@@immediate]
+  type t : immediate = s
   and s = string
 end
 
@@ -9596,8 +9596,8 @@ exception First_exception
 exception Second_exception
 
 module M = struct
-  type t
-  [@@immediate] (* ______________________________________ *)
+  type t : immediate
+  (* ______________________________________ *)
   [@@deriving variants, sexp_of]
 end
 

--- a/test/passing/tests/layout_annotation-erased.ml.err
+++ b/test/passing/tests/layout_annotation-erased.ml.err
@@ -1,0 +1,1 @@
+Warning: tests/layout_annotation.ml:8 exceeds the margin

--- a/test/passing/tests/layout_annotation-erased.ml.opts
+++ b/test/passing/tests/layout_annotation-erased.ml.opts
@@ -1,0 +1,1 @@
+--erase-jane-syntax --max-iter=4

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -10,9 +10,9 @@ type ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt
 
 type t_value
 
-type t_imm
+type t_imm [@@immediate]
 
-type t_imm64
+type t_imm64 [@@immediate64]
 
 type t_float64
 

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -20,11 +20,6 @@ type t_any
 
 type t_void
 
-(* Attributes are not changed *)
-type old_imm [@@immediate]
-
-type old_imm64 [@@immediate64]
-
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -1,0 +1,316 @@
+val foo :
+  'k 'cmp.
+     (module S
+        with type Id_and_repr.t = 'k
+         and type Id_and_repr.comparator_witness = 'cmp )
+  -> 'k Jane_symbol.Map.t
+  -> ('k, Sockaddr.t, 'cmp) Map.t
+
+type ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt
+
+type t_value
+
+type t_imm
+
+type t_imm64
+
+type t_float64
+
+type t_any
+
+type t_void
+
+(* Attributes are not changed *)
+type old_imm [@@immediate]
+
+type old_imm64 [@@immediate64]
+
+(***************************************)
+(* Test 1: annotation on type variable *)
+
+let x : int as 'a = 5
+
+let x : int as 'a = 5
+
+let x : int as 'a = 5
+
+let x : int as 'a = 5
+
+let x : (int as 'a) list as 'b = [3; 4; 5]
+
+let x : int list as 'a = [3; 4; 5]
+
+(****************************************)
+(* Test 2: Annotation on type parameter *)
+
+type 'a t2_imm
+
+type _ t2_imm'
+
+type t1 = int t2_imm
+
+type t2 = bool t2_imm
+
+type 'a t2_float64
+
+type _ t2_float64'
+
+type t3 = float t2_float64
+
+module M1 : sig
+  type 'a t
+end = struct
+  type _ t
+end
+
+module M2 : sig
+  type _ t
+end = struct
+  type 'a t
+end
+
+type t = string t2_imm
+
+let f : 'a t2_imm -> 'a t2_imm = fun x -> x
+
+let f : 'a t2_imm -> 'a t2_imm = fun x -> x
+
+let f : 'a t2_imm -> 'a t2_imm = fun x -> x
+
+let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
+
+let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
+
+type 'a t = 'a t2_imm
+
+type 'a t = 'a t2_imm
+
+type 'a t = 'a t2_imm
+
+let f : _ t2_imm -> unit = fun _ -> ()
+
+let g : _ t2_imm -> unit = fun _ -> ()
+
+let f : _ -> unit = fun _ -> ()
+
+let g : _ -> unit = fun _ -> ()
+
+let f : _ -> _ = fun _ -> assert false
+
+let g : _ -> _ = fun _ -> assert false
+
+(********************************************)
+(* Test 3: Annotation on types in functions *)
+
+let f : 'a -> 'a = fun x -> x
+
+let f : 'a. 'a -> 'a = fun x -> x
+
+let f : 'a. 'a -> 'a = fun x -> x
+
+(********************************************)
+(* Test 4: Annotation on record field types *)
+
+type r = {field: 'a. 'a -> 'a}
+
+let f {field} = field 5
+
+type rf = {fieldf: 'a. 'a -> 'a}
+
+let f {fieldf} = fieldf (Stdlib__Float_u.of_float 3.14)
+
+let f {field} = field "hello"
+
+let r = {field= (fun x -> x)}
+
+let r = {field= Fun.id}
+
+let r = {field= (fun (type a) (x : a) -> x)}
+
+let r = {field= (fun (type a) (x : a) -> x)}
+
+type r_value = {field: 'a. 'a -> 'a}
+
+let r = {field= (fun (type a) (x : a) -> x)}
+
+(* CR layouts v1.5: that's a pretty awful error message *)
+
+type 'a t_imm
+
+type s = {f: 'a. 'a -> 'a u}
+
+and 'a u = 'a t_imm
+
+(* CR layouts v1.5: the location on that message is wrong. But it's hard to
+   improve, because it comes from re-checking typedtree, where we don't have
+   locations any more. I conjecture the same location problem exists when
+   constraints aren't satisfied. *)
+
+(********************)
+(* Test 5: newtypes *)
+
+let f (type a) (x : a) = x
+
+let f (type a) (x : a) = x
+
+let f (type a) (x : a) = x
+
+let f (type a) (x : a) = x
+
+(****************************************)
+(* Test 6: abstract universal variables *)
+
+let f : type a. a -> a = fun x -> x
+
+let f : type a. a -> a = fun x -> x
+
+let f : type a. a -> a = fun x -> x
+
+let f : type a. a -> a = fun x -> x
+
+(**************************************************)
+(* Test 7: Defaulting universal variable to value *)
+
+module type S = sig
+  val f : 'a. 'a t2_imm -> 'a t2_imm
+end
+
+let f : 'a. 'a t2_imm -> 'a t2_imm = fun x -> x
+
+(********************************************)
+(* Test 8: Annotation on universal variable *)
+
+module type S = sig
+  val f : 'a. 'a t2_imm -> 'a t2_imm
+end
+
+module type S = sig
+  val f : 'a t2_imm -> 'a t2_imm
+
+  val g : 'a. 'a t2_imm -> 'a t2_imm
+end
+
+module type S = sig
+  val f : 'a t2_float64 -> 'a t2_float64
+
+  val g : 'a. 'a t2_float64 -> 'a t2_float64
+end
+
+(************************************************************)
+(* Test 9: Annotation on universal in polymorphic parameter *)
+
+let f (x : 'a. 'a -> 'a) = x "string"
+
+(**************************************)
+(* Test 10: Parsing & pretty-printing *)
+
+let f (type a) (x : a) = x
+
+let f (type a) (x : a) = x
+
+let f (type a) (x : a) = x
+
+let o =
+  object
+    method m : type a. a -> a = fun x -> x
+  end
+
+let f : type a. a -> a = fun x -> x
+
+let f x =
+  let g (type a) (x : a) = x in
+  g x [@nontail]
+
+let f x y (type a) (z : a) = z
+
+let f x y (type a) (z : a) = z
+
+external f : 'a. 'a -> 'a = "%identity"
+
+type _ t2_any
+
+exception E : 'a 'b. 'b t2_any * 'a list -> exn
+
+let f (x : 'a. 'a -> 'a) = (x 3, x true)
+
+type _ a = Mk : [> ] * 'a -> int a
+
+module type S = sig
+  type _ a = Mk : [> ] * 'a -> int a
+
+  val f_imm : 'a 'b. 'a -> 'a
+
+  val f_val : 'a. 'a -> 'a
+
+  type _ g = MkG : 'a. 'a g
+
+  type t = int
+end
+
+let f_imm : 'a. 'a -> 'a = fun x -> x
+
+let f_val : 'a. 'a -> 'a = fun x -> f_imm x
+
+type _ g = MkG : 'a. 'a g
+
+type t = int
+
+type t = ('a, 'b) t2
+
+type ('a, 'b) t = 'a * 'b
+
+class c : object
+  method m : 'a. 'a -> 'a
+
+  val f : 'a -> 'a
+end =
+  object
+    method m : type a. a -> a = fun x -> x
+
+    val f = fun (x : 'a) -> x
+  end
+
+type _ g = MkG : 'a 'b. 'a -> 'b g
+
+type 'a t3 = ..
+
+type _ t3 += MkG : 'a 'b. 'a -> 'b t3
+
+let f_gadt : 'a. 'a -> 'a g -> 'a = fun x MkG -> f_imm x
+
+(* comments *)
+val foo :
+  (* comment 1 *)
+  'k
+  (* comment 2 *)
+  (* comment 3 *)
+  (* comment 4 *)
+  (* comment 5 *) 'cmp.
+     (module S
+        with type Id_and_repr.t = 'k
+         and type Id_and_repr.comparator_witness = 'cmp )
+  -> 'k Jane_symbol.Map.t
+  -> ('k, Sockaddr.t, 'cmp) Map.t
+
+type a = b (* comment 0 *) as (* comment 1 *)
+         'k
+(* comment 2 *)
+
+(* comment 3 *)
+
+(* comment 4 *)
+(* comment 5 *)
+
+let f (type a) x = x
+
+let f (type a b c d e f g h i j k l m n o p q r s t u v w x y z) x = x
+
+let f (type a b) x = x
+
+let f (type a b) x = x
+
+let f (type a b) x = x
+
+module type S = sig
+  val init_with_immediates : 'a 'b. int -> f:(int -> 'a) -> 'a t
+end

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -22,11 +22,6 @@ type t_any : any
 
 type t_void : void
 
-(* Attributes are not changed *)
-type old_imm [@@immediate]
-
-type old_imm64 [@@immediate64]
-
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -22,6 +22,11 @@ type t_any : any
 
 type t_void : void
 
+(* Attributes are not changed *)
+type old_imm [@@immediate]
+
+type old_imm64 [@@immediate64]
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 
@@ -310,3 +315,9 @@ let f (type (a : immediate) b) x = x
 let f (type a (b : immediate)) x = x
 
 let f (type (a : immediate) (b : immediate)) x = x
+
+module type S = sig
+  val init_with_immediates :
+    ('a : immediate) ('b : immediate).
+    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+end

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml
@@ -6,6 +6,12 @@ type old_imm64 [@@immediate64]
 type old_imm = p [@@immediate]
 type old_imm64 = q [@@immediate64]
 
+type old_imm [@@ocaml.immediate]
+type old_imm64 [@@ocaml.immediate64]
+
+type old_imm = p [@@ocaml.immediate]
+type old_imm64 = q [@@ocaml.immediate64]
+
 (* Comments are not dropped *)
 
 type old_imm (* a *)[@@immediate(* b *)](* c *)
@@ -27,3 +33,11 @@ type old_imm: immediate64 [@@immediate]
 
 type old_imm64: immediate64 [@@immediate64]
 type old_imm64: immediate [@@immediate64]
+
+(* Do nothing if there's unexpected payload *)
+
+type old_imm [@@immediate "abc"]
+type old_imm [@@immediate "abc"]
+
+type old_imm64 [@@immediate64 "abc"]
+type old_imm64 [@@immediate64 "abc"]

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml
@@ -1,0 +1,29 @@
+(* Legacy immediate attributes are rewritten into layout annotations *)
+
+type old_imm [@@immediate]
+type old_imm64 [@@immediate64]
+
+type old_imm = p [@@immediate]
+type old_imm64 = q [@@immediate64]
+
+(* Comments are not dropped *)
+
+type old_imm (* a *)[@@immediate(* b *)](* c *)
+
+type old_imm64 = (* a *)s (* b *) [@@immediate64](* c *)
+
+(* Do nothing if there are more than one attribute *)
+
+type old_imm [@@immediate] [@@immediate]
+type old_imm [@@immediate] [@@immediate64]
+
+type old_imm64 [@@immediate64] [@@immediate64]
+type old_imm64 [@@immediate64] [@@immediate]
+
+(* Do nothing if there's already a layout annotation *)
+
+type old_imm: immediate [@@immediate]
+type old_imm: immediate64 [@@immediate]
+
+type old_imm64: immediate64 [@@immediate64]
+type old_imm64: immediate [@@immediate64]

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml
@@ -18,6 +18,9 @@ type old_imm (* a *)[@@immediate(* b *)](* c *)
 
 type old_imm64 = (* a *)s (* b *) [@@immediate64](* c *)
 
+type  old_imm64' = (* a *)s (* b *) [@@immediate64](* c *)[@@abc](* d *)
+
+
 (* Do nothing if there are more than one attribute *)
 
 type old_imm [@@immediate] [@@immediate]

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml.opts
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml.opts
@@ -1,0 +1,1 @@
+--max-iter=4 --profile=janestreet

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
@@ -11,14 +11,15 @@ type old_imm64 : immediate64 = q
 
 (* Comments are not dropped *)
 
-type old_imm : immediate
-
 (* a *)
 (* b *)
-(* c *)
-type old_imm64 : immediate64 = (* a *) s
+type old_imm : immediate (* c *)
+
 (* b *)
-(* c *)
+type old_imm64 : immediate64 = (* a *) s (* c *)
+
+(* b *)
+type old_imm64' : immediate64 = (* a *) s (* c *) [@@abc] (* d *)
 
 (* Do nothing if there are more than one attribute *)
 

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
@@ -1,0 +1,31 @@
+(* Legacy immediate attributes are rewritten into layout annotations *)
+
+type old_imm : immediate
+type old_imm64 : immediate64
+type old_imm : immediate = p
+type old_imm64 : immediate64 = q
+
+(* Comments are not dropped *)
+
+type old_imm : immediate
+
+(* a *)
+(* b *)
+(* c *)
+type old_imm64 : immediate64 = (* a *) s
+(* b *)
+(* c *)
+
+(* Do nothing if there are more than one attribute *)
+
+type old_imm [@@immediate] [@@immediate]
+type old_imm [@@immediate] [@@immediate64]
+type old_imm64 [@@immediate64] [@@immediate64]
+type old_imm64 [@@immediate64] [@@immediate]
+
+(* Do nothing if there's already a layout annotation *)
+
+type old_imm : immediate [@@immediate]
+type old_imm : immediate64 [@@immediate]
+type old_imm64 : immediate64 [@@immediate64]
+type old_imm64 : immediate [@@immediate64]

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
@@ -4,6 +4,10 @@ type old_imm : immediate
 type old_imm64 : immediate64
 type old_imm : immediate = p
 type old_imm64 : immediate64 = q
+type old_imm : immediate
+type old_imm64 : immediate64
+type old_imm : immediate = p
+type old_imm64 : immediate64 = q
 
 (* Comments are not dropped *)
 
@@ -29,3 +33,10 @@ type old_imm : immediate [@@immediate]
 type old_imm : immediate64 [@@immediate]
 type old_imm64 : immediate64 [@@immediate64]
 type old_imm64 : immediate [@@immediate64]
+
+(* Do nothing if there's unexpected payload *)
+
+type old_imm [@@immediate "abc"]
+type old_imm [@@immediate "abc"]
+type old_imm64 [@@immediate64 "abc"]
+type old_imm64 [@@immediate64 "abc"]

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -2936,7 +2936,7 @@ let check : type s. (s t, s) pair -> bool = function
   | {fst= IntLit; snd= 6} -> false
 
 module type S = sig
-  type t [@@immediate]
+  type t : immediate
 end
 
 module F (M : S) : S = M
@@ -2951,16 +2951,16 @@ module F : functor (M : S) -> S
 
 module A = struct
   (* Abstract types can be immediate *)
-  type t [@@immediate]
+  type t : immediate
 
   (* [@@immediate] tag here is unnecessary but valid since t has it *)
-  type s = t [@@immediate]
+  type s : immediate = t
 
   (* Again, valid alias even without tag *)
   type r = s
 
   (* Mutually recursive declarations work as well *)
-  type p = q [@@immediate]
+  type p : immediate = q
 
   and q = int
 end
@@ -2987,7 +2987,7 @@ module Y = struct
 end
 
 module Z : sig
-  type t [@@immediate]
+  type t : immediate
 end = (Y : X with type t = int )
 
 [%%expect
@@ -3027,7 +3027,7 @@ module Foo : sig type t val x : t ref end
 |}]
 
 module Bar : sig
-  type t [@@immediate]
+  type t : immediate
 
   val x : t ref
 end = struct
@@ -3075,7 +3075,7 @@ val test_bar : unit -> unit = <fun>
 
 (* Cannot directly declare a non-immediate type as immediate *)
 module B = struct
-  type t = string [@@immediate]
+  type t : immediate = string
 end
 
 [%%expect
@@ -3089,7 +3089,7 @@ Error: Types marked with the immediate attribute must be
 module C = struct
   type t
 
-  type s = t [@@immediate]
+  type s : immediate = t
 end
 
 [%%expect
@@ -3101,7 +3101,7 @@ Error: Types marked with the immediate attribute must be
 
 (* Can't ascribe to an immediate type signature with a non-immediate type *)
 module D : sig
-  type t [@@immediate]
+  type t : immediate
 end = struct
   type t = string
 end
@@ -3144,7 +3144,7 @@ Error: Signature mismatch:
 
 (* Can't use a non-immediate type even if mutually recursive *)
 module E = struct
-  type t = s [@@immediate]
+  type t : immediate = s
 
   and s = string
 end

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -2478,7 +2478,7 @@ expr:
     name=mkrhs(LIDENT {Some $1}) COLON layout=layout_annotation
     RPAREN fun_def
     { let loc = $sloc in
-      wrap_exp_attrs ~loc (mk_newtypes ~loc:$sloc [name, Some layout] $9) $2 }
+      wrap_exp_attrs ~loc (mk_newtypes ~loc:$sloc [name, layout] $9) $2 }
   | expr attribute
       { Exp.attr $1 $2 }
 /* BEGIN AVOID */
@@ -2913,7 +2913,7 @@ strict_binding:
   | LPAREN TYPE
     name=mkrhs(LIDENT {Some $1}) COLON layout=layout_annotation
     RPAREN fun_binding
-      { mk_newtypes ~loc:$sloc [name, Some layout] $7 }
+      { mk_newtypes ~loc:$sloc [name, layout] $7 }
 ;
 local_fun_binding:
     local_strict_binding
@@ -2934,7 +2934,7 @@ local_strict_binding:
   | LPAREN TYPE
     name=mkrhs(LIDENT {Some $1}) COLON layout=layout_annotation
     RPAREN fun_binding
-      { mk_newtypes ~loc:$sloc [name, Some layout] $7 }
+      { mk_newtypes ~loc:$sloc [name, layout] $7 }
 ;
 %inline match_cases:
   xs = preceded_or_separated_nonempty_llist(BAR, match_case)
@@ -2967,7 +2967,7 @@ fun_def:
   | LPAREN TYPE
     name=mkrhs(LIDENT {Some $1}) COLON layout=layout_annotation
     RPAREN fun_def
-      { mk_newtypes ~loc:$sloc [name, Some layout] $7 }
+      { mk_newtypes ~loc:$sloc [name, layout] $7 }
 ;
 
 (* Parsing labeled tuple expressions
@@ -3106,7 +3106,7 @@ newtype: (* : string with_loc * layout_annotation option *)
   | LPAREN
     name=mkrhs(LIDENT {Some $1}) COLON layout=layout_annotation
     RPAREN
-      { name, Some layout }
+      { name, layout }
 
 /* Patterns */
 
@@ -3432,7 +3432,7 @@ generic_type_declaration(flag, kind):
   flag = flag
   params = type_parameters
   id = mkrhs(LIDENT)
-  layout = layout_attr?
+  layout = layout_attr_opt
   kind_priv_manifest = kind
   cstrs = constraints
   attrs2 = post_item_attributes
@@ -3450,7 +3450,7 @@ generic_type_declaration(flag, kind):
   attrs1 = attributes
   params = type_parameters
   id = mkrhs(LIDENT)
-  layout = layout_attr?
+  layout = layout_attr_opt
   kind_priv_manifest = kind
   cstrs = constraints
   attrs2 = post_item_attributes
@@ -3514,13 +3514,17 @@ type_parameters:
 ;
 
 layout_annotation: (* : layout_annotation *)
-  ident { let loc = make_loc $sloc in
-          mkloc (check_layout ~loc $1) loc }
+  ident {
+    if Erase_jane_syntax.should_erase () then None
+    else
+      let loc = make_loc $sloc in
+      Some (mkloc (check_layout ~loc $1) loc) }
 ;
 
-layout_attr:
-  COLON
-  layout_annotation
+layout_attr_opt:
+  /* empty */
+    { None }
+  | COLON layout_annotation
     { $2 }
 ;
 
@@ -3529,7 +3533,7 @@ layout_attr:
   attrs=attributes
   COLON
   layout=layout_annotation
-  { let descr = Ptyp_var (name, Some layout) in
+  { let descr = Ptyp_var (name, layout) in
     mktyp ~loc:$sloc ~attrs descr }
 ;
 
@@ -3795,7 +3799,7 @@ with_type_binder:
   QUOTE mkrhs(ident {Some $1})
     { $2, None }
   | LPAREN QUOTE mkrhs(ident {Some $1})  COLON layout=layout_annotation RPAREN
-    { $3, Some layout }
+    { $3, layout }
 ;
 %inline typevar_list:
   (* : (string with_loc * layout_annotation option) list *)
@@ -3851,16 +3855,20 @@ alias_type:
       { $1 }
   | mktyp(
       ty = alias_type AS QUOTE tyvar = mkrhs(ident {Some $1})
-        { Ptyp_alias(ty, (tyvar, None)) }
-    | aliased_type = alias_type AS
+        { Ptyp_alias(ty, (tyvar, None)) })
+    { $1 }
+  | aliased_type = alias_type AS
       LPAREN
       name=mkrhs(tyvar_name_or_underscore)
       COLON
       layout = layout_annotation
       RPAREN
-        { Ptyp_alias (aliased_type, (name, Some layout)) }
-    )
-    { $1 }
+        { match layout, name.txt with
+        | None, None ->
+          assert (Erase_jane_syntax.should_erase ());
+          aliased_type
+        | _ ->
+          mktyp ~loc:$sloc (Ptyp_alias (aliased_type, (name, layout))) }
 ;
 
 (* Function types include:
@@ -4108,9 +4116,9 @@ atomic_type:
     | extension
         { Ptyp_extension $1 }
     | LPAREN QUOTE name=mkrhs(ident {Some $1}) COLON layout=layout_annotation RPAREN
-      { Ptyp_var (name, Some layout) }
+      { Ptyp_var (name, layout) }
     | LPAREN mkrhs(UNDERSCORE {None}) COLON layout=layout_annotation RPAREN
-      { Ptyp_var ($2, Some layout) }
+      { Ptyp_var ($2, layout) }
 
   )
   { $1 } /* end mktyp group */

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -3660,7 +3660,14 @@ layout_string: (* : string with_loc *)
 layout_attr:
   COLON
   layout=layout_string
-    { Attr.mk ~loc:layout.loc layout (PStr []) }
+    {
+      (* CR layouts: This deviates from what's in [flambda-backend].
+      In the long term, we want to be able to just import
+      parser-standard from there to make them the same again. *)
+      Attr.mk ~loc:layout.loc
+        {layout with txt = "jane.erasable.layouts." ^ layout.txt}
+        (PStr [])
+    }
 ;
 
 %inline type_param_with_layout:


### PR DESCRIPTION
This PR adds support for erasing layout annotations when the `--erase-jane-syntax` flag is provided.

This includes parser standard changes:
- Parser standard is changed to parse layout annotation on type declarations as attribute names prefixed with `jane.erasable.layouts` to have them dropped during ast normalization. Implementation here differs from the jane syntax encoding used by the flambda-backend parser. This is meant as a temporary solution before we can do straightforward parser imports to make them the same again. The alternative of porting [this PR](https://github.com/ocaml-flambda/flambda-backend/pull/1907) doesn't seem to be worth the effort.
- Standard ast normalization is changed to allow `float#` --> `float` rewrites.

And parser extended changes:
- Parser extended is changed to drop all layout annotations during parsing (same as what we do for locals).
- Parser extended removes type alias nodes with no names completely (since `(... as _)` is invalid syntax)

~~This PR notably doesn't make any changes to `[@@immediate]` and `[@@immediate64]`. Those attributes remain the same through this process.~~ See update

~~This PR should be merged after #60.~~ Already merged

---

Update regarding  `[@@immediate]` and `[@@immediate64]`

Last three commits added to this PR changes the treatment of these attributes.

Now ocamlformat rewrites both of these attributes into equivalent layout annotations by default. And when running with `--erase-jane-syntax`, the program does the opposite and rewrites immediate/immediate64 layout annotation on type declarations back into attributes.

~~Make sure [this flambda-backend PR](https://github.com/ocaml-flambda/flambda-backend/pull/2286) gets merged before this change to not break existing code.~~ merged

Might be easier to review [all the changes before this](https://github.com/janestreet/ocamlformat/pull/61/files/6d252d208f661216173d7269fa9f86095a308d9f) and then the [immediate rewrite commits](https://github.com/janestreet/ocamlformat/pull/61/files/6d252d208f661216173d7269fa9f86095a308d9f..ec5f542b6619d71872369c884b9cd01951b61367) separately.