### PR TITLE
Fix explicitly quantified types in value descriptions

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -985,8 +985,12 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_poly ([], _) ->
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
+      let dedent_type_vars =
+        Option.is_some pro && Poly.(c.conf.fmt_opts.break_colon.v = `Before)
+      in
       hovbox_if box 0
-        ( hovbox_if (not box) (-2)
+        ( hovbox_if (not box)
+            (if dedent_type_vars then -2 else 0)
             (list a1N "@ " (fmt_type_var_with_parenze ~have_tick:true c))
         $ fmt ".@ "
         $ fmt_core_type c ~box:true (sub_typ ~ctx t) )

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -986,7 +986,8 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
       hovbox_if box 0
-        ( list a1N "@ " (fmt_type_var_with_parenze ~have_tick:true c)
+        ( hovbox_if (not box) (-2)
+            (list a1N "@ " (fmt_type_var_with_parenze ~have_tick:true c))
         $ fmt ".@ "
         $ fmt_core_type c ~box:true (sub_typ ~ctx t) )
   | Ptyp_tuple typs ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -564,7 +564,9 @@ let fmt_type_var ~have_tick c s =
   $ Option.value_map jkind_opt ~default:noop ~f:(fmt_jkind c)
 
 let fmt_type_var_with_parenze ~have_tick c s =
-  wrap_if (type_var_has_jkind_annot s) "(" ")" (fmt_type_var ~have_tick c s)
+  let jkind_annot = type_var_has_jkind_annot s in
+  cbox_if jkind_annot 0
+    (wrap_if jkind_annot "(" ")" (fmt_type_var ~have_tick c s))
 
 let split_global_flags_from_attrs atrs =
   match
@@ -985,12 +987,8 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_poly ([], _) ->
       impossible "produced by the parser, handled elsewhere"
   | Ptyp_poly (a1N, t) ->
-      let dedent_type_vars =
-        Option.is_some pro && Poly.(c.conf.fmt_opts.break_colon.v = `Before)
-      in
       hovbox_if box 0
-        ( hovbox_if (not box)
-            (if dedent_type_vars then -2 else 0)
+        ( hovbox_if (not box) 0
             (list a1N "@ " (fmt_type_var_with_parenze ~have_tick:true c))
         $ fmt ".@ "
         $ fmt_core_type c ~box:true (sub_typ ~ctx t) )

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -3837,6 +3837,42 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to explicitly_quantified_value_descriptions.mli.stdout
+   (with-stderr-to explicitly_quantified_value_descriptions.mli.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/explicitly_quantified_value_descriptions.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/explicitly_quantified_value_descriptions.mli explicitly_quantified_value_descriptions.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/explicitly_quantified_value_descriptions.mli.err explicitly_quantified_value_descriptions.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to explicitly_quantified_value_descriptions.mli.js-stdout
+   (with-stderr-to explicitly_quantified_value_descriptions.mli.js-stderr
+     (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/explicitly_quantified_value_descriptions.mli})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/explicitly_quantified_value_descriptions.mli.js-ref explicitly_quantified_value_descriptions.mli.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/explicitly_quantified_value_descriptions.mli.js-err explicitly_quantified_value_descriptions.mli.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to extensions-indent.ml.stdout
    (with-stderr-to extensions-indent.ml.stderr
      (run %{bin:ocamlformat} --margin-check --max-iters=3 --extension-indent=5 --stritem-extension-indent=3 %{dep:tests/extensions.ml})))))

--- a/test/passing/tests/binders.ml.js-ref
+++ b/test/passing/tests/binders.ml.js-ref
@@ -2,7 +2,7 @@ external f : 'a -> 'a = "asdf"
 
 external g
   : 'aaaaaaa 'aaaaaaaaaaaaaaa 'aaaaaaaaaaaaaaaaaaaaaa 'aaaaaaaaaaaaaa 'aaaaaaa
-  'fooooo_foooooo.
+    'fooooo_foooooo.
   'a -> 'a -> 'a
   = "asdf"
 

--- a/test/passing/tests/binders.ml.js-ref
+++ b/test/passing/tests/binders.ml.js-ref
@@ -1,11 +1,7 @@
 external f : 'a -> 'a = "asdf"
 
 external g
