### PR TITLE
Fix bug with formatting layout annotations

### DIFF
--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -18,9 +18,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          # PR 65 broke windows support. Getting this back isn't high priority,
-          # but it would be nice.
-          # - windows-latest
+          - windows-latest
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
           - 4.14.x

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -31,36 +31,59 @@ let is_erasable_jane_syntax attr =
 
 (* Immediate layout annotations should be treated the same as their attribute
    counterparts *)
-let normalize_immediate_annot_and_attrs attr =
-  match (attr.attr_name.txt, attr.attr_payload) with
-  (* We also have to normalize "ocaml.immediate" into "immediate" for this to
-     work. Since if we rewrite [@@ocaml.immediate] into an annotation and
-     treat that as [@@immediate]. That's an attribute change we need to
-     accept. *)
-  | ( "jane.erasable.layouts.annot"
-    , PStr
-        [ { pstr_desc=
-              Pstr_eval
-                ({pexp_desc= Pexp_ident {txt= Lident "immediate"; _}; _}, _)
-          ; _ } ] )
-   |"ocaml.immediate", PStr [] ->
-      Some
-        { attr with
-          attr_name= {attr.attr_name with txt= "immediate"}
-        ; attr_payload= PStr [] }
-  | ( "jane.erasable.layouts.annot"
-    , PStr
-        [ { pstr_desc=
-              Pstr_eval
-                ({pexp_desc= Pexp_ident {txt= Lident "immediate64"; _}; _}, _)
-          ; _ } ] )
-   |"ocaml.immediate64", PStr [] ->
-      Some
-        { attr with
-          attr_name= {attr.attr_name with txt= "immediate64"}
-        ; attr_payload= PStr [] }
-  | "jane.erasable.layouts", PStr [] -> None
-  | _, _ -> Some attr
+let normalize_immediate_annot_and_attrs attrs =
+  let overwrite_attr_name attr new_name =
+    { attr with
+      attr_name= {attr.attr_name with txt= new_name}
+    ; attr_payload= PStr [] }
+  in
+  let attrs, _ =
+    List.fold attrs ~init:([], false)
+      ~f:(fun (new_attrs, deleted_layout_annot) attr ->
+        let new_attr, just_deleted_layout_annot =
+          match (attr.attr_name.txt, attr.attr_payload) with
+          (* We also have to normalize "ocaml.immediate" into "immediate" for
+             this to work. Since if we rewrite [@@ocaml.immediate] into an
+             annotation and treat that as [@@immediate]. That's an attribute
+             change we need to accept. *)
+          | ( "jane.erasable.layouts.annot"
+            , PStr
+                [ { pstr_desc=
+                      Pstr_eval
+                        ( { pexp_desc= Pexp_ident {txt= Lident "immediate"; _}
+                          ; _ }
+                        , _ )
+                  ; _ } ] ) ->
+              (Some (overwrite_attr_name attr "immediate"), true)
+          | "ocaml.immediate", PStr [] ->
+              (Some (overwrite_attr_name attr "immediate"), false)
+          | ( "jane.erasable.layouts.annot"
+            , PStr
+                [ { pstr_desc=
+                      Pstr_eval
+                        ( { pexp_desc=
+                              Pexp_ident {txt= Lident "immediate64"; _}
+                          ; _ }
+                        , _ )
+                  ; _ } ] ) ->
+              (Some (overwrite_attr_name attr "immediate64"), true)
+          | "ocaml.immediate64", PStr [] ->
+              (Some (overwrite_attr_name attr "immediate64"), false)
+          | "jane.erasable.layouts", PStr [] ->
+              (* Only remove [jane.erasable.layouts] if we previously rewrote
+                 an associated [jane.erasable.layouts.annot] *)
+              if deleted_layout_annot then (None, false)
+              else (Some attr, false)
+          | _, _ -> (Some attr, false)
+        in
+        let new_attrs =
+          match new_attr with
+          | Some new_attr -> new_attr :: new_attrs
+          | None -> new_attrs
+        in
+        (new_attrs, deleted_layout_annot || just_deleted_layout_annot) )
+  in
+  List.rev attrs
 
 let dedup_cmts fragment ast comments =
   let of_ast ast =
@@ -339,8 +362,7 @@ let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
   in
   let type_declaration (m : Ast_mapper.mapper) decl =
     let ptype_attributes =
-      decl.ptype_attributes
-      |> List.filter_map ~f:normalize_immediate_annot_and_attrs
+      decl.ptype_attributes |> normalize_immediate_annot_and_attrs
       (* CR jane-syntax: This ensures that jane syntax attributes are
          removed *)
       |> if erase_jane_syntax then map_attributes_no_sort m else Fn.id

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -69,11 +69,10 @@ let normalize_immediate_annot_and_attrs attrs =
               (Some (overwrite_attr_name attr "immediate64"), true)
           | "ocaml.immediate64", PStr [] ->
               (Some (overwrite_attr_name attr "immediate64"), false)
-          | "jane.erasable.layouts", PStr [] ->
+          | "jane.erasable.layouts", PStr [] when deleted_layout_annot ->
               (* Only remove [jane.erasable.layouts] if we previously rewrote
                  an associated [jane.erasable.layouts.annot] *)
-              if deleted_layout_annot then (None, false)
-              else (Some attr, false)
+              (None, false)
           | _, _ -> (Some attr, false)
         in
         let new_attrs =

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3565,7 +3565,7 @@
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/layout_annotation.ml layout_annotation.ml.stdout)))
+ (action (diff tests/layout_annotation.ml.ref layout_annotation.ml.stdout)))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -1,21 +1,20 @@
 val foo :
-  ('k
-   : immediate64) 'cmp.
+  ('k : immediate64) 'cmp.
      (module S
         with type Id_and_repr.t = 'k
          and type Id_and_repr.comparator_witness = 'cmp )
   -> 'k Jane_symbol.Map.t
   -> ('k, Sockaddr.t, 'cmp) Map.t
 
-type ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt : value
+type ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt
+  :
+  value
 
-type  t_value  :  value
+type t_value : value
 
-type t_imm
-     : immediate
+type t_imm : immediate
 
-type t_imm64 :
-       immediate64
+type t_imm64 : immediate64
 
 type t_float64 : float64
 


### PR DESCRIPTION
PR #65 introduced a bug with formatting layout annotations. A small example of a file that would fail to format is
```
type t :           value
```
The testsuite did not catch this bug due to the the fact that the only layout annotation test was an already formatted file.

This PR fixes the bug and updates the test to check for this in the future. It also re-enables the windows build, since this was apparently also the bug causing that to fail.