### PR TITLE
Add support for new local syntax

### DIFF
--- a/lib/Extended_ast.ml
+++ b/lib/Extended_ast.ml
@@ -80,7 +80,8 @@ module Parse = struct
                   ( { pexp_desc= Pexp_ident {txt= v_txt; _}
                     ; pexp_attributes= []
                     ; _ }
-                  , t1 )
+                  , Some t1
+                  , [] )
             ; pexp_attributes= []
             ; _ } )
         when enable_short_field_annot
@@ -94,7 +95,8 @@ module Parse = struct
                   ( { pexp_desc= Pexp_ident {txt= v_txt; _}
                     ; pexp_attributes= []
                     ; _ }
-                  , t1 )
+                  , Some t1
+                  , [] )
             ; pexp_attributes= []
             ; _ } )
         when enable_short_field_annot
@@ -147,7 +149,8 @@ module Parse = struct
                   ( { ppat_desc= Ppat_var {txt= v_txt; _}
                     ; ppat_attributes= []
                     ; _ }
-                  , t )
+                  , Some t
+                  , [] )
             ; ppat_attributes= []
             ; _ } )
         when enable_short_field_annot
@@ -182,7 +185,8 @@ module Parse = struct
       | { ppat_desc=
             Ppat_constraint
               ( {ppat_desc= Ppat_unpack (name, None); ppat_attributes= []; _}
-              , {ptyp_desc= Ptyp_package pt; ptyp_attributes= []; _} )
+              , Some {ptyp_desc= Ptyp_package pt; ptyp_attributes= []; _}
+              , [] )
         ; _ } as p ->
           {p with ppat_desc= Ppat_unpack (name, Some pt)}
       | p -> Ast_mapper.default_mapper.pat m p
@@ -228,8 +232,12 @@ module Parse = struct
                 ; pexp_attributes= []
                 ; pexp_loc
                 ; _ }
-              , {ptyp_desc= Ptyp_package pt; ptyp_attributes= []; ptyp_loc; _}
-              )
+              , Some
+                  { ptyp_desc= Ptyp_package pt
+                  ; ptyp_attributes= []
+                  ; ptyp_loc
+                  ; _ }
+              , [] )
         ; _ } as p
         when Migrate_ast.Location.compare_start ptyp_loc pexp_loc > 0 ->
           (* Match locations to differentiate between the two position for

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -142,9 +142,10 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
     let exp = {exp with pexp_loc_stack= []} in
     let {pexp_desc; pexp_loc= loc1; pexp_attributes= attrs1; _} = exp in
     match pexp_desc with
-    | Pexp_poly ({pexp_desc= Pexp_constraint (e, t); _}, None) ->
+    | Pexp_poly ({pexp_desc= Pexp_constraint (e, Some t, []); _}, None) ->
         m.expr m {exp with pexp_desc= Pexp_poly (e, Some t)}
-    | Pexp_constraint (e, {ptyp_desc= Ptyp_poly ([], _t); _}) -> m.expr m e
+    | Pexp_constraint (e, Some {ptyp_desc= Ptyp_poly ([], _t); _}, []) ->
+        m.expr m e
     | Pexp_sequence
         ( exp1
         , { pexp_desc= Pexp_sequence (exp2, exp3)

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -17,7 +17,7 @@ val decompose_arrow :
      Cmts.t
   -> Ast.t
   -> arrow_param list
-  -> core_type
+  -> core_type * mode loc list
   -> (arrow_param * bool) list * (arrow_param * bool) * Ast.t
 (** [decompose_arrow ctl ct2] returns a list of arrow params, where the last
     is a dummy param corresponding to ct2 (the return type) and a bool
@@ -84,6 +84,7 @@ module Let_binding : sig
     ; lb_pun: bool
     ; lb_attrs: attribute list
     ; lb_local: bool
+    ; lb_modes: mode loc list
     ; lb_loc: Location.t }
 
   val of_let_binding :

--- a/test/cli/debug.t
+++ b/test/cli/debug.t
@@ -32,6 +32,8 @@
                   expression (a.ml[4,59+4]..[4,59+7])
                     Pexp_ident "A.x" (a.ml[4,59+4]..[4,59+7])
               ]
+            modes
+            []
         ]
     ]
   
@@ -60,6 +62,8 @@
                   expression (a.ml[4,59+4]..[4,59+7])
                     Pexp_ident "A.x" (a.ml[4,59+4]..[4,59+7])
               ]
+            modes
+            []
         ]
     ]
   
@@ -88,6 +92,8 @@
                   expression (a.ml[2,34+23]..[2,34+26])
                     Pexp_ident "A.x" (a.ml[2,34+23]..[2,34+26])
               ]
+            modes
+            []
         ]
     ]
   
@@ -115,6 +121,8 @@
                   expression (a.ml[2,34+23]..[2,34+26])
                     Pexp_ident "A.x" (a.ml[2,34+23]..[2,34+26])
               ]
+            modes
+            []
         ]
     ]
   
@@ -178,9 +186,13 @@
                       within: (* within unit #2 *)
                        after: (* after unit *)
                     None
+                  modes
+                  []
               ]
               expression (a.ml[6,233+2]..[6,233+3])
                 Pexp_ident "x" (a.ml[6,233+2]..[6,233+3])
+            modes
+            []
         ]
     ]
   
@@ -231,9 +243,13 @@
                       within: (* within unit #2 *)
                        after: (* after unit *)
                     None
+                  modes
+                  []
               ]
               expression (a.ml[6,233+2]..[6,233+3])
                 Pexp_ident "x" (a.ml[6,233+2]..[6,233+3])
+            modes
+            []
         ]
     ]
   
@@ -284,9 +300,13 @@
                       within: (* within unit #1 *)
                       within: (* within unit #2 *)
                     None
+                  modes
+                  []
               ]
               expression (a.ml[13,265+2]..[13,265+3])
                 Pexp_ident "x" (a.ml[13,265+2]..[13,265+3])
+            modes
+            []
         ]
     ]
   
@@ -336,9 +356,13 @@
                       within: (* within unit #1 *)
                       within: (* within unit #2 *)
                     None
+                  modes
+                  []
               ]
               expression (a.ml[13,265+2]..[13,265+3])
                 Pexp_ident "x" (a.ml[13,265+2]..[13,265+3])
+            modes
+            []
         ]
     ]
   