-  : 'aaaaaaa
-  'aaaaaaaaaaaaaaa
-  'aaaaaaaaaaaaaaaaaaaaaa
-  'aaaaaaaaaaaaaa
-  'aaaaaaa
+  : 'aaaaaaa 'aaaaaaaaaaaaaaa 'aaaaaaaaaaaaaaaaaaaaaa 'aaaaaaaaaaaaaa 'aaaaaaa
   'fooooo_foooooo.
   'a -> 'a -> 'a
   = "asdf"

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli
@@ -38,9 +38,10 @@ val f :
    that the type and layout may be split onto multiple lines in the middle of
    wrapping *)
 val f :
-  ('long_quantified_variable_a : layout) ('long_quantified_variable_b :
-  layout) ('long_quantified_variable_c : layout) ('long_quantified_variable_d
-  : layout).
+  ('long_quantified_variable_a : layout)
+  ('long_quantified_variable_b : layout)
+  ('long_quantified_variable_c : layout)
+  ('long_quantified_variable_d : layout).
      long_argument_1234567890
   -> long_argument_1234567890
   -> long_argument_1234567890
@@ -63,9 +64,10 @@ val f :
 
 (* wrapping behavior of layouts when the main type doesn't need to wrap *)
 val f :
-  ('long_quantified_variable_a : layout) ('long_quantified_variable_b :
-  layout) ('long_quantified_variable_c : layout) ('long_quantified_variable_d
-  : layout). short_argument -> short_result
+  ('long_quantified_variable_a : layout)
+  ('long_quantified_variable_b : layout)
+  ('long_quantified_variable_c : layout)
+  ('long_quantified_variable_d : layout). short_argument -> short_result
 
 (* behavior is the same between [val] and [external] descriptions *)
 external f :

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli
@@ -1,0 +1,32 @@
+val f :
+  'a 'b 'c 'd.
+     long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+val f :
+  ('a : layout) ('b : layout) ('c : layout) ('d : layout).
+     long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+external f :
+  'a 'b 'c 'd.
+     long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890 = ""
+
+type t =
+     ('a 'b 'c.
+         long_argument_1234567890
+      -> long_argument_1234567890
+      -> long_argument_1234567890
+      -> long_argument_1234567890
+      -> long_result_1234567890 )
+  -> long_result_1234567890

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli
@@ -75,3 +75,9 @@ external f :
   -> long_argument_1234567890
   -> long_argument_1234567890
   -> long_result_1234567890 = ""
+
+val state_float :
+  ('a : float64) 'e 'f.
+     name:string
+  -> on_event:(local_ 'e -> 'a -> 'a)
+  -> ('e Event.t -> ('a, 'f) t) Unregistered.t

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli
@@ -1,3 +1,12 @@
+(* for comparison, a description with no explicit quantified types *)
+val f :
+     long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+(* most common case of a few short types with no layout annotations *)
 val f :
   'a 'b 'c 'd.
      long_argument_1234567890
@@ -6,6 +15,7 @@ val f :
   -> long_argument_1234567890
   -> long_result_1234567890
 
+(* common case of a few short types with at least one layout annotation *)
 val f :
   ('a : layout) ('b : layout) ('c : layout) ('d : layout).
      long_argument_1234567890
@@ -14,6 +24,50 @@ val f :
   -> long_argument_1234567890
   -> long_result_1234567890
 
+(* uncommon case where quantified types have to line wrap *)
+val f :
+  'long_quantified_variable_a 'long_quantified_variable_b
+  'long_quantified_variable_c 'long_quantified_variable_d.
+     long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+(* uncommon case where quantified types with layouts have to line wrap; note
+   that the type and layout may be split onto multiple lines in the middle of
+   wrapping *)
+val f :
+  ('long_quantified_variable_a : layout) ('long_quantified_variable_b :
+  layout) ('long_quantified_variable_c : layout) ('long_quantified_variable_d
+  : layout).
+     long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+(* same as above, but for janestreet profile *)
+val f :
+  ('even_longer_quantified_variable_a : layout)
+  ('even_longer_quantified_variable_b : layout)
+  ('even_longer_quantified_variable_c : layout)
+  ('even_longer_quantified_variable_d : layout).
+  short_argument -> short_result
+
+(* wrapping behavior when the main type doesn't need to wrap *)
+val f :
+  'long_quantified_variable_a 'long_quantified_variable_b
+  'long_quantified_variable_c 'long_quantified_variable_d.
+  short_argument -> short_result
+
+(* wrapping behavior of layouts when the main type doesn't need to wrap *)
+val f :
+  ('long_quantified_variable_a : layout) ('long_quantified_variable_b :
+  layout) ('long_quantified_variable_c : layout) ('long_quantified_variable_d
+  : layout). short_argument -> short_result
+
+(* behavior is the same between [val] and [external] descriptions *)
 external f :
   'a 'b 'c 'd.
      long_argument_1234567890
@@ -21,12 +75,3 @@ external f :
   -> long_argument_1234567890
   -> long_argument_1234567890
   -> long_result_1234567890 = ""
-
-type t =
-     ('a 'b 'c.
-         long_argument_1234567890
-      -> long_argument_1234567890
-      -> long_argument_1234567890
-      -> long_argument_1234567890
-      -> long_result_1234567890 )
-  -> long_result_1234567890

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
@@ -1,0 +1,33 @@
+val f
+  : 'a 'b 'c 'd.
+  long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+val f
+  : ('a : layout) ('b : layout) ('c : layout) ('d : layout).
+  long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+external f
+  : 'a 'b 'c 'd.
+  long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+  = ""
+
+type t =
+  ('a 'b 'c.
+   long_argument_1234567890
+   -> long_argument_1234567890
+   -> long_argument_1234567890
+   -> long_argument_1234567890
+   -> long_result_1234567890)
+  -> long_result_1234567890

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
@@ -27,7 +27,7 @@ val f
 (* uncommon case where quantified types have to line wrap *)
 val f
   : 'long_quantified_variable_a 'long_quantified_variable_b 'long_quantified_variable_c
-  'long_quantified_variable_d.
+    'long_quantified_variable_d.
   long_argument_1234567890
   -> long_argument_1234567890
   -> long_argument_1234567890
@@ -39,7 +39,7 @@ val f
    wrapping *)
 val f
   : ('long_quantified_variable_a : layout) ('long_quantified_variable_b : layout)
-  ('long_quantified_variable_c : layout) ('long_quantified_variable_d : layout).
+    ('long_quantified_variable_c : layout) ('long_quantified_variable_d : layout).
   long_argument_1234567890
   -> long_argument_1234567890
   -> long_argument_1234567890
@@ -48,21 +48,22 @@ val f
 
 (* same as above, but for janestreet profile *)
 val f
-  : ('even_longer_quantified_variable_a : layout) ('even_longer_quantified_variable_b :
-  layout) ('even_longer_quantified_variable_c : layout)
-  ('even_longer_quantified_variable_d : layout).
+  : ('even_longer_quantified_variable_a : layout)
+    ('even_longer_quantified_variable_b : layout)
+    ('even_longer_quantified_variable_c : layout)
+    ('even_longer_quantified_variable_d : layout).
   short_argument -> short_result
 
 (* wrapping behavior when the main type doesn't need to wrap *)
 val f
   : 'long_quantified_variable_a 'long_quantified_variable_b 'long_quantified_variable_c
-  'long_quantified_variable_d.
+    'long_quantified_variable_d.
   short_argument -> short_result
 
 (* wrapping behavior of layouts when the main type doesn't need to wrap *)
 val f
   : ('long_quantified_variable_a : layout) ('long_quantified_variable_b : layout)
-  ('long_quantified_variable_c : layout) ('long_quantified_variable_d : layout).
+    ('long_quantified_variable_c : layout) ('long_quantified_variable_d : layout).
   short_argument -> short_result
 
 (* behavior is the same between [val] and [external] descriptions *)

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
@@ -1,3 +1,12 @@
+(* for comparison, a description with no explicit quantified types *)
+val f
+  :  long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+(* most common case of a few short types with no layout annotations *)
 val f
   : 'a 'b 'c 'd.
   long_argument_1234567890
@@ -6,6 +15,7 @@ val f
   -> long_argument_1234567890
   -> long_result_1234567890
 
+(* common case of a few short types with at least one layout annotation *)
 val f
   : ('a : layout) ('b : layout) ('c : layout) ('d : layout).
   long_argument_1234567890
@@ -14,6 +24,48 @@ val f
   -> long_argument_1234567890
   -> long_result_1234567890
 
+(* uncommon case where quantified types have to line wrap *)
+val f
+  : 'long_quantified_variable_a 'long_quantified_variable_b 'long_quantified_variable_c
+  'long_quantified_variable_d.
+  long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+(* uncommon case where quantified types with layouts have to line wrap; note
+   that the type and layout may be split onto multiple lines in the middle of
+   wrapping *)
+val f
+  : ('long_quantified_variable_a : layout) ('long_quantified_variable_b : layout)
+  ('long_quantified_variable_c : layout) ('long_quantified_variable_d : layout).
+  long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_argument_1234567890
+  -> long_result_1234567890
+
+(* same as above, but for janestreet profile *)
+val f
+  : ('even_longer_quantified_variable_a : layout) ('even_longer_quantified_variable_b :
+  layout) ('even_longer_quantified_variable_c : layout)
+  ('even_longer_quantified_variable_d : layout).
+  short_argument -> short_result
+
+(* wrapping behavior when the main type doesn't need to wrap *)
+val f
+  : 'long_quantified_variable_a 'long_quantified_variable_b 'long_quantified_variable_c
+  'long_quantified_variable_d.
+  short_argument -> short_result
+
+(* wrapping behavior of layouts when the main type doesn't need to wrap *)
+val f
+  : ('long_quantified_variable_a : layout) ('long_quantified_variable_b : layout)
+  ('long_quantified_variable_c : layout) ('long_quantified_variable_d : layout).
+  short_argument -> short_result
+
+(* behavior is the same between [val] and [external] descriptions *)
 external f
   : 'a 'b 'c 'd.
   long_argument_1234567890
@@ -22,12 +74,3 @@ external f
   -> long_argument_1234567890
   -> long_result_1234567890
   = ""
-
-type t =
-  ('a 'b 'c.
-   long_argument_1234567890
-   -> long_argument_1234567890
-   -> long_argument_1234567890
-   -> long_argument_1234567890
-   -> long_result_1234567890)
-  -> long_result_1234567890

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
@@ -74,3 +74,9 @@ external f
   -> long_argument_1234567890
   -> long_result_1234567890
   = ""
+
+val state_float
+  : ('a : float64) 'e 'f.
+  name:string
+  -> on_event:(local_ 'e -> 'a -> 'a)
+  -> ('e Event.t -> ('a, 'f) t) Unregistered.t

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -219,8 +219,8 @@ let f_gadt : ('a : value). 'a -> 'a g -> 'a = fun x MkG -> f_imm x
 (* comments *)
 val foo
   : ((* comment 1 *) 'k (* comment 2 *) : (* comment 3 *) immediate64 (* comment 4 *))
-  (* comment 5 *)
-  'cmp.
+    (* comment 5 *)
+    'cmp.
   (module S with type Id_and_repr.t = 'k and type Id_and_repr.comparator_witness = 'cmp)
   -> 'k Jane_symbol.Map.t
   -> ('k, Sockaddr.t, 'cmp) Map.t
@@ -229,12 +229,8 @@ type a =
   b (* comment 0 *)
   as
   ((* comment 1 *)
-  'k
-  (* comment 2 *)
-  :
-  (* comment 3 *)
-  immediate64
-  (* comment 4 *))
+  'k (* comment 2 *) : (* comment 3 *)
+  immediate64 (* comment 4 *))
 (* comment 5 *)
 
 let f (type a : immediate) x = x

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -1,8 +1,5 @@
 val foo
-  : ('k
-  :
-  immediate64)
-  'cmp.
+  : ('k : immediate64) 'cmp.
   (module S with type Id_and_repr.t = 'k and type Id_and_repr.comparator_witness = 'cmp)
   -> 'k Jane_symbol.Map.t
   -> ('k, Sockaddr.t, 'cmp) Map.t
@@ -221,13 +218,7 @@ let f_gadt : ('a : value). 'a -> 'a g -> 'a = fun x MkG -> f_imm x
 
 (* comments *)
 val foo
-  : ((* comment 1 *)
-  'k
-  (* comment 2 *)
-  :
-  (* comment 3 *)
-  immediate64
-  (* comment 4 *))
+  : ((* comment 1 *) 'k (* comment 2 *) : (* comment 3 *) immediate64 (* comment 4 *))
   (* comment 5 *)
   'cmp.
   (module S with type Id_and_repr.t = 'k and type Id_and_repr.comparator_witness = 'cmp)
@@ -254,12 +245,7 @@ let f (type (a : immediate) (b : immediate)) x = x
 
 module type S = sig
   val init_with_immediates
-    : ('a
-    :
-    immediate)
-    ('b
-    :
-    immediate).
+    : ('a : immediate) ('b : immediate).
     int -> f:local_ (int -> local_ 'a) -> local_ 'a t
 end
 

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -219,8 +219,8 @@ let f_gadt : ('a : value). 'a -> 'a g -> 'a = fun x MkG -> f_imm x
 (* comments *)
 val foo
   : ((* comment 1 *) 'k (* comment 2 *) : (* comment 3 *) immediate64 (* comment 4 *))
-  (* comment 5 *)
-  'cmp.
+    (* comment 5 *)
+    'cmp.
   (module S with type Id_and_repr.t = 'k and type Id_and_repr.comparator_witness = 'cmp)
   -> 'k Jane_symbol.Map.t
   -> ('k, Sockaddr.t, 'cmp) Map.t
@@ -229,12 +229,8 @@ type a =
   b (* comment 0 *)
   as
   ((* comment 1 *)
-  'k
-  (* comment 2 *)
-  :
-  (* comment 3 *)
-  immediate64
-  (* comment 4 *))
+  'k (* comment 2 *) : (* comment 3 *)
+  immediate64 (* comment 4 *))
 (* comment 5 *)
 
 let f (type a : immediate) x = x

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -1,8 +1,5 @@
 val foo
-  : ('k
-  :
-  immediate64)
-  'cmp.
+  : ('k : immediate64) 'cmp.
   (module S with type Id_and_repr.t = 'k and type Id_and_repr.comparator_witness = 'cmp)
   -> 'k Jane_symbol.Map.t
   -> ('k, Sockaddr.t, 'cmp) Map.t
@@ -221,13 +218,7 @@ let f_gadt : ('a : value). 'a -> 'a g -> 'a = fun x MkG -> f_imm x
 
 (* comments *)
 val foo
-  : ((* comment 1 *)
-  'k
-  (* comment 2 *)
-  :
-  (* comment 3 *)
-  immediate64
-  (* comment 4 *))
+  : ((* comment 1 *) 'k (* comment 2 *) : (* comment 3 *) immediate64 (* comment 4 *))
   (* comment 5 *)
   'cmp.
   (module S with type Id_and_repr.t = 'k and type Id_and_repr.comparator_witness = 'cmp)
@@ -254,12 +245,7 @@ let f (type (a : immediate) (b : immediate)) x = x
 
 module type S = sig
   val init_with_immediates
-    : ('a
-    :
-    immediate)
-    ('b
-    :
-    immediate).
+    : ('a : immediate) ('b : immediate).
     int -> f:local_ (int -> local_ 'a) -> local_ 'a t
 end
 

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -290,12 +290,8 @@ type a =
   b (* comment 0 *)
   as
   ((* comment 1 *)
-  'k
-  (* comment 2 *)
-  :
-  (* comment 3 *)
-  immediate64
-  (* comment 4 *))
+  'k (* comment 2 *) : (* comment 3 *)
+  immediate64 (* comment 4 *))
 (* comment 5 *)
 
 let f (type a : immediate) x = x


### PR DESCRIPTION
Example of current styling in the janestreet profile:
```
val state_float
  : ('a
  :
  float64)
  'e
  'f.
  name:string
  -> on_event:(local_ 'e -> 'a -> 'a)
  -> ('e Event.t -> ('a, 'f) t) Unregistered.t 
```

This PR changes boxing behavior in the janestreet profile for value descriptions to format the above as
```
val state_float
  : ('a : float64) 'e 'f.
  name:string
  -> on_event:(local_ 'e -> 'a -> 'a)
  -> ('e Event.t -> ('a, 'f) t) Unregistered.t

```