### PR TITLE
Fix formatting of gadt constructors with explicit quantification and inline records

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3763,6 +3763,9 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
       in
       pre $ vars $ typs
   | Pcstr_record (loc, lds) ->
+      let vars =
+        match vars with Some vars -> fmt "@ " $ vars | None -> noop
+      in
       let p = Params.get_record_type c.conf in
       let fmt_ld ~first ~last x =
         fmt_if_k (not first) p.sep_before
@@ -3772,7 +3775,7 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
             " "
         $ fmt_if_k (not last) p.sep_after
       in
-      pre
+      pre $ vars
       $ Cmts.fmt c loc ~pro:(break 1 0) ~epi:noop
         @@ wrap_k p.docked_before p.docked_after
         @@ wrap_k p.break_before p.break_after

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -6983,7 +6983,7 @@
  (action
   (with-stdout-to layout_annotation.ml.stdout
    (with-stderr-to layout_annotation.ml.stderr
-     (run %{bin:ocamlformat} --margin-check %{dep:tests/layout_annotation.ml})))))
+     (run %{bin:ocamlformat} --margin-check --max-iters 3 %{dep:tests/layout_annotation.ml})))))
 
 (rule
  (alias runtest)

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -4415,12 +4415,12 @@
  (action
   (with-stdout-to gadt.ml.stdout
    (with-stderr-to gadt.ml.stderr
-     (run %{bin:ocamlformat} --margin-check %{dep:tests/gadt.ml})))))
+     (run %{bin:ocamlformat} --margin-check --max-iters 3 %{dep:tests/gadt.ml})))))
 
 (rule
  (alias runtest)
  (package ocamlformat)
- (action (diff tests/gadt.ml gadt.ml.stdout)))
+ (action (diff tests/gadt.ml.ref gadt.ml.stdout)))
 
 (rule
  (alias runtest)

--- a/test/passing/tests/gadt.ml
+++ b/test/passing/tests/gadt.ml
@@ -22,3 +22,5 @@ type _ g = MkG : 'a. 'a g
 
 type t =
   | T : (* this comment is too long to fix on same line as the record......... *) { x : 'a * 'b * 'c * 'd } -> t
+
+type t = T : 'a . { x : 'a } -> t

--- a/test/passing/tests/gadt.ml
+++ b/test/passing/tests/gadt.ml
@@ -19,3 +19,6 @@ type _ t += A : int | B : int -> int
 type t = A : (int -> int) -> int
 
 type _ g = MkG : 'a. 'a g
+
+type t =
+  | T : (* this comment is too long to fix on same line as the record......... *) { x : 'a * 'b * 'c * 'd } -> t

--- a/test/passing/tests/gadt.ml.js-ref
+++ b/test/passing/tests/gadt.ml.js-ref
@@ -20,3 +20,5 @@ type t =
       
       { x : 'a * 'b * 'c * 'd }
       -> t
+
+type t = T : 'a. { x : 'a } -> t

--- a/test/passing/tests/gadt.ml.opts
+++ b/test/passing/tests/gadt.ml.opts
@@ -1,0 +1,1 @@
+--max-iters 3

--- a/test/passing/tests/gadt.ml.ref
+++ b/test/passing/tests/gadt.ml.ref
@@ -1,22 +1,31 @@
 type t = A : t
+
 type t = A : t * 'b -> t
 
 type (_, _, _, _, _) gadt =
   | SomeLongName :
