### PR TITLE
Do not attempt to pun [let%foo local_ x = x in ...]

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -578,7 +578,16 @@ let split_global_flags_from_attrs atrs =
   | _ -> (None, atrs)
 
 let let_binding_can_be_punned ~binding ~parsed_ext =
-  let ({lb_op; lb_pat; lb_exp; lb_typ; lb_args; _} : Sugar.Let_binding.t) =
+  let ({ lb_op
+       ; lb_pat
+       ; lb_args
+       ; lb_typ
+       ; lb_exp
+       ; lb_pun= _
+       ; lb_attrs= _
+       ; lb_local
+       ; lb_loc= _ }
+        : Sugar.Let_binding.t ) =
     binding
   in
   match
@@ -587,7 +596,8 @@ let let_binding_can_be_punned ~binding ~parsed_ext =
       , lb_exp.ast.pexp_desc
       , lb_typ
       , lb_args
-      , (lb_pat.ast.ppat_attributes, lb_exp.ast.pexp_attributes) ) )
+      , (lb_pat.ast.ppat_attributes, lb_exp.ast.pexp_attributes)
+      , lb_local ) )
   with
   (* There must be either an operator or an extension *)
   | (("let" | "and"), None), _ -> false
@@ -601,7 +611,9 @@ let let_binding_can_be_punned ~binding ~parsed_ext =
       , (* This cannot be a lambda *)
         []
       , (* There must be no attrs on either side *)
-        ([], []) ) )
+        ([], [])
+      , (* This must not be a [let local_] binding *)
+        false ) )
     when (* LHS and RHS variable names must be the same *)
          String.equal left right ->
       true

--- a/test/passing/tests/let_punning.ml
+++ b/test/passing/tests/let_punning.ml
@@ -103,3 +103,7 @@ let u =
 let v =
   let%foo x[@bar] = x and y = y[@baz] in
   ()
+
+let w =
+  let%foo local_ x = x and local_ y = y in
+  ()

--- a/test/passing/tests/let_punning.ml
+++ b/test/passing/tests/let_punning.ml
@@ -86,6 +86,13 @@ let r =
   (* 6666666666 *)
   x + y + z + w + q
 
+(* Attribute on let binding *)
+
+let w_attr x y =
+  let%foo[@bar] x = x
+  and[@baz] y = y in
+  x + y
+
 (* Non-standard syntax *)
 
 let s = [%bar let x = x and y = y in ()]

--- a/test/passing/tests/let_punning.ml.js-ref
+++ b/test/passing/tests/let_punning.ml.js-ref
@@ -103,6 +103,14 @@ let r =
   x + y + z + w + q
 ;;
 
+(* Attribute on let binding *)
+
+let w_attr x y =
+  let%foo[@bar] x
+  and[@baz] y in
+  x + y
+;;
+
 (* Non-standard syntax *)
 
 let s =

--- a/test/passing/tests/let_punning.ml.js-ref
+++ b/test/passing/tests/let_punning.ml.js-ref
@@ -129,3 +129,9 @@ let v =
   and y = y [@baz] in
   ()
 ;;
+
+let w =
+  let%foo local_ x = x
+  and local_ y = y in
+  ()
+;;

--- a/test/passing/tests/let_punning.ml.ref
+++ b/test/passing/tests/let_punning.ml.ref
@@ -106,3 +106,7 @@ let u =
 let v =
   let%foo (x [@bar]) = x and y = y [@baz] in
   ()
+
+let w =
+  let%foo local_ x = x and local_ y = y in
+  ()

--- a/test/passing/tests/let_punning.ml.ref
+++ b/test/passing/tests/let_punning.ml.ref
@@ -86,6 +86,12 @@ let r =
   (* 6666666666 *)
   x + y + z + w + q
 
+(* Attribute on let binding *)
+
+let w_attr x y =
+  let%foo[@bar] x = x and[@baz] y = y in
+  x + y
+
 (* Non-standard syntax *)
 
 let s =


### PR DESCRIPTION
The parser does not permit let puns on `local_` let-bindings, so adding `local_` to a let binding should prevent the binding from being punned by `ocamlformat`.

In the first commit, we add a test exhibiting the bug.

We then fix the bug and add a test for let-bindings with attributes (unlike `let local_ ...`, `let[@foo]...` parses when punned).