### PR TITLE
Remove unnecessary parens from layout annotations in type parameters

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1946,6 +1946,13 @@ end = struct
     | { ast= {ptyp_desc= Ptyp_poly _; _}
       ; ctx= Typ {ptyp_desc= Ptyp_arrow _; _} } ->
         true
+    | { ast= {ptyp_desc= Ptyp_var (_, _) | Ptyp_any; _}
+      ; ctx= Typ {ptyp_desc= Ptyp_constr (_, args); _} }
+      when List.length args > 1 ->
+        (* Type variables and _ do not need parens when they appear as an
+           argument to a multi-parameter type constructor, even if they have
+           layout annotations. *)
+        false
     | {ast= {ptyp_desc= Ptyp_var (_, l); _}; ctx= _} when Option.is_some l ->
         true
     | { ast= {ptyp_desc= Ptyp_tuple ((Some _, _) :: _); _}

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1946,7 +1946,7 @@ end = struct
     | { ast= {ptyp_desc= Ptyp_poly _; _}
       ; ctx= Typ {ptyp_desc= Ptyp_arrow _; _} } ->
         true
-    | { ast= {ptyp_desc= Ptyp_var (_, _) | Ptyp_any; _}
+    | { ast= {ptyp_desc= Ptyp_var (_, _); _}
       ; ctx= Typ {ptyp_desc= Ptyp_constr (_, args); _} }
       when List.length args > 1 ->
         (* Type variables and _ do not need parens when they appear as an

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -68,11 +68,11 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
 type ('a : any, 'b : any, 'c : any) t4
-type 'a t5 = (('a : float64), int, bool) t4
+type 'a t5 = ('a : float64, int, bool) t4
 
-let f : ('a, (_ : value), bool) t4 -> int = fun _ -> 42
+let f : ('a, _ : value, bool) t4 -> int = fun _ -> 42
 
-type ('a, 'b, 'c) t6 = ('a, 'b, ('c : bits32)) t4
+type ('a, 'b, 'c) t6 = ('a, 'b, 'c : bits32) t4
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)
@@ -208,7 +208,7 @@ let f_val : ('a : value). 'a -> 'a = fun x -> f_imm x
 
 type (_ : value) g = MkG : ('a : immediate). 'a g
 type t = int as (_ : immediate)
-type t = (('a : value), ('b : value)) t2
+type t = ('a : value, 'b : value) t2
 type ('a, 'b) t = ('a : value) * ('b : value)
 
 class c : object

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -67,6 +67,13 @@ let g : (_ : value) -> unit = fun _ -> ()
 let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
+type ('a : any, 'b : any, 'c : any) t4
+type 'a t5 = (('a : float64), int, bool) t4
+
+let f : ('a, (_ : value), bool) t4 -> int = fun _ -> 42
+
+type ('a, 'b, 'c) t6 = ('a, 'b, ('c : bits32)) t4
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -94,6 +94,14 @@ let f : _ -> _ = fun _ -> assert false
 
 let g : _ -> _ = fun _ -> assert false
 
+type ('a, 'b, 'c) t4
+
+type 'a t5 = ('a, int, bool) t4
+
+let f : ('a, _, bool) t4 -> int = fun _ -> 42
+
+type ('a, 'b, 'c) t6 = ('a, 'b, 'c) t4
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -97,6 +97,15 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
+type ('a : any, 'b : any, 'c : any) t4
+
+type 'a t5 = ('a : float64, int, bool) t4
+
+let f : ('a, _ : value, bool) t4 -> int = fun _ -> 42;;
+
+type ('a, 'b, 'c) t6 = ('a, 'b, 'c : bits32) t4;;
+
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -105,7 +105,6 @@ let f : ('a, _ : value, bool) t4 -> int = fun _ -> 42;;
 
 type ('a, 'b, 'c) t6 = ('a, 'b, 'c : bits32) t4;;
 
-
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -68,11 +68,11 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
 type ('a : any, 'b : any, 'c : any) t4
-type 'a t5 = (('a : float64), int, bool) t4
+type 'a t5 = ('a : float64, int, bool) t4
 
-let f : ('a, (_ : value), bool) t4 -> int = fun _ -> 42
+let f : ('a, _ : value, bool) t4 -> int = fun _ -> 42
 
-type ('a, 'b, 'c) t6 = ('a, 'b, ('c : bits32)) t4
+type ('a, 'b, 'c) t6 = ('a, 'b, 'c : bits32) t4
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)
@@ -208,7 +208,7 @@ let f_val : ('a : value). 'a -> 'a = fun x -> f_imm x
 
 type (_ : value) g = MkG : ('a : immediate). 'a g
 type t = int as (_ : immediate)
-type t = (('a : value), ('b : value)) t2
+type t = ('a : value, 'b : value) t2
 type ('a, 'b) t = ('a : value) * ('b : value)
 
 class c : object

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -67,6 +67,13 @@ let g : (_ : value) -> unit = fun _ -> ()
 let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
+type ('a : any, 'b : any, 'c : any) t4
+type 'a t5 = (('a : float64), int, bool) t4
+
+let f : ('a, (_ : value), bool) t4 -> int = fun _ -> 42
+
+type ('a, 'b, 'c) t6 = ('a, 'b, ('c : bits32)) t4
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -96,6 +96,14 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
+type ('a : any, 'b : any, 'c : any) t4
+
+type 'a t5 = (('a : float64), int, bool) t4
+
+let f : ('a, (_ : value), bool) t4 -> int = fun _ -> 42
+
+type ('a, 'b, 'c) t6 = ('a, 'b, ('c : bits32)) t4
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -98,11 +98,11 @@ let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
 type ('a : any, 'b : any, 'c : any) t4
 
-type 'a t5 = (('a : float64), int, bool) t4
+type 'a t5 = ('a : float64, int, bool) t4
 
-let f : ('a, (_ : value), bool) t4 -> int = fun _ -> 42
+let f : ('a, _ : value, bool) t4 -> int = fun _ -> 42
 
-type ('a, 'b, 'c) t6 = ('a, 'b, ('c : bits32)) t4
+type ('a, 'b, 'c) t6 = ('a, 'b, 'c : bits32) t4
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)
@@ -260,7 +260,7 @@ type (_ : value) g = MkG : ('a : immediate). 'a g
 
 type t = int as (_ : immediate)
 
-type t = (('a : value), ('b : value)) t2
+type t = ('a : value, 'b : value) t2
 
 type ('a, 'b) t = ('a : value) * ('b : value)
 

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -4193,9 +4193,21 @@ atomic_type:
       { [] }
   | ty = atomic_type
       { [ty] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
+  | LPAREN
+    tys = separated_nontrivial_llist(COMMA, one_type_parameter_of_several)
+    RPAREN
       { tys }
 ;
+
+(* Layout annotations on type expressions typically require parens, as in [('a :
+   float64)].  But this is unnecessary when the type expression is used as the
+   parameter of a tconstr with more than one argument, as in [(int, 'b :
+   float64) t]. *)
+%inline one_type_parameter_of_several:
+  | core_type { $1 }
+  | name=mkrhs(tyvar_name_or_underscore) COLON jkind=jkind_annotation
+    { let descr = Ptyp_var (name, jkind) in
+      mktyp ~loc:$sloc descr }
 
 %inline package_core_type: module_type
       { let (lid, cstrs, attrs) = package_type_of_module_type $1 in

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -4549,8 +4549,23 @@ atomic_type:
       { [] }
   | ty = atomic_type
       { [ty] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
+  | LPAREN
+    tys = separated_nontrivial_llist(COMMA, one_type_parameter_of_several)
+    RPAREN
       { tys }
+
+(* Layout annotations on type expressions typically require parens, as in [('a :
+   float64)].  But this is unnecessary when the type expression is used as the
+   parameter of a tconstr with more than one argument, as in [(int, 'b :
+   float64) t]. *)
+%inline one_type_parameter_of_several:
+  | core_type { $1 }
+  | QUOTE id=ident COLON jkind=jkind_annotation
+    { Jane_syntax.Layouts.type_of ~loc:(make_loc $sloc) @@
+      Ltyp_var { name = Some id; jkind } }
+  | UNDERSCORE COLON jkind=jkind_annotation
+    { Jane_syntax.Layouts.type_of ~loc:(make_loc $sloc) @@
+      Ltyp_var { name = None; jkind } }
 
 %inline package_type: module_type
       { let (lid, cstrs, attrs) = package_type_of_module_type $1 in


### PR DESCRIPTION
This updates ocamlformat to eliminate the parens that are made unnecessary by this compiler PR: https://github.com/ocaml-flambda/flambda-backend/pull/2688

We should not roll an ocamlformat with this PR until that compiler has rolled, because it will remove parens that are needed until then.

@tdelvecchio-jsc could you review this when you have a minute?  There are three commits here - the first adds new tests (which don't even parse yet), the second makes them parse but still prints the unnecessary parens, and the third fixes the formatting to remove the parens.  But it's probably easiest to just review the whole diff at once.