### PR TITLE
Fix a bug with comments and labeled tuples

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1188,7 +1188,9 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
               @@ hovbox 0 (str "~" $ str lbl.txt)
             else if punned_with_constraint then
               Cmts.fmt c lbl.loc @@ (str "~" $ fmt_pattern c pat)
-            else str "~" $ str lbl.txt $ str ":" $ fmt_pattern c pat
+            else
+              Cmts.fmt c lbl.loc
+              @@ (str "~" $ str lbl.txt $ str ":" $ fmt_pattern c pat)
       in
       let fmt_elements =
         list pats (Params.comma_sep c.conf) fmt_lt_pat_element
@@ -2870,7 +2872,9 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
               @@ hovbox 0 (str "~" $ str lbl.txt)
             else if punned_with_constraint then
               Cmts.fmt c lbl.loc @@ (str "~" $ fmt_expression c exp)
-            else str "~" $ str lbl.txt $ str ":" $ fmt_expression c exp
+            else
+              Cmts.fmt c lbl.loc
+              @@ (str "~" $ str lbl.txt $ str ":" $ fmt_expression c exp)
       in
       pro
       $ hvbox_if outer_wrap 0

--- a/test/passing/tests/labeled_tuples_cmts_attrs.ml
+++ b/test/passing/tests/labeled_tuples_cmts_attrs.ml
@@ -22,6 +22,12 @@ let _ = ~z, ~((* baz *) y : int)
 let _ = ~z, ~(y : (* baz *) int)
 let _ = ~z, ~(y : int (* baz *))
 let _ = ~z, ~(y : int) (* baz *)
+let _ = (* baz *) ~z:1, ~y:2
+let _ = ~z:(* baz *) 1, ~y:2
+let _ = ~z:1 (* baz *), ~y:2
+let _ = ~z:1, (* baz *) ~y:2
+let _ = ~z:1, ~y:(* baz *) 2
+let _ = ~z:1, ~y:2 (* baz *)
 
 (* Attrs around types *)
 type t = z:(int[@attr]) * y:bool
@@ -56,3 +62,9 @@ let ~z:42, ~((* baz *) y : int) = ()
 let ~z:42, ~(y : (* baz *) int) = ()
 let ~z:42, ~(y : int (* baz *)) = ()
 let ~z:42, ~(y : int) (* baz *) = ()
+let (* baz *) ~z:a, ~y:b = ()
+let ~z:(* baz *) a, ~y:b = ()
+let ~z:a (* baz *), ~y:b = ()
+let ~z:a, (* baz *) ~y:b = ()
+let ~z:a, ~y:(* baz *) b = ()
+let ~z:a, ~y:b (* baz *) = ()


### PR DESCRIPTION
Labeled tuples printing for patterns and expressions had a bug where we'd drop comments that appeared just before an element if that element is:
- not the first element, 
- not punned, and 
- does not have a type annotation

The bug is simple - I just forgot to check for comments in that case.  This fixes it an adds a test.