### PR TITLE
Small typo fix (campl-streams -> camlp-streams)

### DIFF
--- a/HACKING.jst.md
+++ b/HACKING.jst.md
@@ -83,7 +83,7 @@ Before building
 You will need to install several libraries. This command may work:
 
 ```
-opam install menhir.20210419 fix ocp-indent bechamel-js alcotest campl-streams fpath either dune-build-info uuseg ocaml-version
+opam install menhir.20210419 fix ocp-indent bechamel-js alcotest camlp-streams fpath either dune-build-info uuseg ocaml-version
 ```
 
 Building


### PR DESCRIPTION
While following the opam install instructions while trying to run `make test`, I saw the following error:
```
opam install campl-streams
[ERROR] No package named campl-streams found.
```
This small feature fixes what I think is a typo from `campl-streams` -> `camlp-streams` in the installation instructions.

Testing.
----------
I ran `make test` and will additionally wait for any CI to complete before opening this pr up for review. Please let me know if there is additional testing that I should perform. Thanks!

I additionally saw a DCO check that failed due to me not originally putting:

```
Signed-off-by: Jose Rodriguez [enoumy@gmail.com](mailto:enoumy@gmail.com)
```
on my commit. I then ran `git rebase -i jane` and then reworded the commit the single commit in this feature to include the message, but this still resulted in CI failure. I then manually hit the button called "Set DCO to pass". I am unsure if this is the "proper" way of making the DCO check pass. Please let me know otherwise.