--- a/test/failing/dune.inc
+++ b/test/failing/dune.inc
@@ -237,6 +237,19 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+   (with-outputs-to modes_on_patterns.ml.output
+     (with-accepted-exit-codes 1
+       (run %{bin:ocamlformat} %{dep:tests/modes_on_patterns.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_on_patterns.ml.broken-ref modes_on_patterns.ml.output)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
    (with-outputs-to module.ml.output
      (with-accepted-exit-codes 1
        (run %{bin:ocamlformat} %{dep:tests/module.ml})))))

--- a/test/failing/tests/modes_on_patterns.ml
+++ b/test/failing/tests/modes_on_patterns.ml
@@ -1,0 +1,191 @@
+(* Modes on arbitrary patterns were supported in the parser during development of
+   ocamlformat support for modes, but were later unsupported in the parser, causing
+   the below tests to fail. If patterns are ever again supported in the parser, move
+   these tests back to [test/passing/modes*.ml]. *)
+
+module Patterns = struct
+  (* [let (pat @ mode) = x] parses as a mode on the let binding, not on the pattern *)
+  let pat @ mode = x
+  let (pat : typ @@ mode) = x
+
+  (* [let (pat @ mode), (pat @ mode) = x] currently does not parse *)
+  let ((pat @ mode), (pat @ mode)) = x
+
+  let () =
+    let ((pat @ mode), (pat @ mode)) = x in
+    ()
+  ;;
+
+  let { a = (a @ mode); b = (b1 @ mode), (b2 @ mode); c = (c : typ @@ mode) } = x
+  let (A ((a @ mode), (b @ mode))) = x
+  let (A (a @ mode) @ mode) = x
+
+  (* mode constraints in other patterns *)
+  let { alias1 = (x @ mode) as y
+      ; alias2 = (x : typ @@ mode) as y
+      ; tuple1 = (x @ mode), (y @ mode)
+      ; tuple2 = (x : typ @@ mode), (y : typ @@ mode)
+      ; tuple3 = ~x:(x @ mode), ~y:(y @ mode)
+      ; tuple4 = ~x:(x : typ @@ mode), ~y:(y : typ @@ mode)
+      ; construct1 = A (x @ mode)
+      ; construct2 = A ((x, y) @ mode)
+      ; construct3 = A ((x @ mode), (y @ mode))
+      ; construct4 = A (x : typ @@ mode)
+      ; construct5 = A ((x, y) : typ @@ mode)
+      ; construct6 = A ((x : typ @@ mode), (y : typ @@ mode))
+      ; variant1 = `A (x @ mode)
+      ; variant2 = `A ((x, y) @ mode)
+      ; variant3 = `A ((x @ mode), (y @ mode))
+      ; variant4 = `A (x : typ @@ mode)
+      ; variant5 = `A ((x, y) : typ @@ mode)
+      ; variant6 = `A ((x : typ @@ mode), (y : typ @@ mode))
+      ; array1 = [| (x @ mode) |]
+      ; array2 = [| (x : typ @@ mode) |]
+      ; list1 = [ (x @ mode) ]
+      ; list2 = [ (x : typ @@ mode) ]
+      ; or1 = (x @ mode) | (y @ mode)
+      ; or2 = (x : typ @@ mode) | (y : typ @@ mode)
+      ; constraint1 = ((x @ mode) @ mode)
+      ; constraint2 = ((x : typ @@ mode) @ mode)
+      ; constraint3 = ((x @ mode) : typ @@ mode)
+      ; constraint4 = ((x : typ @@ mode) : typ @@ mode)
+      ; lazy1 = (lazy (x @ mode))
+      ; lazy2 = (lazy (x : typ @@ mode))
+      ; exception1 = (exception (x @ mode))
+      ; exception2 = (exception (x : typ @@ mode))
+      ; extension1 = [%ext? (x @ mode)]
+      ; extension2 = [%ext? (x : typ @@ mode)]
+      ; open1 = M.((X @ mode))
+      ; open2 = M.((X : typ @@ mode))
+      ; cons1 = (x @ mode) :: (y @ mode) :: (z @ mode)
+      ; cons2 = (x : typ @@ mode) :: (y : typ @@ mode) :: (z : typ @@ mode)
+      }
+    =
+    x
+  ;;
+
+  (* other patterns in mode constraints *)
+  let { any1 = (_ @ mode)
+      ; any2 = (_ : typ @@ mode)
+      ; var1 = (x @ mode)
+      ; var2 = (x : typ @@ mode)
+      ; alias1 = (A as x @ mode)
+      ; alias2 = (A as x : typ @@ mode)
+      ; constant1 = ("" @ mode)
+      ; constant2 = ("" : typ @@ mode)
+      ; interval1 = ('a' .. 'z' @ mode)
+      ; interval2 = ('a' .. 'z' : typ @@ mode)
+      ; tuple1 = ((x, y) @ mode)
+      ; tuple2 = ((x, y) : typ @@ mode)
+      ; tuple3 = ((~x, ~y) @ mode)
+      ; tuple4 = ((~x, ~y) : typ @@ mode)
+      ; construct1 = (A @ mode)
+      ; construct2 = (A x @ mode)
+      ; construct3 = (A (x, y) @ mode)
+      ; construct4 = (A { x; y } @ mode)
+      ; construct5 = (A : typ @@ mode)
+      ; construct6 = (A x : typ @@ mode)
+      ; construct7 = (A (x, y) : typ @@ mode)
+      ; construct8 = (A { x; y } : typ @@ mode)
+      ; variant1 = (`A @ mode)
+      ; variant2 = (`A x @ mode)
+      ; variant3 = (`A (x, y) @ mode)
+      ; variant4 = (`A : typ @@ mode)
+      ; variant5 = (`A x : typ @@ mode)
+      ; variant6 = (`A (x, y) : typ @@ mode)
+      ; record1 = ({ x } @ mode)
+      ; record2 = ({ x } : typ @@ mode)
+      ; array1 = ([| x |] @ mode)
+      ; array2 = ([| x |] : typ @@ mode)
+      ; list1 = ([ x ] @ mode)
+      ; list2 = ([ x ] : typ @@ mode)
+      ; or1 = (x | y @ mode)
+      ; or2 = (x | y : typ @@ mode)
+      ; constraint1 = ((x @ mode) @ mode)
+      ; constraint2 = ((x : typ @@ mode) @ mode)
+      ; constraint3 = ((x @ mode) : typ @@ mode)
+      ; constraint4 = ((x : typ @@ mode) : typ @@ mode)
+      ; type1 = (#x @ mode)
+      ; type2 = (#x : typ @@ mode)
+      ; lazy1 = ((lazy x) @ mode)
+      ; lazy2 = ((lazy x) : typ @@ mode)
+      ; unpack1 = ((module P) @ mode)
+      ; unpack2 = ((module P) : typ @@ mode)
+      ; unpack3 = ((module P : S) @ mode)
+      ; unpack4 = ((module P : S) : typ @@ mode)
+      ; exception1 = ((exception E) @ mode)
+      ; exception2 = ((exception E) : typ @@ mode)
+      ; extension1 = ([%ext] @ mode)
+      ; extension2 = ([%ext] : typ @@ mode)
+      ; open1 = (M.(X x) @ mode)
+      ; open2 = (M.(X x) : typ @@ mode)
+      ; cons1 = (a :: b :: c @ mode)
+      ; cons2 = (a :: b :: c : typ @@ mode)
+      }
+    =
+    x
+  ;;
+end
+
+module No_illegal_sugaring = struct
+  let { x = (x : t @@ mode) } = y
+
+  let () =
+    let ((module M) : (module T) @@ mode) = ((module M) : (module T) @@ mode) in
+    ()
+  ;;
+
+  let (~x:(x @ mode), ~y:(y @ mode)) = ~x:(x : _ @@ mode), ~y:(y : _ @@ mode)
+end
+
+module Line_breaking = struct
+  module Patterns = struct
+    let long_pat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      x
+    ;;
+
+    let (long_pat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+           t
+           @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      =
+      x
+    ;;
+
+    let (long_pat_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+           long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      =
+      x
+    ;;
+  end
+end
+
+module Regressions = struct
+  class t =
+    let ((x @ mode), (y @ mode)) = x in
+    object end
+end
+
+module Attrs = struct
+  let (pat [@attr]) @ mode = x
+  let ((pat [@attr]) : typ @@ mode) = x
+  let (pat : (typ[@attr]) @@ mode) = x
+  let ((pat : typ @@ mode) [@attr]) = x
+end
+
+module Comments = struct
+  let (* cmt *) pat @ mode = x
+  let pat (* cmt *) @ mode = x
+  let pat @ (* cmt *) mode = x
+  let pat @ mode (* cmt *) = x
+  let (* cmt *) (pat : typ @@ mode) = x
+  let ((* cmt *) pat : typ @@ mode) = x
+  let (pat (* cmt *) : typ @@ mode) = x
+  let (pat : (* cmt *) typ @@ mode) = x
+  let (pat : typ (* cmt *) @@ mode) = x
+  let (pat : typ @@ (* cmt *) mode) = x
+  let (pat : typ @@ mode (* cmt *)) = x
+  let (pat : typ @@ mode) (* cmt *) = x
+end

--- a/test/failing/tests/modes_on_patterns.ml.broken-ref
+++ b/test/failing/tests/modes_on_patterns.ml.broken-ref
@@ -1,0 +1,9 @@
+ocamlformat: ignoring "tests/modes_on_patterns.ml" (syntax error)
+File "tests/modes_on_patterns.ml", line 9, characters 17-19:
+9 |   let (pat : typ @@ mode) = x
+                     ^^
+Error: Syntax error: ')' expected
+File "tests/modes_on_patterns.ml", line 9, characters 6-7:
+9 |   let (pat : typ @@ mode) = x
+          ^
+  This '(' might be unmatched

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -8027,6 +8027,186 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to modes-ocaml_version.ml.stdout
+   (with-stderr-to modes-ocaml_version.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --ocaml-version=4.14.0 %{dep:tests/modes.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes-ocaml_version.ml.ref modes-ocaml_version.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes-ocaml_version.ml.err modes-ocaml_version.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes.ml.stdout
+   (with-stderr-to modes.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/modes.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes.ml.ref modes.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes.ml.err modes.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes.ml.js-stdout
+   (with-stderr-to modes.ml.js-stderr
+     (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/modes.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes.ml.js-ref modes.ml.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes.ml.js-err modes.ml.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_attrs.ml.stdout
+   (with-stderr-to modes_attrs.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/modes_attrs.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_attrs.ml.ref modes_attrs.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_attrs.ml.err modes_attrs.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_attrs.ml.js-stdout
+   (with-stderr-to modes_attrs.ml.js-stderr
+     (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/modes_attrs.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_attrs.ml.js-ref modes_attrs.ml.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_attrs.ml.js-err modes_attrs.ml.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_cmts-break_separators_after.ml.stdout
+   (with-stderr-to modes_cmts-break_separators_after.ml.stderr
+     (run %{bin:ocamlformat} --margin-check --break-separators=after %{dep:tests/modes_cmts.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts-break_separators_after.ml.ref modes_cmts-break_separators_after.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts-break_separators_after.ml.err modes_cmts-break_separators_after.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_cmts.ml.stdout
+   (with-stderr-to modes_cmts.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/modes_cmts.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts.ml.ref modes_cmts.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts.ml.err modes_cmts.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_cmts.ml.js-stdout
+   (with-stderr-to modes_cmts.ml.js-stderr
+     (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/modes_cmts.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts.ml.js-ref modes_cmts.ml.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts.ml.js-err modes_cmts.ml.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_cmts_move.ml.stdout
+   (with-stderr-to modes_cmts_move.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/modes_cmts_move.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts_move.ml.ref modes_cmts_move.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts_move.ml.err modes_cmts_move.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to modes_cmts_move.ml.js-stdout
+   (with-stderr-to modes_cmts_move.ml.js-stderr
+     (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/modes_cmts_move.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts_move.ml.js-ref modes_cmts_move.ml.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/modes_cmts_move.ml.js-err modes_cmts_move.ml.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to module.ml.stdout
    (with-stderr-to module.ml.stderr
      (run %{bin:ocamlformat} --margin-check %{dep:tests/module.ml})))))
@@ -9285,7 +9465,7 @@
  (action (diff tests/prefix_infix.ml.js-err prefix_infix.ml.js-stderr)))
 
 (rule
- (deps tests/.ocamlformat tests/dir1/dir2/.ocamlformat tests/dir1/dir2/print_config.ml)
+ (deps tests/.ocamlformat tests/dir1/.ocamlformat tests/dir1/dir2/.ocamlformat tests/dir1/dir2/print_config.ml)
  (enabled_if (<> %{os_type} Win32))
  (package ocamlformat)
  (action
@@ -9306,7 +9486,7 @@
  (action (diff tests/print_config.ml.err print_config.ml.stderr)))
 
 (rule
- (deps tests/.ocamlformat tests/dir1/dir2/.ocamlformat tests/dir1/dir2/print_config.ml)
+ (deps tests/.ocamlformat tests/dir1/.ocamlformat tests/dir1/dir2/.ocamlformat tests/dir1/dir2/print_config.ml)
  (enabled_if (<> %{os_type} Win32))
  (package ocamlformat)
  (action

--- a/test/passing/tests/local.ml.js-ref
+++ b/test/passing/tests/local.ml.js-ref
@@ -143,25 +143,25 @@ type 'a r =
 
 type 'a r =
   | Foo of
-      global_ (* a *)
-              (* b *)
-              (* c *)
+      (* a *)
+      (* b *)
+      global_ (* c *)
               (* d *)
       'a
   | Bar of
       'a
-      * global_ (* e *)
-                (* f *)
-                (* g *)
-                (* h *)
+      * (* e *)
+        (* f *)
+      global_ (* g *)
+              (* h *)
       'a
   | Baz of
       global_ int
       * string
-      * global_ (* i *)
-                (* j *)
-                (* k *)
-                (* l *)
+      * (* i *)
+        (* j *)
+      global_ (* k *)
+              (* l *)
       'a
 
 let () =

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -152,25 +152,25 @@ type 'a r =
 
 type 'a r =
   | Foo of
-      global_ (* a *)
-              (* b *)
-              (* c *)
+      (* a *)
+      (* b *)
+      global_ (* c *)
               (* d *)
       'a
   | Bar of
       'a
-      * global_ (* e *)
-                (* f *)
-                (* g *)
-                (* h *)
+      * (* e *)
+        (* f *)
+      global_ (* g *)
+              (* h *)
       'a
   | Baz of
       global_ int
       * string
-      * global_ (* i *)
-                (* j *)
-                (* k *)
-                (* l *)
+      * (* i *)
+        (* j *)
+      global_ (* k *)
+              (* l *)
       'a
 
 let () =

--- a/test/passing/tests/modes-ocaml_version.ml.opts
+++ b/test/passing/tests/modes-ocaml_version.ml.opts
@@ -1,0 +1,1 @@
+--ocaml-version=4.14.0

--- a/test/passing/tests/modes-ocaml_version.ml.ref
+++ b/test/passing/tests/modes-ocaml_version.ml.ref
@@ -1,0 +1,471 @@
+(* The first half of this file tests basic formatting of the [@]-based mode
+   syntax in various positions to make sure we are able to handle them all,
+   and that they are correctly parenthesized. The second half more thoroughly
+   checks formatting when there are line breaks in various positions. *)
+
+(* Modes on arbitrary patterns were supported in the parser during
+   development of ocamlformat support for modes, but were later unsupported
+   in the parser. Tests of modes on patterns have thus been moved to
+   [test/failing/tests/modes_on_patterns.ml]. If patterns are ever again
+   supported in the parser, move those tests back to this file (and other
+   [modes*.ml] files in this directory). *)
+
+module Let_bindings = struct
+  let x @ mode = y
+
+  let x @ mode1 mode2 = y
+
+  let x : typ @@ mode1 mode2 = y
+
+  let x : typ1 typ2 @@ mode1 mode2 = y
+
+  let x : typ1 -> typ2 @@ mode1 mode2 = y
+
+  let x : typ1 * typ2 @@ mode1 mode2 = y
+
+  let x @ mode = x
+
+  and y @ mode = y
+
+  and z : typ @@ mode = z
+
+  let () =
+    let x @ mode = y in
+    let x : typ @@ mode = y in
+    let x @ mode = x and y @ mode = y and z : typ @@ mode = z in
+    ()
+
+  let () =
+    let%bind x @ mode = y in
+    let%map x @ mode = y in
+    let%ext x : typ @@ mode = y in
+    let%ext x @ mode = x and y @ mode = y and z : typ @@ mode = z in
+    ()
+end
+
+module Expressions = struct
+  let x = (expr : typ @@ mode1 mode2)
+
+  let x = (expr : typ1 typ2 @@ mode1 mode2)
+
+  let x = (expr : typ1 -> typ2 @@ mode1 mode2)
+
+  let x = (expr : typ1 * typ2 @@ mode1 mode2)
+
+  (* mode constraints in expressions *)
+  let x =
+    { let1=
+        (let x = (x : _ @@ mode) and y = (y : _ @@ mode) in
+         (z : _ @@ mode) )
+    ; function1= (function x -> (x : _ @@ mode) | y -> (y : _ @@ mode))
+    ; fun1= (fun ?(x = (x : _ @@ mode)) () -> (y : _ @@ mode))
+    ; apply1= (x : _ @@ mode) (y : _ @@ mode)
+    ; apply2= f ~lbl:(x : _ @@ mode)
+    ; apply3= f ~x:(x : _ @@ mode)
+    ; apply4= f ?lbl:(x : _ @@ mode)
+    ; apply5= f ?x:(x : _ @@ mode)
+    ; match1=
+        ( match (x : _ @@ mode) with
+        | y -> (y : _ @@ mode)
+        | z -> (z : _ @@ mode) )
+    ; try1= (try (x : _ @@ mode) with y -> (y : _ @@ mode))
+    ; tuple1= ((x : _ @@ mode), (y : _ @@ mode))
+    ; tuple2= (~x:(x : _ @@ mode), ~y:(z : _ @@ mode))
+    ; construct1= A (x : _ @@ mode)
+    ; construct2= A ((x : _ @@ mode), (y : _ @@ mode))
+    ; variant1= `A (x : _ @@ mode)
+    ; variant2= `A ((x : _ @@ mode), (y : _ @@ mode))
+    ; field1= (x : _ @@ mode).x
+    ; setfield1= (x : _ @@ mode).x <- (y : _ @@ mode)
+    ; array1= [|(x : _ @@ mode); (y : _ @@ mode)|]
+    ; array2= [:(x : _ @@ mode); (y : _ @@ mode):]
+    ; list1= [(x : _ @@ mode); (y : _ @@ mode)]
+    ; ite1= (if (x : _ @@ mode) then (y : _ @@ mode) else (z : _ @@ mode))
+    ; sequence1=
+        ( (x : _ @@ mode) ;
+          (y : _ @@ mode) )
+    ; while1=
+        while (x : _ @@ mode) do
+          (y : _ @@ mode)
+        done
+    ; for1=
+        for i = (x : _ @@ mode) to (y : _ @@ mode) do
+          (z : _ @@ mode)
+        done
+    ; constraint1= ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1= ((x : _ @@ mode) :> _)
+    ; send1= (x : _ @@ mode)#y
+    ; setinstvar1= x <- (x : _ @@ mode)
+    ; override1= {<x = (x : _ @@ mode); y = (y : _ @@ mode)>}
+    ; letmodule1=
+        (let module M = ME in
+        (x : _ @@ mode) )
+    ; letexception1=
+        (let exception E in
+        (x : _ @@ mode) )
+    ; assert1= assert (x : _ @@ mode)
+    ; lazy1= lazy (x : _ @@ mode)
+    ; newtype1= (fun (type t) -> (x : _ @@ mode))
+    ; open1= M.((x : _ @@ mode))
+    ; letopen1=
+        (let open M in
+         (x : _ @@ mode) )
+    ; letop1=
+        (let* x = (x : _ @@ mode) in
+         (y : _ @@ mode) )
+    ; extension1= [%ext (x : _ @@ mode)]
+    ; cons1= (x : _ @@ mode) :: (y : _ @@ mode) :: (z : _ @@ mode)
+    ; prefix1= !(x : _ @@ mode)
+    ; infix1= (x : _ @@ mode) + (y : _ @@ mode) }
+
+  (* expressions in mode constraints *)
+  let x =
+    { ident1= (x : _ @@ mode)
+    ; constant1= ("" : _ @@ mode)
+    ; let1=
+        ( let x = y in
+          z
+          : _
+          @@ mode )
+    ; function1= (function x -> x | y -> y : _ @@ mode)
+    ; fun1= (fun x -> y : _ @@ mode)
+    ; apply1= (f x : _ @@ mode)
+    ; match1= (match x with y -> y | z -> z : _ @@ mode)
+    ; try1= (try x with y -> y | z -> z : _ @@ mode)
+    ; tuple1= ((x, y) : _ @@ mode)
+    ; tuple2= ((~x, ~y) : _ @@ mode)
+    ; construct1= (A : _ @@ mode)
+    ; construct2= (A x : _ @@ mode)
+    ; construct3= (A (x, y) : _ @@ mode)
+    ; construct4= (A {x} : _ @@ mode)
+    ; variant1= (`A : _ @@ mode)
+    ; variant2= (`A x : _ @@ mode)
+    ; record1= ({x} : _ @@ mode)
+    ; field1= (x.y : _ @@ mode)
+    ; setfield1= (x.y <- z : _ @@ mode)
+    ; array1= ([|x|] : _ @@ mode)
+    ; array2= ([:x:] : _ @@ mode)
+    ; list1= ([x] : _ @@ mode)
+    ; ite1= (if x then y else z : _ @@ mode)
+    ; sequence1= (x ; y : _ @@ mode)
+    ; while1=
+        while x do
+          y
+        done
+        @@ mode
+    ; for1=
+        for x = y to z do
+          a
+        done
+        @@ mode
+    ; constraint1= ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1= ((x :> _) : _ @@ mode)
+    ; send1= (x#y : _ @@ mode)
+    ; new1= (new x : _ @@ mode)
+    ; setinstvar1= (x <- 2 : _ @@ mode)
+    ; override1= ({<y = z>} : _ @@ mode)
+    ; letmodule1=
+        ( let module M = ME in
+          x
+          : _
+          @@ mode )
+    ; letexception1=
+        ( let exception E in
+          x
+          : _
+          @@ mode )
+    ; assert1= (assert x : _ @@ mode)
+    ; lazy1= (lazy x : _ @@ mode)
+    ; object1= (object end : _ @@ mode)
+    ; newtype1= (fun (type t) -> x : _ @@ mode)
+    ; pack1= ((module M) : _ @@ mode)
+    ; pack2= ((module M : S) : _ @@ mode)
+    ; open1= (M.(x y) : _ @@ mode)
+    ; letopen1=
+        ( let open M in
+          x
+          : _
+          @@ mode )
+    ; letop1=
+        ( let* x = y in
+          z
+          : _
+          @@ mode )
+    ; extension1= ([%ext] : _ @@ mode)
+    ; hole1= (_ : _ @@ mode)
+    ; cons1= (x :: y :: z : _ @@ mode)
+    ; prefix1= (!x : _ @@ mode)
+    ; infix1= (x + y : _ @@ mode) }
+end
+
+module Arrow_params = struct
+  type t = lhs @ mode1 mode2 -> rhs @ mode3 mode4
+
+  type t =
+    arg1 @ mode1 -> lbl:arg2 @ mode2 -> ?lbl:arg3 @ mode3 -> res @ mode4
+
+  let x : lhs @ mode1 -> rhs @ mode2 @@ mode3 = y
+
+  let x = (expr : lhs @ mode1 -> rhs @ mode2 @@ mode3)
+end
+
+module Modalities_on_record_fields = struct
+  type t = {x: t @@ mode1 mode2; mutable x: t @@ mode1 mode2}
+
+  type t = A of {x: t @@ mode1 mode2}
+end
+
+module Modalities_on_construct_arguments = struct
+  type t = A of typ @@ mode1 mode2 | B of typ1 @@ mode1 * typ2 @@ mode2
+
+  type t =
+    | A : typ @@ mode1 mode2 -> t
+    | B : typ1 @@ mode1 * typ2 @@ mode2 -> t
+end
+
+module type Value_descriptions = sig
+  val x : typ @@ mode1 mode2
+
+  val x : typ1 typ2 @@ mode1 mode2
+
+  val x : typ1 -> typ2 @@ mode1 mode2
+
+  val x : typ1 * typ2 @@ mode1 mode2
+end
+
+module Let_bound_functions = struct
+  let (f @ mode) arg1 arg2 = x
+
+  let (f @ mode) arg1 arg2 : typ = x
+
+  let (f @ mode1 mode2) arg1 arg2 = x
+
+  let (f @ mode) (arg @ mode) (arg : typ @@ mode) ~lbl:(arg @ mode)
+      ~lbl:(arg : typ @@ mode) ~(arg @ mode) ~(arg : typ @@ mode)
+      ?lbl:(arg @ mode) ?lbl:(arg : typ @@ mode) ?lbl:(arg @ mode = value)
+      ?lbl:(arg : typ @@ mode = value) ?(arg @ mode) ?(arg : typ @@ mode)
+      ?(arg @ mode = value) ?(arg : typ @@ mode = value) : typ =
+    value
+end
+
+module No_illegal_sugaring = struct
+  let y = {x= (x : t @@ mode)}
+
+  let y = {x:> t = (x : t @@ mode)}
+end
+
+module Line_breaking = struct
+  module Let_bindings = struct
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      1
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      1
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      1
+  end
+
+  module Expressions = struct
+    let x =
+      ( long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+
+    let x =
+      ( long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+  end
+
+  module Arrow_params = struct
+    type t =
+         arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+
+    type t =
+         long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    let x :
+           arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2 =
+      y
+
+    let x :
+           long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      y
+
+    let x =
+      ( expr
+        :    arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+        @@ mode1 mode2 )
+
+    let x =
+      ( expr
+        :    long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        @@ mode1 mode2 )
+  end
+
+  module Modalities_on_record_fields = struct
+    type t =
+      { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 }
+
+    type t =
+      | A of
+          { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+              long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 }
+  end
+
+  module Modalities_on_constructor_arguments = struct
+    type t =
+      | A of
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+
+    type t =
+      | A :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+          -> t
+  end
+
+  module type Value_descriptions = sig
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+      long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+  end
+
+  module Let_bound_functions = struct
+    let (long_fun_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+        (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+        (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+          t
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+        (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 ) =
+      a
+  end
+end
+
+module Interaction_with_existing_syntax = struct
+  (* let bindings *)
+
+  let local_ x @ mode1 mode2 = y
+
+  let local_ x : typ1 typ2 @@ mode1 mode2 = y
+
+  (* lhs/rhs of arrows *)
+
+  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+
+  let x : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3 = y
+
+  let x = (expr : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3)
+
+  (* modalities on record fields *)
+
+  type t = {global_ x: t @@ mode1 mode2}
+
+  type t = A of {global_ x: t @@ mode1 mode2}
+
+  (* modalities on constructor arguments *)
+
+  type t =
+    | A of global_ typ @@ mode1 mode2
+    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+
+  type t =
+    | A : global_ typ @@ mode1 mode2 -> t
+    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+end
+
+module Regressions = struct
+  let x =
+    a_long_expression_that_has_its_own_line
+    @ (* a long comment that comes after the [@] *)
+    a_long_expression_that_comes_after_the_comment
+
+  let (x, y) @ mode =
+    let (x, y) @ mode = (x, y) in
+    (x, y)
+
+  let (t as t) @ mode = local_
+    let (t as t) @ mode = local_ t in
+    t
+
+  let (x, y) @ mode = local_
+    let (x, y) @ mode = local_ t in
+    t
+
+  class t =
+    let (x, y) @ mode = x in
+    object end
+end

--- a/test/passing/tests/modes-ocaml_version.ml.why-no-js
+++ b/test/passing/tests/modes-ocaml_version.ml.why-no-js
@@ -1,0 +1,1 @@
+The purpose of this test is to evaluate against the ocaml-version option, which is not compatible with js-ref.

--- a/test/passing/tests/modes.ml
+++ b/test/passing/tests/modes.ml
@@ -1,0 +1,519 @@
+(* The first half of this file tests basic formatting of the [@]-based mode syntax
+   in various positions to make sure we are able to handle them all, and that
+   they are correctly parenthesized. The second half more thoroughly checks
+   formatting when there are line breaks in various positions. *)
+
+(* Modes on arbitrary patterns were supported in the parser during development of
+   ocamlformat support for modes, but were later unsupported in the parser. Tests of
+   modes on patterns have thus been moved to [test/failing/tests/modes_on_patterns.ml].
+   If patterns are ever again supported in the parser, move those tests back to this
+   file (and other [modes*.ml] files in this directory). *)
+
+module Let_bindings = struct
+  let x @ mode = y
+  let x @ mode1 mode2 = y
+  let x : typ @@ mode1 mode2 = y
+  let x : typ1 typ2 @@ mode1 mode2 = y
+  let x : typ1 -> typ2 @@ mode1 mode2 = y
+  let x : typ1 * typ2 @@ mode1 mode2 = y
+
+  let x @ mode = x
+  and y @ mode = y
+  and z : typ @@ mode = z
+
+  let () =
+    let x @ mode = y in
+    let x : typ @@ mode = y in
+    let x @ mode = x
+    and y @ mode = y
+    and z : typ @@ mode = z in
+    ()
+  ;;
+
+  let () =
+    let%bind x @ mode = y in
+    let%map x @ mode = y in
+    let%ext x : typ @@ mode = y in
+    let%ext x @ mode = x
+    and y @ mode = y
+    and z : typ @@ mode = z in
+    ()
+  ;;
+end
+
+module Expressions = struct
+  let x = (expr : typ @@ mode1 mode2)
+  let x = (expr : typ1 typ2 @@ mode1 mode2)
+  let x = (expr : typ1 -> typ2 @@ mode1 mode2)
+  let x = (expr : typ1 * typ2 @@ mode1 mode2)
+
+  (* mode constraints in expressions *)
+  let x =
+    { let1 =
+        (let x = (x : _ @@ mode)
+         and y = (y : _ @@ mode) in
+         (z : _ @@ mode))
+    ; function1 =
+        (function
+          | x -> (x : _ @@ mode)
+          | y -> (y : _ @@ mode))
+    ; fun1 = (fun ?(x = (x : _ @@ mode)) () -> (y : _ @@ mode))
+    ; apply1 = (x : _ @@ mode) (y : _ @@ mode)
+    ; apply2 = f ~lbl:(x : _ @@ mode)
+    ; apply3 = f ~x:(x : _ @@ mode)
+    ; apply4 = f ?lbl:(x : _ @@ mode)
+    ; apply5 = f ?x:(x : _ @@ mode)
+    ; match1 =
+        (match (x : _ @@ mode) with
+         | y -> (y : _ @@ mode)
+         | z -> (z : _ @@ mode))
+    ; try1 =
+        (try (x : _ @@ mode) with
+         | y -> (y : _ @@ mode))
+    ; tuple1 = (x : _ @@ mode), (y : _ @@ mode)
+    ; tuple2 = ~x:(x : _ @@ mode), ~y:(z : _ @@ mode)
+    ; construct1 = A (x : _ @@ mode)
+    ; construct2 = A ((x : _ @@ mode), (y : _ @@ mode))
+    ; variant1 = `A (x : _ @@ mode)
+    ; variant2 = `A ((x : _ @@ mode), (y : _ @@ mode))
+    ; field1 = (x : _ @@ mode).x
+    ; setfield1 = (x : _ @@ mode).x <- (y : _ @@ mode)
+    ; array1 = [| (x : _ @@ mode); (y : _ @@ mode) |]
+    ; array2 = [: (x : _ @@ mode); (y : _ @@ mode) :]
+    ; list1 = [ (x : _ @@ mode); (y : _ @@ mode) ]
+    ; ite1 = (if (x : _ @@ mode) then (y : _ @@ mode) else (z : _ @@ mode))
+    ; sequence1 =
+        ((x : _ @@ mode);
+         (y : _ @@ mode))
+    ; while1 =
+        while (x : _ @@ mode) do
+          (y : _ @@ mode)
+        done
+    ; for1 =
+        for i = (x : _ @@ mode) to (y : _ @@ mode) do
+          (z : _ @@ mode)
+        done
+    ; constraint1 = ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1 = ((x : _ @@ mode) :> _)
+    ; send1 = (x : _ @@ mode)#y
+    ; setinstvar1 = x <- (x : _ @@ mode)
+    ; override1 = {<x = (x : _ @@ mode); y = (y : _ @@ mode)>}
+    ; letmodule1 =
+        (let module M = ME in
+        (x : _ @@ mode))
+    ; letexception1 =
+        (let exception E in
+        (x : _ @@ mode))
+    ; assert1 = assert (x : _ @@ mode)
+    ; lazy1 = lazy (x : _ @@ mode)
+    ; newtype1 = (fun (type t) -> (x : _ @@ mode))
+    ; open1 = M.((x : _ @@ mode))
+    ; letopen1 =
+        (let open M in
+         (x : _ @@ mode))
+    ; letop1 =
+        (let* x = (x : _ @@ mode) in
+         (y : _ @@ mode))
+    ; extension1 = [%ext (x : _ @@ mode)]
+    ; cons1 = (x : _ @@ mode) :: (y : _ @@ mode) :: (z : _ @@ mode)
+    ; prefix1 = !(x : _ @@ mode)
+    ; infix1 = (x : _ @@ mode) + (y : _ @@ mode)
+    }
+  ;;
+
+  (* expressions in mode constraints *)
+  let x =
+    { ident1 = (x : _ @@ mode)
+    ; constant1 = ("" : _ @@ mode)
+    ; let1 =
+        (let x = y in
+         z
+         : _
+         @@ mode)
+    ; function1 =
+        (function
+         | x -> x
+         | y -> y
+         : _
+         @@ mode)
+    ; fun1 = (fun x -> y : _ @@ mode)
+    ; apply1 = (f x : _ @@ mode)
+    ; match1 =
+        ((match x with
+          | y -> y
+          | z -> z)
+         : _
+         @@ mode)
+    ; try1 =
+        ((try x with
+          | y -> y
+          | z -> z)
+         : _
+         @@ mode)
+    ; tuple1 = ((x, y) : _ @@ mode)
+    ; tuple2 = ((~x, ~y) : _ @@ mode)
+    ; construct1 = (A : _ @@ mode)
+    ; construct2 = (A x : _ @@ mode)
+    ; construct3 = (A (x, y) : _ @@ mode)
+    ; construct4 = (A { x } : _ @@ mode)
+    ; variant1 = (`A : _ @@ mode)
+    ; variant2 = (`A x : _ @@ mode)
+    ; record1 = ({ x } : _ @@ mode)
+    ; field1 = (x.y : _ @@ mode)
+    ; setfield1 = (x.y <- z : _ @@ mode)
+    ; array1 = ([| x |] : _ @@ mode)
+    ; array2 = ([: x :] : _ @@ mode)
+    ; list1 = ([ x ] : _ @@ mode)
+    ; ite1 = (if x then y else z : _ @@ mode)
+    ; sequence1 =
+        (x;
+         y
+         : _
+         @@ mode)
+    ; while1 =
+        while x do
+          y
+        done
+        @@ mode
+    ; for1 =
+        for x = y to z do
+          a
+        done
+        @@ mode
+    ; constraint1 = ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1 = ((x :> _) : _ @@ mode)
+    ; send1 = (x#y : _ @@ mode)
+    ; new1 = (new x : _ @@ mode)
+    ; setinstvar1 = (x <- 2 : _ @@ mode)
+    ; override1 = ({<y = z>} : _ @@ mode)
+    ; letmodule1 =
+        (let module M = ME in
+         x
+         : _
+         @@ mode)
+    ; letexception1 =
+        (let exception E in
+         x
+         : _
+         @@ mode)
+    ; assert1 = (assert x : _ @@ mode)
+    ; lazy1 = (lazy x : _ @@ mode)
+    ; object1 = (object end : _ @@ mode)
+    ; newtype1 = (fun (type t) -> x : _ @@ mode)
+    ; pack1 = ((module M) : _ @@ mode)
+    ; pack2 = ((module M : S) : _ @@ mode)
+    ; open1 = (M.(x y) : _ @@ mode)
+    ; letopen1 =
+        (let open M in
+         x
+         : _
+         @@ mode)
+    ; letop1 =
+        (let* x = y in
+         z
+         : _
+         @@ mode)
+    ; extension1 = ([%ext] : _ @@ mode)
+    ; hole1 = (_ : _ @@ mode)
+    ; cons1 = (x :: y :: z : _ @@ mode)
+    ; prefix1 = (!x : _ @@ mode)
+    ; infix1 = (x + y : _ @@ mode)
+    }
+  ;;
+end
+
+module Arrow_params = struct
+  type t = lhs @ mode1 mode2 -> rhs @ mode3 mode4
+  type t = arg1 @ mode1 -> lbl:arg2 @ mode2 -> ?lbl:arg3 @ mode3 -> res @ mode4
+
+  let x : lhs @ mode1 -> rhs @ mode2 @@ mode3 = y
+  let x = (expr : lhs @ mode1 -> rhs @ mode2 @@ mode3)
+end
+
+module Modalities_on_record_fields = struct
+  type t =
+    { x : t @@ mode1 mode2
+    ; mutable x : t @@ mode1 mode2
+    }
+
+  type t = A of { x : t @@ mode1 mode2 }
+end
+
+module Modalities_on_construct_arguments = struct
+  type t =
+    | A of typ @@ mode1 mode2
+    | B of typ1 @@ mode1 * typ2 @@ mode2
+
+  type t =
+    | A : typ @@ mode1 mode2 -> t
+    | B : typ1 @@ mode1 * typ2 @@ mode2 -> t
+end
+
+module type Value_descriptions = sig
+  val x : typ @@ mode1 mode2
+  val x : typ1 typ2 @@ mode1 mode2
+  val x : typ1 -> typ2 @@ mode1 mode2
+  val x : typ1 * typ2 @@ mode1 mode2
+end
+
+module Let_bound_functions = struct
+  let (f @ mode) arg1 arg2 = x
+  let (f @ mode) arg1 arg2 : typ = x
+  let (f @ mode1 mode2) arg1 arg2 = x
+
+  let (f @ mode)
+    (arg @ mode)
+    (arg : typ @@ mode)
+    ~lbl:(arg @ mode)
+    ~lbl:(arg : typ @@ mode)
+    ~(arg @ mode)
+    ~(arg : typ @@ mode)
+    ?lbl:(arg @ mode)
+    ?lbl:(arg : typ @@ mode)
+    ?lbl:(arg @ mode = value)
+    ?lbl:(arg : typ @@ mode = value)
+    ?(arg @ mode)
+    ?(arg : typ @@ mode)
+    ?(arg @ mode = value)
+    ?(arg : typ @@ mode = value)
+    : typ
+    =
+    value
+  ;;
+end
+
+module No_illegal_sugaring = struct
+  let y = { x = (x : t @@ mode) }
+  let y = { x :> t = (x : t @@ mode) }
+end
+
+module Line_breaking = struct
+  module Let_bindings = struct
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      1
+    ;;
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : t @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      1
+    ;;
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      1
+    ;;
+  end
+
+  module Expressions = struct
+    let x =
+      (long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       : t
+       @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+    ;;
+
+    let x =
+      (long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+    ;;
+  end
+
+  module Arrow_params = struct
+    type t =
+      arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+
+    type t =
+      long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    let x
+      :  arg @ mode1 mode2 -> arg @ mode1 mode2 -> arg @ mode1 mode2 -> arg @ mode1 mode2
+      -> arg @ mode1 mode2 -> arg @ mode1 mode2 -> arg @ mode1 mode2
+      =
+      y
+    ;;
+
+    let x
+      :  long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      y
+    ;;
+
+    let x =
+      (expr
+       : arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+       @@ mode1 mode2)
+    ;;
+
+    let x =
+      (expr
+       : long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+         -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+         -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+         -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+       @@ mode1 mode2)
+    ;;
+  end
+
+  module Modalities_on_record_fields = struct
+    type t =
+      { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      }
+
+    type t =
+      | A of
+          { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+              long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          }
+  end
+
+  module Modalities_on_constructor_arguments = struct
+    type t =
+      | A of
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+
+    type t =
+      | A :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+          -> t
+  end
+
+  module type Value_descriptions = sig
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : t
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+  end
+
+  module Let_bound_functions = struct
+    let (long_fun_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      =
+      a
+    ;;
+  end
+end
+
+module Interaction_with_existing_syntax = struct
+  (* let bindings *)
+
+  let local_ x @ mode1 mode2 = y
+  let local_ x : typ1 typ2 @@ mode1 mode2 = y
+
+  (* lhs/rhs of arrows *)
+
+  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+
+  let x : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3 = y
+  let x = (expr : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3)
+
+  (* modalities on record fields *)
+
+  type t = { global_ x : t @@ mode1 mode2 }
+  type t = A of { global_ x : t @@ mode1 mode2 }
+
+  (* modalities on constructor arguments *)
+
+  type t =
+    | A of global_ typ @@ mode1 mode2
+    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+
+  type t =
+    | A : global_ typ @@ mode1 mode2 -> t
+    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+end
+
+module Regressions = struct
+  let x =
+    a_long_expression_that_has_its_own_line
+    @ (* a long comment that comes after the [@] *)
+    a_long_expression_that_comes_after_the_comment
+  ;;
+
+  let (x, y) @ mode =
+    let (x, y) @ mode = x, y in
+    x, y
+  ;;
+
+  let (t as t) @ mode = local_
+    let (t as t) @ mode = local_ t in
+    t
+  ;;
+
+  let (x, y) @ mode = local_
+    let (x, y) @ mode = local_ t in
+    t
+  ;;
+
+  class t =
+    let (x, y) @ mode = x in
+    object end
+end

--- a/test/passing/tests/modes.ml.js-ref
+++ b/test/passing/tests/modes.ml.js-ref
@@ -1,0 +1,519 @@
+(* The first half of this file tests basic formatting of the [@]-based mode syntax
+   in various positions to make sure we are able to handle them all, and that
+   they are correctly parenthesized. The second half more thoroughly checks
+   formatting when there are line breaks in various positions. *)
+
+(* Modes on arbitrary patterns were supported in the parser during development of
+   ocamlformat support for modes, but were later unsupported in the parser. Tests of
+   modes on patterns have thus been moved to [test/failing/tests/modes_on_patterns.ml].
+   If patterns are ever again supported in the parser, move those tests back to this
+   file (and other [modes*.ml] files in this directory). *)
+
+module Let_bindings = struct
+  let x @ mode = y
+  let x @ mode1 mode2 = y
+  let x : typ @@ mode1 mode2 = y
+  let x : typ1 typ2 @@ mode1 mode2 = y
+  let x : typ1 -> typ2 @@ mode1 mode2 = y
+  let x : typ1 * typ2 @@ mode1 mode2 = y
+
+  let x @ mode = x
+  and y @ mode = y
+  and z : typ @@ mode = z
+
+  let () =
+    let x @ mode = y in
+    let x : typ @@ mode = y in
+    let x @ mode = x
+    and y @ mode = y
+    and z : typ @@ mode = z in
+    ()
+  ;;
+
+  let () =
+    let%bind x @ mode = y in
+    let%map x @ mode = y in
+    let%ext x : typ @@ mode = y in
+    let%ext x @ mode = x
+    and y @ mode = y
+    and z : typ @@ mode = z in
+    ()
+  ;;
+end
+
+module Expressions = struct
+  let x = (expr : typ @@ mode1 mode2)
+  let x = (expr : typ1 typ2 @@ mode1 mode2)
+  let x = (expr : typ1 -> typ2 @@ mode1 mode2)
+  let x = (expr : typ1 * typ2 @@ mode1 mode2)
+
+  (* mode constraints in expressions *)
+  let x =
+    { let1 =
+        (let x = (x : _ @@ mode)
+         and y = (y : _ @@ mode) in
+         (z : _ @@ mode))
+    ; function1 =
+        (function
+          | x -> (x : _ @@ mode)
+          | y -> (y : _ @@ mode))
+    ; fun1 = (fun ?(x = (x : _ @@ mode)) () -> (y : _ @@ mode))
+    ; apply1 = (x : _ @@ mode) (y : _ @@ mode)
+    ; apply2 = f ~lbl:(x : _ @@ mode)
+    ; apply3 = f ~x:(x : _ @@ mode)
+    ; apply4 = f ?lbl:(x : _ @@ mode)
+    ; apply5 = f ?x:(x : _ @@ mode)
+    ; match1 =
+        (match (x : _ @@ mode) with
+         | y -> (y : _ @@ mode)
+         | z -> (z : _ @@ mode))
+    ; try1 =
+        (try (x : _ @@ mode) with
+         | y -> (y : _ @@ mode))
+    ; tuple1 = (x : _ @@ mode), (y : _ @@ mode)
+    ; tuple2 = ~x:(x : _ @@ mode), ~y:(z : _ @@ mode)
+    ; construct1 = A (x : _ @@ mode)
+    ; construct2 = A ((x : _ @@ mode), (y : _ @@ mode))
+    ; variant1 = `A (x : _ @@ mode)
+    ; variant2 = `A ((x : _ @@ mode), (y : _ @@ mode))
+    ; field1 = (x : _ @@ mode).x
+    ; setfield1 = (x : _ @@ mode).x <- (y : _ @@ mode)
+    ; array1 = [| (x : _ @@ mode); (y : _ @@ mode) |]
+    ; array2 = [: (x : _ @@ mode); (y : _ @@ mode) :]
+    ; list1 = [ (x : _ @@ mode); (y : _ @@ mode) ]
+    ; ite1 = (if (x : _ @@ mode) then (y : _ @@ mode) else (z : _ @@ mode))
+    ; sequence1 =
+        ((x : _ @@ mode);
+         (y : _ @@ mode))
+    ; while1 =
+        while (x : _ @@ mode) do
+          (y : _ @@ mode)
+        done
+    ; for1 =
+        for i = (x : _ @@ mode) to (y : _ @@ mode) do
+          (z : _ @@ mode)
+        done
+    ; constraint1 = ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1 = ((x : _ @@ mode) :> _)
+    ; send1 = (x : _ @@ mode)#y
+    ; setinstvar1 = x <- (x : _ @@ mode)
+    ; override1 = {<x = (x : _ @@ mode); y = (y : _ @@ mode)>}
+    ; letmodule1 =
+        (let module M = ME in
+        (x : _ @@ mode))
+    ; letexception1 =
+        (let exception E in
+        (x : _ @@ mode))
+    ; assert1 = assert (x : _ @@ mode)
+    ; lazy1 = lazy (x : _ @@ mode)
+    ; newtype1 = (fun (type t) -> (x : _ @@ mode))
+    ; open1 = M.((x : _ @@ mode))
+    ; letopen1 =
+        (let open M in
+         (x : _ @@ mode))
+    ; letop1 =
+        (let* x = (x : _ @@ mode) in
+         (y : _ @@ mode))
+    ; extension1 = [%ext (x : _ @@ mode)]
+    ; cons1 = (x : _ @@ mode) :: (y : _ @@ mode) :: (z : _ @@ mode)
+    ; prefix1 = !(x : _ @@ mode)
+    ; infix1 = (x : _ @@ mode) + (y : _ @@ mode)
+    }
+  ;;
+
+  (* expressions in mode constraints *)
+  let x =
+    { ident1 = (x : _ @@ mode)
+    ; constant1 = ("" : _ @@ mode)
+    ; let1 =
+        (let x = y in
+         z
+         : _
+         @@ mode)
+    ; function1 =
+        (function
+         | x -> x
+         | y -> y
+         : _
+         @@ mode)
+    ; fun1 = (fun x -> y : _ @@ mode)
+    ; apply1 = (f x : _ @@ mode)
+    ; match1 =
+        ((match x with
+          | y -> y
+          | z -> z)
+         : _
+         @@ mode)
+    ; try1 =
+        ((try x with
+          | y -> y
+          | z -> z)
+         : _
+         @@ mode)
+    ; tuple1 = ((x, y) : _ @@ mode)
+    ; tuple2 = ((~x, ~y) : _ @@ mode)
+    ; construct1 = (A : _ @@ mode)
+    ; construct2 = (A x : _ @@ mode)
+    ; construct3 = (A (x, y) : _ @@ mode)
+    ; construct4 = (A { x } : _ @@ mode)
+    ; variant1 = (`A : _ @@ mode)
+    ; variant2 = (`A x : _ @@ mode)
+    ; record1 = ({ x } : _ @@ mode)
+    ; field1 = (x.y : _ @@ mode)
+    ; setfield1 = (x.y <- z : _ @@ mode)
+    ; array1 = ([| x |] : _ @@ mode)
+    ; array2 = ([: x :] : _ @@ mode)
+    ; list1 = ([ x ] : _ @@ mode)
+    ; ite1 = (if x then y else z : _ @@ mode)
+    ; sequence1 =
+        (x;
+         y
+         : _
+         @@ mode)
+    ; while1 =
+        while x do
+          y
+        done
+        @@ mode
+    ; for1 =
+        for x = y to z do
+          a
+        done
+        @@ mode
+    ; constraint1 = ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1 = ((x :> _) : _ @@ mode)
+    ; send1 = (x#y : _ @@ mode)
+    ; new1 = (new x : _ @@ mode)
+    ; setinstvar1 = (x <- 2 : _ @@ mode)
+    ; override1 = ({<y = z>} : _ @@ mode)
+    ; letmodule1 =
+        (let module M = ME in
+         x
+         : _
+         @@ mode)
+    ; letexception1 =
+        (let exception E in
+         x
+         : _
+         @@ mode)
+    ; assert1 = (assert x : _ @@ mode)
+    ; lazy1 = (lazy x : _ @@ mode)
+    ; object1 = (object end : _ @@ mode)
+    ; newtype1 = (fun (type t) -> x : _ @@ mode)
+    ; pack1 = ((module M) : _ @@ mode)
+    ; pack2 = ((module M : S) : _ @@ mode)
+    ; open1 = (M.(x y) : _ @@ mode)
+    ; letopen1 =
+        (let open M in
+         x
+         : _
+         @@ mode)
+    ; letop1 =
+        (let* x = y in
+         z
+         : _
+         @@ mode)
+    ; extension1 = ([%ext] : _ @@ mode)
+    ; hole1 = (_ : _ @@ mode)
+    ; cons1 = (x :: y :: z : _ @@ mode)
+    ; prefix1 = (!x : _ @@ mode)
+    ; infix1 = (x + y : _ @@ mode)
+    }
+  ;;
+end
+
+module Arrow_params = struct
+  type t = lhs @ mode1 mode2 -> rhs @ mode3 mode4
+  type t = arg1 @ mode1 -> lbl:arg2 @ mode2 -> ?lbl:arg3 @ mode3 -> res @ mode4
+
+  let x : lhs @ mode1 -> rhs @ mode2 @@ mode3 = y
+  let x = (expr : lhs @ mode1 -> rhs @ mode2 @@ mode3)
+end
+
+module Modalities_on_record_fields = struct
+  type t =
+    { x : t @@ mode1 mode2
+    ; mutable x : t @@ mode1 mode2
+    }
+
+  type t = A of { x : t @@ mode1 mode2 }
+end
+
+module Modalities_on_construct_arguments = struct
+  type t =
+    | A of typ @@ mode1 mode2
+    | B of typ1 @@ mode1 * typ2 @@ mode2
+
+  type t =
+    | A : typ @@ mode1 mode2 -> t
+    | B : typ1 @@ mode1 * typ2 @@ mode2 -> t
+end
+
+module type Value_descriptions = sig
+  val x : typ @@ mode1 mode2
+  val x : typ1 typ2 @@ mode1 mode2
+  val x : typ1 -> typ2 @@ mode1 mode2
+  val x : typ1 * typ2 @@ mode1 mode2
+end
+
+module Let_bound_functions = struct
+  let (f @ mode) arg1 arg2 = x
+  let (f @ mode) arg1 arg2 : typ = x
+  let (f @ mode1 mode2) arg1 arg2 = x
+
+  let (f @ mode)
+    (arg @ mode)
+    (arg : typ @@ mode)
+    ~lbl:(arg @ mode)
+    ~lbl:(arg : typ @@ mode)
+    ~(arg @ mode)
+    ~(arg : typ @@ mode)
+    ?lbl:(arg @ mode)
+    ?lbl:(arg : typ @@ mode)
+    ?lbl:(arg @ mode = value)
+    ?lbl:(arg : typ @@ mode = value)
+    ?(arg @ mode)
+    ?(arg : typ @@ mode)
+    ?(arg @ mode = value)
+    ?(arg : typ @@ mode = value)
+    : typ
+    =
+    value
+  ;;
+end
+
+module No_illegal_sugaring = struct
+  let y = { x = (x : t @@ mode) }
+  let y = { x :> t = (x : t @@ mode) }
+end
+
+module Line_breaking = struct
+  module Let_bindings = struct
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      1
+    ;;
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : t @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      1
+    ;;
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      1
+    ;;
+  end
+
+  module Expressions = struct
+    let x =
+      (long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       : t
+       @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+    ;;
+
+    let x =
+      (long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+       @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+    ;;
+  end
+
+  module Arrow_params = struct
+    type t =
+      arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+
+    type t =
+      long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    let x
+      :  arg @ mode1 mode2 -> arg @ mode1 mode2 -> arg @ mode1 mode2 -> arg @ mode1 mode2
+      -> arg @ mode1 mode2 -> arg @ mode1 mode2 -> arg @ mode1 mode2
+      =
+      y
+    ;;
+
+    let x
+      :  long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      =
+      y
+    ;;
+
+    let x =
+      (expr
+       : arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+         -> arg @ mode1 mode2
+       @@ mode1 mode2)
+    ;;
+
+    let x =
+      (expr
+       : long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+         -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+         -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+         -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+       @@ mode1 mode2)
+    ;;
+  end
+
+  module Modalities_on_record_fields = struct
+    type t =
+      { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      }
+
+    type t =
+      | A of
+          { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+              long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          }
+  end
+
+  module Modalities_on_constructor_arguments = struct
+    type t =
+      | A of
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+
+    type t =
+      | A :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+          -> t
+  end
+
+  module type Value_descriptions = sig
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : t
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+  end
+
+  module Let_bound_functions = struct
+    let (long_fun_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+      =
+      a
+    ;;
+  end
+end
+
+module Interaction_with_existing_syntax = struct
+  (* let bindings *)
+
+  let local_ x @ mode1 mode2 = y
+  let local_ x : typ1 typ2 @@ mode1 mode2 = y
+
+  (* lhs/rhs of arrows *)
+
+  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+
+  let x : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3 = y
+  let x = (expr : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3)
+
+  (* modalities on record fields *)
+
+  type t = { global_ x : t @@ mode1 mode2 }
+  type t = A of { global_ x : t @@ mode1 mode2 }
+
+  (* modalities on constructor arguments *)
+
+  type t =
+    | A of global_ typ @@ mode1 mode2
+    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+
+  type t =
+    | A : global_ typ @@ mode1 mode2 -> t
+    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+end
+
+module Regressions = struct
+  let x =
+    a_long_expression_that_has_its_own_line
+    @ (* a long comment that comes after the [@] *)
+    a_long_expression_that_comes_after_the_comment
+  ;;
+
+  let (x, y) @ mode =
+    let (x, y) @ mode = x, y in
+    x, y
+  ;;
+
+  let (t as t) @ mode = local_
+    let (t as t) @ mode = local_ t in
+    t
+  ;;
+
+  let (x, y) @ mode = local_
+    let (x, y) @ mode = local_ t in
+    t
+  ;;
+
+  class t =
+    let (x, y) @ mode = x in
+    object end
+end

--- a/test/passing/tests/modes.ml.ref
+++ b/test/passing/tests/modes.ml.ref
@@ -1,0 +1,471 @@
+(* The first half of this file tests basic formatting of the [@]-based mode
+   syntax in various positions to make sure we are able to handle them all,
+   and that they are correctly parenthesized. The second half more thoroughly
+   checks formatting when there are line breaks in various positions. *)
+
+(* Modes on arbitrary patterns were supported in the parser during
+   development of ocamlformat support for modes, but were later unsupported
+   in the parser. Tests of modes on patterns have thus been moved to
+   [test/failing/tests/modes_on_patterns.ml]. If patterns are ever again
+   supported in the parser, move those tests back to this file (and other
+   [modes*.ml] files in this directory). *)
+
+module Let_bindings = struct
+  let x @ mode = y
+
+  let x @ mode1 mode2 = y
+
+  let x : typ @@ mode1 mode2 = y
+
+  let x : typ1 typ2 @@ mode1 mode2 = y
+
+  let x : typ1 -> typ2 @@ mode1 mode2 = y
+
+  let x : typ1 * typ2 @@ mode1 mode2 = y
+
+  let x @ mode = x
+
+  and y @ mode = y
+
+  and z : typ @@ mode = z
+
+  let () =
+    let x @ mode = y in
+    let x : typ @@ mode = y in
+    let x @ mode = x and y @ mode = y and z : typ @@ mode = z in
+    ()
+
+  let () =
+    let%bind x @ mode = y in
+    let%map x @ mode = y in
+    let%ext x : typ @@ mode = y in
+    let%ext x @ mode = x and y @ mode = y and z : typ @@ mode = z in
+    ()
+end
+
+module Expressions = struct
+  let x = (expr : typ @@ mode1 mode2)
+
+  let x = (expr : typ1 typ2 @@ mode1 mode2)
+
+  let x = (expr : typ1 -> typ2 @@ mode1 mode2)
+
+  let x = (expr : typ1 * typ2 @@ mode1 mode2)
+
+  (* mode constraints in expressions *)
+  let x =
+    { let1=
+        (let x = (x : _ @@ mode) and y = (y : _ @@ mode) in
+         (z : _ @@ mode) )
+    ; function1= (function x -> (x : _ @@ mode) | y -> (y : _ @@ mode))
+    ; fun1= (fun ?(x = (x : _ @@ mode)) () -> (y : _ @@ mode))
+    ; apply1= (x : _ @@ mode) (y : _ @@ mode)
+    ; apply2= f ~lbl:(x : _ @@ mode)
+    ; apply3= f ~x:(x : _ @@ mode)
+    ; apply4= f ?lbl:(x : _ @@ mode)
+    ; apply5= f ?x:(x : _ @@ mode)
+    ; match1=
+        ( match (x : _ @@ mode) with
+        | y -> (y : _ @@ mode)
+        | z -> (z : _ @@ mode) )
+    ; try1= (try (x : _ @@ mode) with y -> (y : _ @@ mode))
+    ; tuple1= ((x : _ @@ mode), (y : _ @@ mode))
+    ; tuple2= (~x:(x : _ @@ mode), ~y:(z : _ @@ mode))
+    ; construct1= A (x : _ @@ mode)
+    ; construct2= A ((x : _ @@ mode), (y : _ @@ mode))
+    ; variant1= `A (x : _ @@ mode)
+    ; variant2= `A ((x : _ @@ mode), (y : _ @@ mode))
+    ; field1= (x : _ @@ mode).x
+    ; setfield1= (x : _ @@ mode).x <- (y : _ @@ mode)
+    ; array1= [|(x : _ @@ mode); (y : _ @@ mode)|]
+    ; array2= [:(x : _ @@ mode); (y : _ @@ mode):]
+    ; list1= [(x : _ @@ mode); (y : _ @@ mode)]
+    ; ite1= (if (x : _ @@ mode) then (y : _ @@ mode) else (z : _ @@ mode))
+    ; sequence1=
+        ( (x : _ @@ mode) ;
+          (y : _ @@ mode) )
+    ; while1=
+        while (x : _ @@ mode) do
+          (y : _ @@ mode)
+        done
+    ; for1=
+        for i = (x : _ @@ mode) to (y : _ @@ mode) do
+          (z : _ @@ mode)
+        done
+    ; constraint1= ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1= ((x : _ @@ mode) :> _)
+    ; send1= (x : _ @@ mode)#y
+    ; setinstvar1= x <- (x : _ @@ mode)
+    ; override1= {<x = (x : _ @@ mode); y = (y : _ @@ mode)>}
+    ; letmodule1=
+        (let module M = ME in
+        (x : _ @@ mode) )
+    ; letexception1=
+        (let exception E in
+        (x : _ @@ mode) )
+    ; assert1= assert (x : _ @@ mode)
+    ; lazy1= lazy (x : _ @@ mode)
+    ; newtype1= (fun (type t) -> (x : _ @@ mode))
+    ; open1= M.((x : _ @@ mode))
+    ; letopen1=
+        (let open M in
+         (x : _ @@ mode) )
+    ; letop1=
+        (let* x = (x : _ @@ mode) in
+         (y : _ @@ mode) )
+    ; extension1= [%ext (x : _ @@ mode)]
+    ; cons1= (x : _ @@ mode) :: (y : _ @@ mode) :: (z : _ @@ mode)
+    ; prefix1= !(x : _ @@ mode)
+    ; infix1= (x : _ @@ mode) + (y : _ @@ mode) }
+
+  (* expressions in mode constraints *)
+  let x =
+    { ident1= (x : _ @@ mode)
+    ; constant1= ("" : _ @@ mode)
+    ; let1=
+        ( let x = y in
+          z
+          : _
+          @@ mode )
+    ; function1= (function x -> x | y -> y : _ @@ mode)
+    ; fun1= (fun x -> y : _ @@ mode)
+    ; apply1= (f x : _ @@ mode)
+    ; match1= (match x with y -> y | z -> z : _ @@ mode)
+    ; try1= (try x with y -> y | z -> z : _ @@ mode)
+    ; tuple1= ((x, y) : _ @@ mode)
+    ; tuple2= ((~x, ~y) : _ @@ mode)
+    ; construct1= (A : _ @@ mode)
+    ; construct2= (A x : _ @@ mode)
+    ; construct3= (A (x, y) : _ @@ mode)
+    ; construct4= (A {x} : _ @@ mode)
+    ; variant1= (`A : _ @@ mode)
+    ; variant2= (`A x : _ @@ mode)
+    ; record1= ({x} : _ @@ mode)
+    ; field1= (x.y : _ @@ mode)
+    ; setfield1= (x.y <- z : _ @@ mode)
+    ; array1= ([|x|] : _ @@ mode)
+    ; array2= ([:x:] : _ @@ mode)
+    ; list1= ([x] : _ @@ mode)
+    ; ite1= (if x then y else z : _ @@ mode)
+    ; sequence1= (x ; y : _ @@ mode)
+    ; while1=
+        while x do
+          y
+        done
+        @@ mode
+    ; for1=
+        for x = y to z do
+          a
+        done
+        @@ mode
+    ; constraint1= ((x : _ @@ mode) : _ @@ mode)
+    ; coerce1= ((x :> _) : _ @@ mode)
+    ; send1= (x#y : _ @@ mode)
+    ; new1= (new x : _ @@ mode)
+    ; setinstvar1= (x <- 2 : _ @@ mode)
+    ; override1= ({<y = z>} : _ @@ mode)
+    ; letmodule1=
+        ( let module M = ME in
+          x
+          : _
+          @@ mode )
+    ; letexception1=
+        ( let exception E in
+          x
+          : _
+          @@ mode )
+    ; assert1= (assert x : _ @@ mode)
+    ; lazy1= (lazy x : _ @@ mode)
+    ; object1= (object end : _ @@ mode)
+    ; newtype1= (fun (type t) -> x : _ @@ mode)
+    ; pack1= ((module M) : _ @@ mode)
+    ; pack2= ((module M : S) : _ @@ mode)
+    ; open1= (M.(x y) : _ @@ mode)
+    ; letopen1=
+        ( let open M in
+          x
+          : _
+          @@ mode )
+    ; letop1=
+        ( let* x = y in
+          z
+          : _
+          @@ mode )
+    ; extension1= ([%ext] : _ @@ mode)
+    ; hole1= (_ : _ @@ mode)
+    ; cons1= (x :: y :: z : _ @@ mode)
+    ; prefix1= (!x : _ @@ mode)
+    ; infix1= (x + y : _ @@ mode) }
+end
+
+module Arrow_params = struct
+  type t = lhs @ mode1 mode2 -> rhs @ mode3 mode4
+
+  type t =
+    arg1 @ mode1 -> lbl:arg2 @ mode2 -> ?lbl:arg3 @ mode3 -> res @ mode4
+
+  let x : lhs @ mode1 -> rhs @ mode2 @@ mode3 = y
+
+  let x = (expr : lhs @ mode1 -> rhs @ mode2 @@ mode3)
+end
+
+module Modalities_on_record_fields = struct
+  type t = {x: t @@ mode1 mode2; mutable x: t @@ mode1 mode2}
+
+  type t = A of {x: t @@ mode1 mode2}
+end
+
+module Modalities_on_construct_arguments = struct
+  type t = A of typ @@ mode1 mode2 | B of typ1 @@ mode1 * typ2 @@ mode2
+
+  type t =
+    | A : typ @@ mode1 mode2 -> t
+    | B : typ1 @@ mode1 * typ2 @@ mode2 -> t
+end
+
+module type Value_descriptions = sig
+  val x : typ @@ mode1 mode2
+
+  val x : typ1 typ2 @@ mode1 mode2
+
+  val x : typ1 -> typ2 @@ mode1 mode2
+
+  val x : typ1 * typ2 @@ mode1 mode2
+end
+
+module Let_bound_functions = struct
+  let (f @ mode) arg1 arg2 = x
+
+  let (f @ mode) arg1 arg2 : typ = x
+
+  let (f @ mode1 mode2) arg1 arg2 = x
+
+  let (f @ mode) (arg @ mode) (arg : typ @@ mode) ~lbl:(arg @ mode)
+      ~lbl:(arg : typ @@ mode) ~(arg @ mode) ~(arg : typ @@ mode)
+      ?lbl:(arg @ mode) ?lbl:(arg : typ @@ mode) ?lbl:(arg @ mode = value)
+      ?lbl:(arg : typ @@ mode = value) ?(arg @ mode) ?(arg : typ @@ mode)
+      ?(arg @ mode = value) ?(arg : typ @@ mode = value) : typ =
+    value
+end
+
+module No_illegal_sugaring = struct
+  let y = {x= (x : t @@ mode)}
+
+  let y = {x:> t = (x : t @@ mode)}
+end
+
+module Line_breaking = struct
+  module Let_bindings = struct
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      1
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      1
+
+    let long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      1
+  end
+
+  module Expressions = struct
+    let x =
+      ( long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        : t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+
+    let x =
+      ( long_expr_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        : long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+  end
+
+  module Arrow_params = struct
+    type t =
+         arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+      -> arg @ mode1 mode2
+
+    type t =
+         long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+         @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    let x :
+           arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2
+        -> arg @ mode1 mode2 =
+      y
+
+    let x :
+           long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+           @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 =
+      y
+
+    let x =
+      ( expr
+        :    arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+          -> arg @ mode1 mode2
+        @@ mode1 mode2 )
+
+    let x =
+      ( expr
+        :    long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          -> label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          -> ?label:long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          -> long_result_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+        @@ mode1 mode2 )
+  end
+
+  module Modalities_on_record_fields = struct
+    type t =
+      { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+      ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 }
+
+    type t =
+      | A of
+          { long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; mutable long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: t
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          ; long_field_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+              long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 }
+  end
+
+  module Modalities_on_constructor_arguments = struct
+    type t =
+      | A of
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+
+    type t =
+      | A :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+          * short_type @@ mode1 mode2
+          -> t
+  end
+
+  module type Value_descriptions = sig
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : t
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+
+    val long_value_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+      long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8
+  end
+
+  module Let_bound_functions = struct
+    let (long_fun_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8)
+        (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+        (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+          t
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 )
+        (long_arg_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+          long_type_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          @@ mode1 mode2 mode3 mode4 mode5 mode6 mode7 mode8 ) =
+      a
+  end
+end
+
+module Interaction_with_existing_syntax = struct
+  (* let bindings *)
+
+  let local_ x @ mode1 mode2 = y
+
+  let local_ x : typ1 typ2 @@ mode1 mode2 = y
+
+  (* lhs/rhs of arrows *)
+
+  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+
+  let x : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3 = y
+
+  let x = (expr : local_ lhs @ mode1 -> local_ rhs @ mode2 @@ mode3)
+
+  (* modalities on record fields *)
+
+  type t = {global_ x: t @@ mode1 mode2}
+
+  type t = A of {global_ x: t @@ mode1 mode2}
+
+  (* modalities on constructor arguments *)
+
+  type t =
+    | A of global_ typ @@ mode1 mode2
+    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+
+  type t =
+    | A : global_ typ @@ mode1 mode2 -> t
+    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+end
+
+module Regressions = struct
+  let x =
+    a_long_expression_that_has_its_own_line
+    @ (* a long comment that comes after the [@] *)
+    a_long_expression_that_comes_after_the_comment
+
+  let (x, y) @ mode =
+    let (x, y) @ mode = (x, y) in
+    (x, y)
+
+  let (t as t) @ mode = local_
+    let (t as t) @ mode = local_ t in
+    t
+
+  let (x, y) @ mode = local_
+    let (x, y) @ mode = local_ t in
+    t
+
+  class t =
+    let (x, y) @ mode = x in
+    object end
+end

--- a/test/passing/tests/modes_attrs.ml
+++ b/test/passing/tests/modes_attrs.ml
@@ -1,0 +1,68 @@
+(* let bindings *)
+
+let[@attr] x @ mode1 mode2 = y
+let[@attr] x : typ @@ mode1 mode2 = y
+
+(* expressions *)
+
+let x = (expr [@attr] : typ @@ mode1 mode2)
+let x = (expr : (typ[@attr]) @@ mode1 mode2)
+let x = ((expr : typ @@ mode1 mode2) [@attr])
+
+(* lhs/rhs of arrows *)
+
+type t = (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 [@@attr]
+
+let x : (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6 @@ m7 m8 = y
+let x = (expr [@attr] : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) [@@attr]
+
+(* modalities on record fields *)
+
+type t = { x : (t[@attr]) @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2 [@attr] }
+type t = { mutable x : (t[@attr]) @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2 [@attr] }
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (t1[@attr]) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (t2[@attr]) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3[@attr]) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (t4[@attr]) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3 @ m5 -> t4 @ m6)[@attr]) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 [@attr]
+
+type t =
+  | A : (t1[@attr]) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * (t2[@attr]) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3[@attr]) @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (t4[@attr]) @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3 @ m5 -> t4 @ m6)[@attr]) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t [@attr]
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (t1[@attr]) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> (t2[@attr]) @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 [@@attr]
+end
+
+(* let-bound functions *)
+
+let[@attr] (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) ((arg1 [@attr]) @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) ((arg2 [@attr]) @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (typ[@attr]) = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x [@@attr]

--- a/test/passing/tests/modes_attrs.ml.js-ref
+++ b/test/passing/tests/modes_attrs.ml.js-ref
@@ -1,0 +1,68 @@
+(* let bindings *)
+
+let[@attr] x @ mode1 mode2 = y
+let[@attr] x : typ @@ mode1 mode2 = y
+
+(* expressions *)
+
+let x = (expr [@attr] : typ @@ mode1 mode2)
+let x = (expr : (typ[@attr]) @@ mode1 mode2)
+let x = ((expr : typ @@ mode1 mode2) [@attr])
+
+(* lhs/rhs of arrows *)
+
+type t = (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 [@@attr]
+
+let x : (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6 @@ m7 m8 = y
+let x = (expr [@attr] : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) [@@attr]
+
+(* modalities on record fields *)
+
+type t = { x : (t[@attr]) @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2 [@attr] }
+type t = { mutable x : (t[@attr]) @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2 [@attr] }
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (t1[@attr]) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (t2[@attr]) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3[@attr]) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (t4[@attr]) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3 @ m5 -> t4 @ m6)[@attr]) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 [@attr]
+
+type t =
+  | A : (t1[@attr]) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * (t2[@attr]) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3[@attr]) @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (t4[@attr]) @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3 @ m5 -> t4 @ m6)[@attr]) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t [@attr]
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (t1[@attr]) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> (t2[@attr]) @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 [@@attr]
+end
+
+(* let-bound functions *)
+
+let[@attr] (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) ((arg1 [@attr]) @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) ((arg2 [@attr]) @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (typ[@attr]) = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x [@@attr]

--- a/test/passing/tests/modes_attrs.ml.ref
+++ b/test/passing/tests/modes_attrs.ml.ref
@@ -1,0 +1,102 @@
+(* let bindings *)
+
+let[@attr] x @ mode1 mode2 = y
+
+let[@attr] x : typ @@ mode1 mode2 = y
+
+(* expressions *)
+
+let x = (expr [@attr] : typ @@ mode1 mode2)
+
+let x = (expr : (typ[@attr]) @@ mode1 mode2)
+
+let x = ((expr : typ @@ mode1 mode2) [@attr])
+
+(* lhs/rhs of arrows *)
+
+type t = (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 [@@attr]
+
+let x : (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6 @@ m7 m8 = y
+
+let x = (expr [@attr] : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : (lhs[@attr]) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> (mhs[@attr]) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (rhs[@attr]) @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) [@@attr]
+
+(* modalities on record fields *)
+
+type t = {x: (t[@attr]) @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2 [@attr]}
+
+type t = {mutable x: (t[@attr]) @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2 [@attr]}
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (t1[@attr]) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (t2[@attr]) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3[@attr]) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (t4[@attr]) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3 @ m5 -> t4 @ m6)[@attr]) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 [@attr]
+
+type t =
+  | A :
+      (t1[@attr]) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * (t2[@attr]) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3[@attr]) @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (t4[@attr]) @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * ((t3 @ m5 -> t4 @ m6)[@attr]) @@ m7 m8
+      -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+      [@attr]
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (t1[@attr]) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> (t2[@attr]) @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 [@@attr]
+end
+
+(* let-bound functions *)
+
+let[@attr] (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) ((arg1 [@attr]) @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) ((arg2 [@attr]) @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (typ[@attr]) = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x [@@attr]

--- a/test/passing/tests/modes_cmts-break_separators_after.ml.opts
+++ b/test/passing/tests/modes_cmts-break_separators_after.ml.opts
@@ -1,0 +1,1 @@
+--break-separators=after

--- a/test/passing/tests/modes_cmts-break_separators_after.ml.ref
+++ b/test/passing/tests/modes_cmts-break_separators_after.ml.ref
@@ -1,0 +1,377 @@
+(* Check that comments are not dropped or moved in unusual ways. A few
+   commented out tests where comments move have explanations, and are tested
+   in [modes_cmts_move.ml]. *)
+
+(* let bindings *)
+
+let (* cmt *) x @ mode1 mode2 = y
+
+let x (* cmt *) @ mode1 mode2 = y
+
+let x @ (* cmt *) mode1 mode2 = y
+
+let x @ mode1 (* cmt *) mode2 = y
+
+let x @ mode1 mode2 (* cmt *) = y
+
+let x @ mode1 mode2 = (* cmt *) y
+
+let (* cmt *) x : typ @@ mode1 mode2 = y
+
+let x (* cmt *) : typ @@ mode1 mode2 = y
+
+let x : (* cmt *) typ @@ mode1 mode2 = y
+
+let x : typ (* cmt *) @@ mode1 mode2 = y
+
+let x : typ @@ (* cmt *) mode1 mode2 = y
+
+let x : typ @@ mode1 (* cmt *) mode2 = y
+
+let x : typ @@ mode1 mode2 (* cmt *) = y
+
+let x : typ @@ mode1 mode2 = (* cmt *) y
+
+(* expressions *)
+
+let x = ((* cmt *) expr : typ @@ mode1 mode2)
+
+let x = (expr (* cmt *) : typ @@ mode1 mode2)
+
+let x = (expr : (* cmt *) typ @@ mode1 mode2)
+
+let x = (expr : typ (* cmt *) @@ mode1 mode2)
+
+let x = (expr : typ @@ (* cmt *) mode1 mode2)
+
+let x = (expr : typ @@ mode1 (* cmt *) mode2)
+
+let x = (expr : typ @@ mode1 mode2 (* cmt *))
+
+(* lhs/rhs of arrows *)
+
+type t = (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *)
+
+let x : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *) = y
+
+let x = (expr (* cmt *) : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *))
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) (* cmt *)
+
+(* modalities on record fields *)
+
+type t = {x (* cmt *): t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: (* cmt *) t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: t (* cmt *) @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: t @@ (* cmt *) mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 (* cmt *) mode2; y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; (* cmt *) y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; (* cmt *) y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y (* cmt *): t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: (* cmt *) t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: t (* cmt *) @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: t @@ (* cmt *) mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: t @@ mode1 (* cmt *) mode2}
+
+type t = {x: t @@ mode1 mode2; y: t @@ mode1 mode2 (* cmt *)}
+
+type t = {mutable x (* cmt *): t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: (* cmt *) t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t (* cmt *) @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ (* cmt *) mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 (* cmt *) mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; (* cmt *) y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; (* cmt *) y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y (* cmt *): t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: (* cmt *) t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t (* cmt *) @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t @@ (* cmt *) mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t @@ mode1 (* cmt *) mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t @@ mode1 mode2 (* cmt *)}
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8
+  (* | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7
+     m8 *)
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *)
+
+type t =
+  | A :
+      (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8
+      -> t
+  (* Comment moves between [@@] and [m7]: | A : t1 @@ m1 m2 * t2 @@ m3 m4 *
+     (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8 -> t *)
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *)
+      -> t
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (* cmt *) t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 (* cmt *) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ (* cmt *) m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 (* cmt *) m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 (* cmt *) -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> (* cmt *) t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 (* cmt *) @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ (* cmt *) m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 (* cmt *) m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 (* cmt *) @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ (* cmt *) m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 (* cmt *) m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 (* cmt *)
+end
+
+(* let-bound functions *)
+
+(* Comment moves to between [(] and [f]: let (* cmt *) (f @ mode1) (arg1 @
+   mode2) (arg2 @ mode3) : typ = x *)
+
+let ((* cmt *) f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f (* cmt *) @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ (* cmt *) mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1 (* cmt *)) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (* cmt *) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) ((* cmt *) arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 (* cmt *) @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ (* cmt *) mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2 (* cmt *)) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (* cmt *) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) ((* cmt *) arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 (* cmt *) @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ (* cmt *) mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3 (* cmt *)) : typ = x
+
+(* Comment moves to after [=], but not because of modes: let (f @ mode1)
+   (arg1 @ mode2) (arg2 @ mode3) (* cmt *) : typ = x *)
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (* cmt *) typ = x

--- a/test/passing/tests/modes_cmts-break_separators_after.ml.why-no-js
+++ b/test/passing/tests/modes_cmts-break_separators_after.ml.why-no-js
@@ -1,0 +1,1 @@
+This tests the behavior of a particular option which would be overriden by [.js-ref].

--- a/test/passing/tests/modes_cmts.ml
+++ b/test/passing/tests/modes_cmts.ml
@@ -1,0 +1,212 @@
+(* Check that comments are not dropped or moved in unusual ways.
+   A few commented out tests where comments move have explanations, and are
+   tested in [modes_cmts_move.ml]. *)
+
+(* let bindings *)
+
+let (* cmt *) x @ mode1 mode2 = y
+let x (* cmt *) @ mode1 mode2 = y
+let x @ (* cmt *) mode1 mode2 = y
+let x @ mode1 (* cmt *) mode2 = y
+let x @ mode1 mode2 (* cmt *) = y
+let x @ mode1 mode2 = (* cmt *) y
+let (* cmt *) x : typ @@ mode1 mode2 = y
+let x (* cmt *) : typ @@ mode1 mode2 = y
+let x : (* cmt *) typ @@ mode1 mode2 = y
+let x : typ (* cmt *) @@ mode1 mode2 = y
+let x : typ @@ (* cmt *) mode1 mode2 = y
+let x : typ @@ mode1 (* cmt *) mode2 = y
+let x : typ @@ mode1 mode2 (* cmt *) = y
+let x : typ @@ mode1 mode2 = (* cmt *) y
+
+(* expressions *)
+
+let x = ((* cmt *) expr : typ @@ mode1 mode2)
+let x = (expr (* cmt *) : typ @@ mode1 mode2)
+let x = (expr : (* cmt *) typ @@ mode1 mode2)
+let x = (expr : typ (* cmt *) @@ mode1 mode2)
+let x = (expr : typ @@ (* cmt *) mode1 mode2)
+let x = (expr : typ @@ mode1 (* cmt *) mode2)
+let x = (expr : typ @@ mode1 mode2 (* cmt *))
+
+(* lhs/rhs of arrows *)
+
+type t = (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *)
+
+let x : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *) = y
+let x = (expr (* cmt *) : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *))
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) (* cmt *)
+
+(* modalities on record fields *)
+
+type t = { x (* cmt *) : t @@ mode1 mode2; y : t @@ mode1 mode2 }
+type t = { x : (* cmt *) t @@ mode1 mode2; y : t @@ mode1 mode2 }
+type t = { x : t (* cmt *) @@ mode1 mode2; y : t @@ mode1 mode2 }
+type t = { x : t @@ (* cmt *) mode1 mode2; y : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 (* cmt *) mode2; y : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2 (* cmt *); y : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2; (* cmt *) y : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2; y (* cmt *) : t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2; y : (* cmt *) t @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2; y : t (* cmt *) @@ mode1 mode2 }
+type t = { x : t @@ mode1 mode2; y : t @@ (* cmt *) mode1 mode2 }
+type t = { x : t @@ mode1 mode2; y : t @@ mode1 (* cmt *) mode2 }
+type t = { x : t @@ mode1 mode2; y : t @@ mode1 mode2 (* cmt *) }
+type t = { mutable x (* cmt *) : t @@ mode1 mode2; y : t @@ mode1 mode2 }
+type t = { mutable x : (* cmt *) t @@ mode1 mode2; y : t @@ mode1 mode2 }
+type t = { mutable x : t (* cmt *) @@ mode1 mode2; y : t @@ mode1 mode2 }
+type t = { mutable x : t @@ (* cmt *) mode1 mode2; y : t @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 (* cmt *) mode2; y : t @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2 (* cmt *); y : t @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2; (* cmt *) y : t @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2; y (* cmt *) : t @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2; y : (* cmt *) t @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2; y : t (* cmt *) @@ mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2; y : t @@ (* cmt *) mode1 mode2 }
+type t = { mutable x : t @@ mode1 mode2; y : t @@ mode1 (* cmt *) mode2 }
+type t = { mutable x : t @@ mode1 mode2; y : t @@ mode1 mode2 (* cmt *) }
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8
+  (* | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8 *)
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *)
+
+type t =
+  | A : (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8 -> t
+  (* Comment moves between [@@] and [m7]:
+     | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8 -> t *)
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *) -> t
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (* cmt *) t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 (* cmt *) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ (* cmt *) m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 (* cmt *) m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 (* cmt *) -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> (* cmt *) t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 (* cmt *) @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ (* cmt *) m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 (* cmt *) m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 (* cmt *) @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ (* cmt *) m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 (* cmt *) m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 (* cmt *)
+end
+
+(* let-bound functions *)
+
+(* Comment moves to between [(] and [f]:
+   let (* cmt *) (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x *)
+
+let ((* cmt *) f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f (* cmt *) @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ (* cmt *) mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1 (* cmt *)) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (* cmt *) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) ((* cmt *) arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 (* cmt *) @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ (* cmt *) mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2 (* cmt *)) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (* cmt *) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) ((* cmt *) arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 (* cmt *) @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ (* cmt *) mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3 (* cmt *)) : typ = x
+
+(* Comment moves to after [=], but not because of modes:
+   let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) (* cmt *) : typ = x *)
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (* cmt *) typ = x

--- a/test/passing/tests/modes_cmts.ml.js-ref
+++ b/test/passing/tests/modes_cmts.ml.js-ref
@@ -1,0 +1,315 @@
+(* Check that comments are not dropped or moved in unusual ways.
+   A few commented out tests where comments move have explanations, and are
+   tested in [modes_cmts_move.ml]. *)
+
+(* let bindings *)
+
+let (* cmt *) x @ mode1 mode2 = y
+let x (* cmt *) @ mode1 mode2 = y
+let x @ (* cmt *) mode1 mode2 = y
+let x @ mode1 (* cmt *) mode2 = y
+let x @ mode1 mode2 (* cmt *) = y
+let x @ mode1 mode2 = (* cmt *) y
+let (* cmt *) x : typ @@ mode1 mode2 = y
+let x (* cmt *) : typ @@ mode1 mode2 = y
+let x : (* cmt *) typ @@ mode1 mode2 = y
+let x : typ (* cmt *) @@ mode1 mode2 = y
+let x : typ @@ (* cmt *) mode1 mode2 = y
+let x : typ @@ mode1 (* cmt *) mode2 = y
+let x : typ @@ mode1 mode2 (* cmt *) = y
+let x : typ @@ mode1 mode2 = (* cmt *) y
+
+(* expressions *)
+
+let x = ((* cmt *) expr : typ @@ mode1 mode2)
+let x = (expr (* cmt *) : typ @@ mode1 mode2)
+let x = (expr : (* cmt *) typ @@ mode1 mode2)
+let x = (expr : typ (* cmt *) @@ mode1 mode2)
+let x = (expr : typ @@ (* cmt *) mode1 mode2)
+let x = (expr : typ @@ mode1 (* cmt *) mode2)
+let x = (expr : typ @@ mode1 mode2 (* cmt *))
+
+(* lhs/rhs of arrows *)
+
+type t = (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *)
+
+let x : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8 = y
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *) = y
+let x = (expr (* cmt *) : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8)
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *))
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) (* cmt *)
+
+(* modalities on record fields *)
+
+type t =
+  { x (* cmt *) : t @@ mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : (* cmt *) t @@ mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t (* cmt *) @@ mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ (* cmt *) mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 (* cmt *) mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2 (* cmt *)
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; (* cmt *) y : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; y (* cmt *) : t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; y : (* cmt *) t @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; y : t (* cmt *) @@ mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; y : t @@ (* cmt *) mode1 mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; y : t @@ mode1 (* cmt *) mode2
+  }
+
+type t =
+  { x : t @@ mode1 mode2
+  ; y : t @@ mode1 mode2 (* cmt *)
+  }
+
+type t =
+  { mutable x (* cmt *) : t @@ mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : (* cmt *) t @@ mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t (* cmt *) @@ mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ (* cmt *) mode1 mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 (* cmt *) mode2
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2 (* cmt *)
+  ; y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; (* cmt *) y : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; y (* cmt *) : t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; y : (* cmt *) t @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; y : t (* cmt *) @@ mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; y : t @@ (* cmt *) mode1 mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; y : t @@ mode1 (* cmt *) mode2
+  }
+
+type t =
+  { mutable x : t @@ mode1 mode2
+  ; y : t @@ mode1 mode2 (* cmt *)
+  }
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8
+  (* | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8 *)
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *)
+
+type t =
+  | A : (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8 -> t
+  (* Comment moves between [@@] and [m7]:
+     | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8 -> t *)
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8 -> t
+  | A : t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *) -> t
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (* cmt *) t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 (* cmt *) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ (* cmt *) m1 m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 (* cmt *) m2 -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 (* cmt *) -> t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> (* cmt *) t2 @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 (* cmt *) @ m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ (* cmt *) m3 m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 (* cmt *) m4 @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 (* cmt *) @@ m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ (* cmt *) m5 m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 (* cmt *) m6
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 (* cmt *)
+end
+
+(* let-bound functions *)
+
+(* Comment moves to between [(] and [f]:
+   let (* cmt *) (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x *)
+
+let ((* cmt *) f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f (* cmt *) @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ (* cmt *) mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1 (* cmt *)) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (* cmt *) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) ((* cmt *) arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 (* cmt *) @ mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ (* cmt *) mode2) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2 (* cmt *)) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (* cmt *) (arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) ((* cmt *) arg2 @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 (* cmt *) @ mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ (* cmt *) mode3) : typ = x
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3 (* cmt *)) : typ = x
+
+(* Comment moves to after [=], but not because of modes:
+   let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) (* cmt *) : typ = x *)
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (* cmt *) typ = x

--- a/test/passing/tests/modes_cmts.ml.ref
+++ b/test/passing/tests/modes_cmts.ml.ref
@@ -1,0 +1,377 @@
+(* Check that comments are not dropped or moved in unusual ways. A few
+   commented out tests where comments move have explanations, and are tested
+   in [modes_cmts_move.ml]. *)
+
+(* let bindings *)
+
+let (* cmt *) x @ mode1 mode2 = y
+
+let x (* cmt *) @ mode1 mode2 = y
+
+let x @ (* cmt *) mode1 mode2 = y
+
+let x @ mode1 (* cmt *) mode2 = y
+
+let x @ mode1 mode2 (* cmt *) = y
+
+let x @ mode1 mode2 = (* cmt *) y
+
+let (* cmt *) x : typ @@ mode1 mode2 = y
+
+let x (* cmt *) : typ @@ mode1 mode2 = y
+
+let x : (* cmt *) typ @@ mode1 mode2 = y
+
+let x : typ (* cmt *) @@ mode1 mode2 = y
+
+let x : typ @@ (* cmt *) mode1 mode2 = y
+
+let x : typ @@ mode1 (* cmt *) mode2 = y
+
+let x : typ @@ mode1 mode2 (* cmt *) = y
+
+let x : typ @@ mode1 mode2 = (* cmt *) y
+
+(* expressions *)
+
+let x = ((* cmt *) expr : typ @@ mode1 mode2)
+
+let x = (expr (* cmt *) : typ @@ mode1 mode2)
+
+let x = (expr : (* cmt *) typ @@ mode1 mode2)
+
+let x = (expr : typ (* cmt *) @@ mode1 mode2)
+
+let x = (expr : typ @@ (* cmt *) mode1 mode2)
+
+let x = (expr : typ @@ mode1 (* cmt *) mode2)
+
+let x = (expr : typ @@ mode1 mode2 (* cmt *))
+
+(* lhs/rhs of arrows *)
+
+type t = (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6
+
+type t = lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *)
+
+let x : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8 = y
+
+let x : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *) = y
+
+let x = (expr (* cmt *) : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : (* cmt *) lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs (* cmt *) @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ (* cmt *) m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 (* cmt *) m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 (* cmt *) -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> (* cmt *) mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs (* cmt *) @ m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ (* cmt *) m3 m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 (* cmt *) m4 -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 (* cmt *) -> rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> (* cmt *) rhs @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs (* cmt *) @ m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ (* cmt *) m5 m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 (* cmt *) m6 @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 (* cmt *) @@ m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ (* cmt *) m7 m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 (* cmt *) m8)
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8 (* cmt *))
+
+let x = (expr : lhs @ m1 m2 -> mhs @ m3 m4 -> rhs @ m5 m6 @@ m7 m8) (* cmt *)
+
+(* modalities on record fields *)
+
+type t = {x (* cmt *): t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: (* cmt *) t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: t (* cmt *) @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: t @@ (* cmt *) mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 (* cmt *) mode2; y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2 (* cmt *); y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; (* cmt *) y: t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y (* cmt *): t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: (* cmt *) t @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: t (* cmt *) @@ mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: t @@ (* cmt *) mode1 mode2}
+
+type t = {x: t @@ mode1 mode2; y: t @@ mode1 (* cmt *) mode2}
+
+type t = {x: t @@ mode1 mode2; y: t @@ mode1 mode2 (* cmt *)}
+
+type t = {mutable x (* cmt *): t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: (* cmt *) t @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t (* cmt *) @@ mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ (* cmt *) mode1 mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 (* cmt *) mode2; y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2 (* cmt *); y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; (* cmt *) y: t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y (* cmt *): t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: (* cmt *) t @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t (* cmt *) @@ mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t @@ (* cmt *) mode1 mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t @@ mode1 (* cmt *) mode2}
+
+type t = {mutable x: t @@ mode1 mode2; y: t @@ mode1 mode2 (* cmt *)}
+
+(* modalities on constructor arguments *)
+
+type t =
+  | A of (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8
+  (* | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7
+     m8 *)
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *)
+
+type t =
+  | A :
+      (* cmt *) t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 (* cmt *) @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ (* cmt *) m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 (* cmt *) m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 (* cmt *) * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * (* cmt *) t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 (* cmt *) @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ (* cmt *) m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 (* cmt *) m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 (* cmt *) * (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (* cmt *) (t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * ((* cmt *) t3 @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 (* cmt *) @ m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ (* cmt *) m5 -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 (* cmt *) -> t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> (* cmt *) t4 @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 (* cmt *) @ m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ (* cmt *) m6) @@ m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6 (* cmt *)) @@ m7 m8
+      -> t
+  (* Comment moves between [@@] and [m7]: | A : t1 @@ m1 m2 * t2 @@ m3 m4 *
+     (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8 -> t *)
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 (* cmt *) m8
+      -> t
+  | A :
+      t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ m7 m8 (* cmt *)
+      -> t
+
+(* value descriptions *)
+
+module type S = sig
+  val x : (* cmt *) t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 (* cmt *) @ m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ (* cmt *) m1 m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 (* cmt *) m2 -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 (* cmt *) -> t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> (* cmt *) t2 @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 (* cmt *) @ m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ (* cmt *) m3 m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 (* cmt *) m4 @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 (* cmt *) @@ m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ (* cmt *) m5 m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 (* cmt *) m6
+
+  val x : t1 @ m1 m2 -> t2 @ m3 m4 @@ m5 m6 (* cmt *)
+end
+
+(* let-bound functions *)
+
+(* Comment moves to between [(] and [f]: let (* cmt *) (f @ mode1) (arg1 @
+   mode2) (arg2 @ mode3) : typ = x *)
+
+let ((* cmt *) f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f (* cmt *) @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ (* cmt *) mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1 (* cmt *)) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (* cmt *) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) ((* cmt *) arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 (* cmt *) @ mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ (* cmt *) mode2) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2 (* cmt *)) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (* cmt *) (arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) ((* cmt *) arg2 @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 (* cmt *) @ mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ (* cmt *) mode3) : typ = x
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3 (* cmt *)) : typ = x
+
+(* Comment moves to after [=], but not because of modes: let (f @ mode1)
+   (arg1 @ mode2) (arg2 @ mode3) (* cmt *) : typ = x *)
+
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : (* cmt *) typ = x

--- a/test/passing/tests/modes_cmts_move.ml
+++ b/test/passing/tests/modes_cmts_move.ml
@@ -1,0 +1,20 @@
+(* This comment moves for similar reason to existing behavior as shown below.
+   In particular, the operator ([@@] / [->]) does not carry a source locaion,
+   and the comment attaches to the location of the identifier on the right side
+   of the operator rather than the left due to the parenthesis. Fixing this would
+   require messing with the comment association logic, which is difficult. *)
+type t = A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) (* cmt *) @@ m7 m8
+type t = A of (t -> u) (* cmt *) @@ m
+type t = A of ((t -> u) (* cmt *) -> m)
+
+(* This comment attaches to the [f]; the syntax [(f @ mode1)] doesn't have its own
+   location to latch onto. This seems like a rare position to put a comment, so it doesn't
+   seem worth changing the parser to be able to differentiate the following two. *)
+let (* cmt *) (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let (* cmt *) (f @ mode) arg = x
+let ((* cmt *) f @ mode) arg = x
+
+(* This comment moves due to existing behavior as shown below. *)
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) (* cmt *) : typ = x
+let f (arg @ mode) (* cmt *) : typ = x
+let f (arg : typ) (* cmt *) : typ = x

--- a/test/passing/tests/modes_cmts_move.ml.js-ref
+++ b/test/passing/tests/modes_cmts_move.ml.js-ref
@@ -1,0 +1,20 @@
+(* This comment moves for similar reason to existing behavior as shown below.
+   In particular, the operator ([@@] / [->]) does not carry a source locaion,
+   and the comment attaches to the location of the identifier on the right side
+   of the operator rather than the left due to the parenthesis. Fixing this would
+   require messing with the comment association logic, which is difficult. *)
+type t = A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+type t = A of (t -> u) @@ (* cmt *) m
+type t = A of ((t -> u) -> (* cmt *) m)
+
+(* This comment attaches to the [f]; the syntax [(f @ mode1)] doesn't have its own
+   location to latch onto. This seems like a rare position to put a comment, so it doesn't
+   seem worth changing the parser to be able to differentiate the following two. *)
+let ((* cmt *) f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+let ((* cmt *) f @ mode) arg = x
+let ((* cmt *) f @ mode) arg = x
+
+(* This comment moves due to existing behavior as shown below. *)
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = (* cmt *) x
+let f (arg @ mode) : typ = (* cmt *) x
+let f (arg : typ) : typ = (* cmt *) x

--- a/test/passing/tests/modes_cmts_move.ml.ref
+++ b/test/passing/tests/modes_cmts_move.ml.ref
@@ -1,0 +1,29 @@
+(* This comment moves for similar reason to existing behavior as shown below.
+   In particular, the operator ([@@] / [->]) does not carry a source locaion,
+   and the comment attaches to the location of the identifier on the right
+   side of the operator rather than the left due to the parenthesis. Fixing
+   this would require messing with the comment association logic, which is
+   difficult. *)
+type t =
+  | A of t1 @@ m1 m2 * t2 @@ m3 m4 * (t3 @ m5 -> t4 @ m6) @@ (* cmt *) m7 m8
+
+type t = A of (t -> u) @@ (* cmt *) m
+
+type t = A of ((t -> u) -> (* cmt *) m)
+
+(* This comment attaches to the [f]; the syntax [(f @ mode1)] doesn't have
+   its own location to latch onto. This seems like a rare position to put a
+   comment, so it doesn't seem worth changing the parser to be able to
+   differentiate the following two. *)
+let ((* cmt *) f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = x
+
+let ((* cmt *) f @ mode) arg = x
+
+let ((* cmt *) f @ mode) arg = x
+
+(* This comment moves due to existing behavior as shown below. *)
+let (f @ mode1) (arg1 @ mode2) (arg2 @ mode3) : typ = (* cmt *) x
+
+let f (arg @ mode) : typ = (* cmt *) x
+
+let f (arg : typ) : typ = (* cmt *) x

--- a/test/passing/tests/print_config.ml.deps
+++ b/test/passing/tests/print_config.ml.deps
@@ -1,2 +1,3 @@
+tests/dir1/.ocamlformat
 tests/dir1/dir2/.ocamlformat
 tests/dir1/dir2/print_config.ml

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -69,7 +69,7 @@ module Typ = struct
 
   let any ?loc ?attrs () = mk ?loc ?attrs Ptyp_any
   let var ?loc ?attrs a = mk ?loc ?attrs (Ptyp_var a)
-  let arrow ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_arrow (a, b))
+  let arrow ?loc ?attrs a b c = mk ?loc ?attrs (Ptyp_arrow (a, b, c))
   let tuple ?loc ?attrs a = mk ?loc ?attrs (Ptyp_tuple a)
   let unboxed_tuple ?loc ?attrs a = mk ?loc ?attrs (Ptyp_unboxed_tuple a)
   let constr ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_constr (a, b))
@@ -107,7 +107,7 @@ module Pat = struct
   let array ?loc ?attrs a b = mk ?loc ?attrs (Ppat_array (a, b))
   let list ?loc ?attrs a = mk ?loc ?attrs (Ppat_list a)
   let or_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_or a)
-  let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Ppat_constraint (a, b))
+  let constraint_ ?loc ?attrs a b c = mk ?loc ?attrs (Ppat_constraint (a, b, c))
   let type_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_type a)
   let lazy_ ?loc ?attrs a = mk ?loc ?attrs (Ppat_lazy a)
   let unpack ?loc ?attrs a b = mk ?loc ?attrs (Ppat_unpack (a, b))
@@ -146,7 +146,7 @@ module Exp = struct
   let sequence ?loc ?attrs a b = mk ?loc ?attrs (Pexp_sequence (a, b))
   let while_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_while (a, b))
   let for_ ?loc ?attrs a b c d e = mk ?loc ?attrs (Pexp_for (a, b, c, d, e))
-  let constraint_ ?loc ?attrs a b = mk ?loc ?attrs (Pexp_constraint (a, b))
+  let constraint_ ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_constraint (a, b, c))
   let coerce ?loc ?attrs a b c = mk ?loc ?attrs (Pexp_coerce (a, b, c))
   let send ?loc ?attrs a b = mk ?loc ?attrs (Pexp_send (a, b))
   let new_ ?loc ?attrs a = mk ?loc ?attrs (Pexp_new a)
@@ -369,10 +369,11 @@ end
 
 module Val = struct
   let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
-        ?(prim = []) name typ =
+        ?(prim = []) ?(modalities = []) name typ =
     {
      pval_name = name;
      pval_type = typ;
+     pval_modalities = modalities;
      pval_attributes = add_docs_attrs docs attrs;
      pval_loc = loc;
      pval_prim = prim;
@@ -448,12 +449,13 @@ end
 
 module Vb = struct
   let mk ?(loc = !default_loc) ?(attrs = []) ?(docs = empty_docs)
-        ?(text = []) ?value_constraint ~is_pun pat expr =
+        ?(text = []) ?value_constraint ?(modes = []) ~is_pun pat expr =
     {
      pvb_pat = pat;
      pvb_expr = expr;
      pvb_constraint=value_constraint;
-     pvb_is_pun = is_pun;
+     pvb_modes=modes;
+     pvb_is_pun=is_pun;
      pvb_attributes =
        add_text_attrs text (add_docs_attrs docs attrs);
      pvb_loc = loc;
@@ -509,11 +511,19 @@ module Type = struct
      pcd_attributes = add_info_attrs info attrs;
     }
 
+  let constructor_arg ?(loc = !default_loc) ?(modalities = []) typ =
+    {
+      pca_modalities = modalities;
+      pca_type = typ;
+      pca_loc = loc;
+    }
+
   let field ?(loc = !default_loc) ?(attrs = []) ?(info = empty_info)
-        ?(mut = Immutable) name typ =
+        ?(mut = Immutable) ?(modalities = []) name typ =
     {
      pld_name = name;
      pld_mutable = mut;
+     pld_modalities = modalities;
      pld_type = typ;
      pld_loc = loc;
      pld_attributes = add_info_attrs info attrs;

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -803,6 +803,8 @@ rule token = parse
             { PREFIXOP op }
   | ['=' '<' '>' '|' '&' '$'] symbolchar * as op
             { INFIXOP0 op }
+  | "@" { AT }
+  | "@@" { ATAT }
   | ['@' '^'] symbolchar * as op
             { INFIXOP1 op }
   | ['+' '-'] symbolchar * as op

--- a/vendor/parser-standard/lexer.mll
+++ b/vendor/parser-standard/lexer.mll
@@ -780,6 +780,8 @@ rule token = parse
             { PREFIXOP op }
   | ['=' '<' '>' '|' '&' '$'] symbolchar * as op
             { INFIXOP0 op }
+  | "@" { AT }
+  | "@@" { ATAT }
   | ['@' '^'] symbolchar * as op
             { INFIXOP1 op }
   | ['+' '-'] symbolchar * as op


### PR DESCRIPTION
This adds support for modes and modalities in the following positions:

- Let bindings:
`let x @ mode = y`
`let x : typ @@ mode = y`
- Expressions:
`let _ = (x : typ @@ mode)`
- Arrow params:
`type t = typ @ mode -> lbl:typ @ mode -> typ @ mode`
- Modalities on record fields:
`type t = { x : typ @@ modality }`
- Modalities on constructor arguments:
`type t = A of typ @@ modality * typ @@ modality`
- Value descriptions:
`val x : typ @@ mode`
- Patterns:
`let ((x @ mode), (y @ mode)) = z`
- Let-bound functions:
`let (f @ mode) (x @ mode) (y @ mode) = z`