-      ('a, 'b, long_name * long_name2, 't, 'u) gadt * ('b, 'c, 'v, 'u, 'k) gadt2
+      ('a, 'b, long_name * long_name2, 't, 'u) gadt
+      * ('b, 'c, 'v, 'u, 'k) gadt2
       -> ('a, 'c, long_name * 'k, 't, 'v) gadt
   | AnEvenLongerName :
-      ('a, 'b, long_name * long_name2, 't, 'u) gadt * ('b, 'c, 'v, 'u, 'k) gadt2
+      ('a, 'b, long_name * long_name2, 't, 'u) gadt
+      * ('b, 'c, 'v, 'u, 'k) gadt2
       -> ('a, 'c, long_name * 'k, 't, 'v) gadt
 
 type _ t = ..
+
 type _ t += A : int | B : int -> int
+
 type t = A : (int -> int) -> int
+
 type _ g = MkG : 'a. 'a g
 
 type t =
   | T :
-      (* this comment is too long to fix on same line as the record......... *)
+      (* this comment is too long to fix on same line as the
+         record......... *)
       
-      { x : 'a * 'b * 'c * 'd }
+      {x: 'a * 'b * 'c * 'd}
       -> t
+
+type t = T : 'a. {x: 'a} -> t

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -280,3 +280,23 @@ let _ : _ =
     [@@layout (poly : value bits64), (acc : value bits64)]
     ;;]
 ;;
+
+(**********************************************)
+(* Test 12: annotated quantification in gadts *)
+
+type t = T : ('a : value) 'b ('c : float64) 'd. 'a * 'b * 'c * 'd -> t
+type t = T : ('a : value) 'b ('c : float64) 'd. { x : 'a * 'b * 'c * 'd } -> t
+
+type t =
+  | T :
+      ((* 1 *) 'a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd.
+      (* 4 *) 'a * 'b * 'c * 'd
+      -> t
+
+type t =
+  | T :
+      ((* 1 *) 'a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd.
+      (* 4 *)
+      
+      { x : 'a * 'b * 'c * 'd }
+      -> t

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -324,3 +324,21 @@ let _ : _ =
     let%lpoly rec fold (type a acc) (xs : a list) ~(init : acc) ~f =
       match xs with [] -> init | x :: xs -> fold xs ~init:(f init x) ~f
     [@@layout (poly : value bits64), (acc : value bits64)]]
+
+(**********************************************)
+(* Test 12: annotated quantification in gadts *)
+
+type t = T : 'a 'b 'c 'd. 'a * 'b * 'c * 'd -> t
+
+type t = T : 'a 'b 'c 'd. {x: 'a * 'b * 'c * 'd} -> t
+
+type t =
+  | T : (* 1 *) 'a 'b (* 2 *) 'c (* 3 *) 'd. (* 4 *) 'a * 'b * 'c * 'd -> t
+
+type t =
+  | T :
+      (* 1 *) 'a 'b (* 2 *) 'c (* 3 *) 'd.
+      (* 4 *)
+      
+      {x: 'a * 'b * 'c * 'd}
+      -> t

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -332,3 +332,17 @@ let _ : _ =
     let%lpoly rec fold (type (a : poly) acc) (xs : a list) ~(init : acc) ~f =
       match xs with [] -> init | x :: xs -> fold xs ~init:(f init x) ~f
     [@@layout (poly : value bits64), (acc : value bits64)]]
+
+(**********************************************)
+(* Test 12: annotated quantification in gadts *)
+
+type t = T : ('a : value) 'b ('c : float64) 'd . 'a * 'b * 'c * 'd -> t
+
+type t = T : ('a : value) 'b ('c : float64) 'd . { x : 'a * 'b * 'c * 'd } -> t
+
+type t =
+  | T : (* 1 *) ('a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd . (* 4 *) 'a * 'b * 'c * 'd -> t
+
+type t =
+  | T : (* 1 *) ('a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd . (* 4 *) { x : 'a * 'b * 'c * 'd } -> t
+

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -280,3 +280,23 @@ let _ : _ =
     [@@layout (poly : value bits64), (acc : value bits64)]
     ;;]
 ;;
+
+(**********************************************)
+(* Test 12: annotated quantification in gadts *)
+
+type t = T : ('a : value) 'b ('c : float64) 'd. 'a * 'b * 'c * 'd -> t
+type t = T : ('a : value) 'b ('c : float64) 'd. { x : 'a * 'b * 'c * 'd } -> t
+
+type t =
+  | T :
+      ((* 1 *) 'a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd.
+      (* 4 *) 'a * 'b * 'c * 'd
+      -> t
+
+type t =
+  | T :
+      ((* 1 *) 'a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd.
+      (* 4 *)
+      
+      { x : 'a * 'b * 'c * 'd }
+      -> t

--- a/test/passing/tests/layout_annotation.ml.opts
+++ b/test/passing/tests/layout_annotation.ml.opts
@@ -1,0 +1,1 @@
+--max-iters 3

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -331,3 +331,24 @@ let _ : _ =
     let%lpoly rec fold (type (a : poly) acc) (xs : a list) ~(init : acc) ~f =
       match xs with [] -> init | x :: xs -> fold xs ~init:(f init x) ~f
     [@@layout (poly : value bits64), (acc : value bits64)]]
+
+(**********************************************)
+(* Test 12: annotated quantification in gadts *)
+
+type t = T : ('a : value) 'b ('c : float64) 'd. 'a * 'b * 'c * 'd -> t
+
+type t = T : ('a : value) 'b ('c : float64) 'd. {x: 'a * 'b * 'c * 'd} -> t
+
+type t =
+  | T :
+      ((* 1 *) 'a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd.
+      (* 4 *) 'a * 'b * 'c * 'd
+      -> t
+
+type t =
+  | T :
+      ((* 1 *) 'a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd.
+      (* 4 *)
+      
+      {x: 'a * 'b * 'c * 'd}
+      -> t


### PR DESCRIPTION
The goal of this PR is to fix formatting of:
```ocaml
type t = T : 'a . { x : 'a } -> t
```
This is currently broken.  The formatter just forgets to print the quantified variables in the case of gadt constructors with inline records, so the fix is very simple.  There are four commits (though it might make more sense to just review the whole diff at once):

- The first commit documents some slightly sad formatting in the case of long lines and inline records (an extra newline is printed for some reason). This is not sad enough for me to figure out how to fix, but it comes up in my new tests and I wanted to document that it's not caused by the rest of the PR.
- The second commit adds the above test, which is broken.
- The third commit is the fix.
- The fourth commit adds some slightly more complicated tests, including layout annotations and comments.  In one case ocamformat will slightly shift a comment at the beginning of the type of a constructor, but in a way that seems fine / not worth doing anything about (but feel free to disagree).

Two of the new tests require us to pass `--max-iters 3` where we did not previously need it, but that seems fine.

Review requested from @tdelvecchio-jsc 