### PR TITLE
Do not enforce let punning in let operators

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -578,7 +578,7 @@ let split_global_flags_from_attrs atrs =
   | _ -> (None, atrs)
 
 let let_binding_can_be_punned ~binding ~parsed_ext =
-  let ({ lb_op
+  let ({ lb_op= _
        ; lb_pat
        ; lb_args
        ; lb_typ
@@ -591,29 +591,28 @@ let let_binding_can_be_punned ~binding ~parsed_ext =
     binding
   in
   match
-    ( (lb_op.txt, parsed_ext)
-    , ( lb_pat.ast.ppat_desc
-      , lb_exp.ast.pexp_desc
-      , lb_typ
-      , lb_args
-      , (lb_pat.ast.ppat_attributes, lb_exp.ast.pexp_attributes)
-      , lb_local ) )
+    ( parsed_ext
+    , lb_pat.ast.ppat_desc
+    , lb_exp.ast.pexp_desc
+    , lb_typ
+    , lb_args
+    , (lb_pat.ast.ppat_attributes, lb_exp.ast.pexp_attributes)
+    , lb_local )
   with
-  (* There must be either an operator or an extension *)
-  | (("let" | "and"), None), _ -> false
-  | ( _
-    , ( (* LHS must be just a variable *)
-        Ppat_var {txt= left; _}
-      , (* RHS must be just an identifier with no dots *)
-        Pexp_ident {txt= Lident right; _}
-      , (* There cannot be a type annotation on the [let] *)
-        None
-      , (* This cannot be a lambda *)
-        []
-      , (* There must be no attrs on either side *)
-        ([], [])
-      , (* This must not be a [let local_] binding *)
-        false ) )
+  | ( (* Binding must be inside an extension node (we do not pun operators) *)
+      Some _
+      (* LHS must be just a variable *)
+    , Ppat_var {txt= left; _}
+    , (* RHS must be just an identifier with no dots *)
+      Pexp_ident {txt= Lident right; _}
+    , (* There cannot be a type annotation on the [let] *)
+      None
+    , (* This cannot be a lambda *)
+      []
+    , (* There must be no attrs on either side *)
+      ([], [])
+    , (* This must not be a [let local_] binding *)
+      false )
     when (* LHS and RHS variable names must be the same *)
          String.equal left right ->
       true

--- a/test/passing/tests/let_punning.ml.js-ref
+++ b/test/passing/tests/let_punning.ml.js-ref
@@ -6,9 +6,9 @@ and y = 2
 and z = 3
 
 let p =
-  let* x
-  and* y
-  and* z in
+  let* x = x
+  and* y = y
+  and* z = z in
   x, y, z
 ;;
 
@@ -20,9 +20,9 @@ let q =
 ;;
 
 let p =
-  let* x
-  and* y
-  and* z in
+  let* x = x
+  and* y = y
+  and* z = z in
   x, y, z
 ;;
 
@@ -34,7 +34,7 @@ let q =
 ;;
 
 let p =
-  let* x
+  let* x = x
   and* y = z in
   x, y
 ;;
@@ -47,7 +47,7 @@ let q =
 
 let p =
   let* x = y
-  and* z in
+  and* z = z in
   x, z
 ;;
 
@@ -60,23 +60,25 @@ let q =
 (* Comments *)
 
 let r =
-  let* (* 11111 *) w in
-  let* x (* 22222 *) in
-  let* y (* 33333 *) in
-  let* z (* 44444 *) in
+  let* (* 11111 *) w = w in
+  let* x (* 22222 *) = x in
+  let* y = (* 33333 *) y in
+  let* z = z (* 44444 *) in
   let*
     (* 55555 *)
     (* 66666 *) x
     (* 77777 *)
     (* 88888 *)
+    =
     (* 99999 *)
+    x
     (* 00000 *)
   in
-  let* (* 1111111111 *) x
-  and* (* 2222222222 *) y
-  and* z (* 3333333333 *)
-  and* w (* 4444444444 *)
-  and* q (* 5555555555 *) in
+  let* (* 1111111111 *) x = x
+  and* (* 2222222222 *) y = y
+  and* z (* 3333333333 *) = z
+  and* w = (* 4444444444 *) w
+  and* q = q (* 5555555555 *) in
   (* 6666666666 *)
   x + y + z + w + q
 ;;


### PR DESCRIPTION
We do not use operators like `let*` internally, so we don't gain much by punning them. Meanwhile, enforcing that they are punned complicates the process of keeping internal copies of some external projects in sync with upstream.

We restrict the let-punning added to the `janestreet` profile in #70 to let extension points, like `let%bind x in ()`.

The tests reflect the new behavior.