### PR TITLE
Parse any layout name, not just a preset list

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -540,16 +540,7 @@ let fmt_quoted_string key ext s = function
 
 let type_var_has_layout_annot (_, layout_opt) = Option.is_some layout_opt
 
-let layout_to_string = function
-  | Any -> "any"
-  | Value -> "value"
-  | Void -> "void"
-  | Immediate64 -> "immediate64"
-  | Immediate -> "immediate"
-  | Float64 -> "float64"
-  | Word -> "word"
-  | Bits32 -> "bits32"
-  | Bits64 -> "bits64"
+let layout_to_string = function Layout s -> s
 
 let fmt_layout_str ~c ~loc string =
   fmt "@ :@ " $ Cmts.fmt c loc @@ str string

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -133,8 +133,9 @@ let remove_local_attrs cmts param =
 
 let get_layout_of_legacy_attr attr =
   match (attr.attr_name.txt, attr.attr_payload) with
-  | ("ocaml.immediate64" | "immediate64"), PStr [] -> Some Immediate64
-  | ("ocaml.immediate" | "immediate"), PStr [] -> Some Immediate
+  | ("ocaml.immediate64" | "immediate64"), PStr [] ->
+      Some (Layout "immediate64")
+  | ("ocaml.immediate" | "immediate"), PStr [] -> Some (Layout "immediate")
   | _ -> None
 
 let rewrite_type_declaration_imm_attr_to_layout_annot cmts decl =

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -309,3 +309,18 @@ let f (type a b) x = x
 module type S = sig
   val init_with_immediates : 'a 'b. int -> f:(int -> 'a) -> 'a t
 end
+
+(**************************************)
+(* Test 11: Arbitrary strings as layout names *)
+
+type t_asdf
+
+let x : int as 'a = 5
+
+let f : 'a. 'a t -> 'a t = fun x -> x
+
+let _ : _ =
+  [%str
+    let%lpoly rec fold (type a acc) (xs : a list) ~(init : acc) ~f =
+      match xs with [] -> init | x :: xs -> fold xs ~init:(f init x) ~f
+    [@@layout (poly : value bits64), (acc : value bits64)]]

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -316,3 +316,18 @@ module type S = sig
     ('a : immediate) ('b : immediate).
     int -> f:local_ (int -> local_ 'a) -> local_ 'a t
 end
+
+(**************************************)
+(* Test 11: Arbitrary strings as layout names *)
+
+type t_asdf : asdf
+
+let x : int as ('a : some_layout) = 5
+
+let f : ('a : alayout). 'a t -> 'a t = fun x -> x
+
+let _ : _ =
+  [%str
+    let%lpoly rec fold (type (a : poly) acc) (xs : a list) ~(init : acc) ~f =
+      match xs with [] -> init | x :: xs -> fold xs ~init:(f init x) ~f
+    [@@layout (poly : value bits64), (acc : value bits64)]]

--- a/vendor/parser-extended/asttypes.mli
+++ b/vendor/parser-extended/asttypes.mli
@@ -61,20 +61,9 @@ type 'a loc = 'a Location.loc = {
   loc : Location.t;
 }
 
-(* constant layouts are parsed as layout annotations, and also used
-   in the type checker as already-inferred (i.e. non-variable) layouts *)
-type const_layout =
-  | Any
-  | Value
-  | Void
-  | Immediate64
-  | Immediate
-  | Float64
-  | Word
-  | Bits32
-  | Bits64
+type layout = Layout of string [@@unboxed]
 
-type layout_annotation = const_layout loc
+type layout_annotation = layout loc
 type ty_var = string option loc * layout_annotation option
 
 type label = string

--- a/vendor/parser-extended/asttypes.mli
+++ b/vendor/parser-extended/asttypes.mli
@@ -61,9 +61,9 @@ type 'a loc = 'a Location.loc = {
   loc : Location.t;
 }
 
-type layout = Layout of string [@@unboxed]
+type const_layout = Layout of string [@@unboxed]
 
-type layout_annotation = layout loc
+type layout_annotation = const_layout loc
 type ty_var = string option loc * layout_annotation option
 
 type label = string

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -704,24 +704,11 @@ let mk_directive ~loc name arg =
       pdir_loc = make_loc loc;
     }
 
-let check_layout ~loc id : const_layout =
-  match id with
-  | "any" -> Any
-  | "value" -> Value
-  | "void" -> Void
-  | "immediate64" -> Immediate64
-  | "immediate" -> Immediate
-  | "float64" -> Float64
-  | "word" -> Word
-  | "bits32" -> Bits32
-  | "bits64" -> Bits64
-  | _ -> expecting_loc loc "layout"
-
 let convert_layout_to_legacy_attr =
   let mk ~loc name = [Attr.mk ~loc (mkloc name loc) (PStr [])] in
   function
-  | {txt = Immediate; loc} -> mk ~loc "immediate"
-  | {txt = Immediate64; loc} -> mk ~loc "immediate64"
+  | {txt = Layout "immediate"; loc} -> mk ~loc "immediate"
+  | {txt = Layout "immediate64"; loc} -> mk ~loc "immediate64"
   | _ -> []
 
 (* NOTE: An alternate approach for performing the erasure of %call_pos and %src_pos
@@ -3576,7 +3563,7 @@ layout_annotation_gen:
   ident
     {
       let loc = make_loc $sloc in
-      (mkloc (check_layout ~loc $1) loc)
+      (mkloc (Layout $1) loc)
     }
 
 layout_annotation: (* : layout_annotation *)

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -201,15 +201,7 @@ let paren_kind i ppf = function
   | Bracket -> line i ppf "Bracket\n"
 
 let layout_to_string = function
-  | Any -> "any"
-  | Value -> "value"
-  | Void -> "void"
-  | Immediate64 -> "immediate64"
-  | Immediate -> "immediate"
-  | Float64 -> "float64"
-  | Word -> "word"
-  | Bits32 -> "bits32"
-  | Bits64 -> "bits64"
+  | Layout s -> s
 
 let fmt_layout_opt ppf l = Format.fprintf ppf "%s"
   (Option.value ~default:"none" (Option.map (fun l -> layout_to_string l.txt) l))

--- a/vendor/parser-standard/asttypes.mli
+++ b/vendor/parser-standard/asttypes.mli
@@ -55,9 +55,9 @@ type 'a loc = 'a Location.loc = {
 
 (* constant layouts are parsed as layout annotations, and also used
    in the type checker as already-inferred (i.e. non-variable) layouts *)
-type layout = Layout of string [@@unboxed]
+type const_layout = Layout of string [@@unboxed]
 
-type layout_annotation = layout loc
+type layout_annotation = const_layout loc
 
 type label = string
 

--- a/vendor/parser-standard/asttypes.mli
+++ b/vendor/parser-standard/asttypes.mli
@@ -55,18 +55,9 @@ type 'a loc = 'a Location.loc = {
 
 (* constant layouts are parsed as layout annotations, and also used
    in the type checker as already-inferred (i.e. non-variable) layouts *)
-type const_layout =
-  | Any
-  | Value
-  | Void
-  | Immediate64
-  | Immediate
-  | Float64
-  | Word
-  | Bits32
-  | Bits64
+type layout = Layout of string [@@unboxed]
 
-type layout_annotation = const_layout loc
+type layout_annotation = layout loc
 
 type label = string
 

--- a/vendor/parser-standard/jane_syntax.ml
+++ b/vendor/parser-standard/jane_syntax.ml
@@ -755,7 +755,7 @@ end
 (** Layout annotations' encoding as attribute payload, used in both n-ary
     functions and layouts. *)
 module Layout_annotation : sig
-  include Payload_protocol with type t := const_layout
+  include Payload_protocol with type t := layout
 
   module Decode : sig
     include module type of Decode
@@ -766,33 +766,14 @@ module Layout_annotation : sig
   end
 end = struct
   module Protocol = Make_payload_protocol_of_stringable (struct
-      type t = const_layout
+      type t = layout
 
       let indefinite_article_and_name = "a", "layout"
 
       let to_string = function
-        | Any -> "any"
-        | Value -> "value"
-        | Void -> "void"
-        | Immediate64 -> "immediate64"
-        | Immediate -> "immediate"
-        | Float64 -> "float64"
-        | Word -> "word"
-        | Bits32 -> "bits32"
-        | Bits64 -> "bits64"
+        | Layout s -> s
 
-      (* CR layouts v1.5: revise when moving layout recognition away from parser*)
-      let of_string = function
-        | "any" -> Some Any
-        | "value" -> Some Value
-        | "void" -> Some Void
-        | "immediate" -> Some Immediate
-        | "immediate64" -> Some Immediate64
-        | "float64" -> Some Float64
-        | "word" -> Some Word
-        | "bits32" -> Some Bits32
-        | "bits64" -> Some Bits64
-        | _ -> None
+      let of_string s = Some (Layout s)
     end)
   (*******************************************************)
   (* Conversions with a payload *)

--- a/vendor/parser-standard/jane_syntax.ml
+++ b/vendor/parser-standard/jane_syntax.ml
@@ -755,7 +755,7 @@ end
 (** Layout annotations' encoding as attribute payload, used in both n-ary
     functions and layouts. *)
 module Layout_annotation : sig
-  include Payload_protocol with type t := layout
+  include Payload_protocol with type t := const_layout
 
   module Decode : sig
     include module type of Decode
@@ -766,7 +766,7 @@ module Layout_annotation : sig
   end
 end = struct
   module Protocol = Make_payload_protocol_of_stringable (struct
-      type t = layout
+      type t = const_layout
 
       let indefinite_article_and_name = "a", "layout"
 

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -743,19 +743,6 @@ let mk_directive ~loc name arg =
       pdir_loc = make_loc loc;
     }
 
-let check_layout ~loc id : const_layout =
-  match id with
-  | "any" -> Any
-  | "value" -> Value
-  | "void" -> Void
-  | "immediate64" -> Immediate64
-  | "immediate" -> Immediate
-  | "float64" -> Float64
-  | "word" -> Word
-  | "bits32" -> Bits32
-  | "bits64" -> Bits64
-  | _ -> expecting_loc loc "layout"
-
 (* Unboxed literals *)
 
 (* CR layouts v2.5: The [unboxed_*] functions will both be improved and lose
@@ -3647,13 +3634,11 @@ type_parameters:
 
 layout_annotation: (* : layout_annotation *)
   ident { let loc = make_loc $sloc in
-          mkloc (check_layout ~loc $1) loc }
+          mkloc (Layout $1) loc }
 ;
 
 layout_string: (* : string with_loc *)
-  (* the [check_layout] just ensures this is the name of a layout *)
   ident { let loc = make_loc $sloc in
-          ignore (check_layout ~loc $1 : const_layout);
           mkloc $1 loc }
 ;
 

--- a/vendor/parser-standard/printast.ml
+++ b/vendor/parser-standard/printast.ml
@@ -19,16 +19,8 @@ open Lexing
 open Location
 open Parsetree
 
-let const_layout_to_string = function
-  | Any -> "any"
-  | Value -> "value"
-  | Immediate -> "immediate"
-  | Immediate64 -> "immediate64"
-  | Void -> "void"
-  | Float64 -> "float64"
-  | Word -> "word"
-  | Bits32 -> "bits32"
-  | Bits64 -> "bits64"
+let layout_to_string = function
+  | Layout s -> s
 
 let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in
@@ -149,11 +141,11 @@ let tyvar ppf s =
   else
     Format.fprintf ppf "'%s" s
 
-let const_layout ppf lay =
-  Format.fprintf ppf "%s" (const_layout_to_string lay)
+let layout ppf lay =
+  Format.fprintf ppf "%s" (layout_to_string lay)
 
-let layout_annotation i ppf layout =
-  line i ppf "%a" const_layout layout.txt
+let layout_annotation i ppf lay =
+  line i ppf "%a" layout lay.txt
 
 let typevars ppf vs =
   List.iter (fun x -> fprintf ppf " %a" tyvar x.txt) vs

--- a/vendor/parser-standard/printast.ml
+++ b/vendor/parser-standard/printast.ml
@@ -19,9 +19,6 @@ open Lexing
 open Location
 open Parsetree
 
-let layout_to_string = function
-  | Layout s -> s
-
 let fmt_position with_name f l =
   let fname = if with_name then l.pos_fname else "" in
   if l.pos_lnum = -1
@@ -141,11 +138,11 @@ let tyvar ppf s =
   else
     Format.fprintf ppf "'%s" s
 
-let layout ppf lay =
-  Format.fprintf ppf "%s" (layout_to_string lay)
+let const_layout ppf (Layout lay) =
+  Format.fprintf ppf "%s" lay
 
-let layout_annotation i ppf lay =
-  line i ppf "%a" layout lay.txt
+let layout_annotation i ppf layout =
+  line i ppf "%a" const_layout layout.txt
 
 let typevars ppf vs =
   List.iter (fun x -> fprintf ppf " %a" tyvar x.txt) vs


### PR DESCRIPTION
Updates both `parser-standard` and `parser-extended` to be able to parse any string as a layout name. This puts them in line with the behavior of the `flambda-backend` compiler's parser.