### PR TITLE
Compact let puns

### DIFF
--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -243,10 +243,11 @@ OPTIONS (CODE FORMATTING STYLE)
            Nested match parens formatting. The flag is unset by default.
            Cannot be set in attributes.
 
-       --let-and={compact|sparse}
+       --let-and={compact|sparse|compact-puns}
            Style of let_and. compact will try to format `let p = e and p = e`
-           in a single line. sparse will always break between them. The
-           default value is compact.
+           in a single line. sparse will always break between them.
+           compact-puns will only try to format `let p and p` in a single
+           line The default value is compact.
 
        --let-binding-indent=COLS
            Indentation of let binding expressions (COLS columns) if they do

--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -247,7 +247,7 @@ OPTIONS (CODE FORMATTING STYLE)
            Style of let_and. compact will try to format `let p = e and p = e`
            in a single line. sparse will always break between them.
            compact-puns will only try to format `let p and p` in a single
-           line The default value is compact.
+           line. The default value is compact.
 
        --let-binding-indent=COLS
            Indentation of let binding expressions (COLS columns) if they do

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -217,7 +217,7 @@ let janestreet_profile from =
   ; indicate_nested_or_patterns= elt `Unsafe_no
   ; infix_precedence= elt `Parens
   ; leading_nested_match_parens= elt true
-  ; let_and= elt `Sparse
+  ; let_and= elt `Compact_only_in_let_pun
   ; let_binding_indent= elt 2
   ; let_binding_deindent_fun= elt false
   ; let_binding_spacing= elt `Double_semicolon
@@ -943,7 +943,10 @@ module Formatting = struct
           "$(b,compact) will try to format `let p = e and p = e` in a \
            single line."
       ; Decl.Value.make ~name:"sparse" `Sparse
-          "$(b,sparse) will always break between them." ]
+          "$(b,sparse) will always break between them."
+      ; Decl.Value.make ~name:"compact-puns" `Compact_only_in_let_pun
+          "$(b,compact-puns) will only try to format `let p and p` in a \
+           single line" ]
     in
     Decl.choice ~names ~all ~default ~doc ~kind
       (fun conf elt -> update conf ~f:(fun f -> {f with let_and= elt}))

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -946,7 +946,7 @@ module Formatting = struct
           "$(b,sparse) will always break between them."
       ; Decl.Value.make ~name:"compact-puns" `Compact_only_in_let_pun
           "$(b,compact-puns) will only try to format `let p and p` in a \
-           single line" ]
+           single line." ]
     in
     Decl.choice ~names ~all ~default ~doc ~kind
       (fun conf elt -> update conf ~f:(fun f -> {f with let_and= elt}))

--- a/lib/Conf_t.ml
+++ b/lib/Conf_t.ml
@@ -88,7 +88,7 @@ type fmt_opts =
   ; indicate_nested_or_patterns: [`Space | `Unsafe_no] elt
   ; infix_precedence: [`Indent | `Parens] elt
   ; leading_nested_match_parens: bool elt
-  ; let_and: [`Compact | `Sparse] elt
+  ; let_and: [`Compact | `Sparse | `Compact_only_in_let_pun] elt
   ; let_binding_indent: int elt
   ; let_binding_deindent_fun: bool elt
   ; let_binding_spacing: [`Compact | `Sparse | `Double_semicolon] elt

--- a/lib/Conf_t.mli
+++ b/lib/Conf_t.mli
@@ -85,7 +85,7 @@ type fmt_opts =
   ; indicate_nested_or_patterns: [`Space | `Unsafe_no] elt
   ; infix_precedence: [`Indent | `Parens] elt
   ; leading_nested_match_parens: bool elt
-  ; let_and: [`Compact | `Sparse] elt
+  ; let_and: [`Compact | `Sparse | `Compact_only_in_let_pun] elt
   ; let_binding_indent: int elt
   ; let_binding_deindent_fun: bool elt
         (** De-indent the [fun] in a let-binding body. *)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -577,7 +577,7 @@ let split_global_flags_from_attrs atrs =
   | [global_attr], atrs -> (Some global_attr, atrs)
   | _ -> (None, atrs)
 
-let let_binding_can_be_punned ~binding ~parsed_ext =
+let let_binding_can_be_punned ~binding ~is_ext =
   let ({ lb_op= _
        ; lb_pat
        ; lb_args
@@ -592,7 +592,7 @@ let let_binding_can_be_punned ~binding ~parsed_ext =
     binding
   in
   match
-    ( parsed_ext
+    ( is_ext
     , lb_pat.ast.ppat_desc
     , lb_exp.ast.pexp_desc
     , lb_typ
@@ -602,7 +602,7 @@ let let_binding_can_be_punned ~binding ~parsed_ext =
     , lb_modes )
   with
   | ( (* Binding must be inside an extension node (we do not pun operators) *)
-      Some _
+      true
       (* LHS must be just a variable *)
     , Ppat_var {txt= left; _}
     , (* RHS must be just an identifier with no dots *)
@@ -4839,7 +4839,7 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
 
 and fmt_let c ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~body_loc
     ~has_attr ~indent_after_in =
-  let parsed_ext = ext in
+  let is_ext = Option.is_some ext in
   let parens = parens || has_attr in
   let fmt_in indent =
     match c.conf.fmt_opts.break_before_in.v with
@@ -4855,7 +4855,7 @@ and fmt_let c ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~body_loc
                 compare c.conf.opr_opts.ocaml_version.v Releases.v4_13_0 >= 0 )
               && binding.lb_pun
           | `Always_pun_if_possible ->
-              let_binding_can_be_punned ~binding ~parsed_ext
+              let_binding_can_be_punned ~binding ~is_ext
         in
         (binding, punned_in_output) )
   in

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4839,25 +4839,39 @@ and fmt_structure_item c ~last:last_item ?ext ~semisemi
 
 and fmt_let c ~ext ~rec_flag ~bindings ~parens ~fmt_atrs ~fmt_expr ~body_loc
     ~has_attr ~indent_after_in =
+  let parsed_ext = ext in
   let parens = parens || has_attr in
   let fmt_in indent =
     match c.conf.fmt_opts.break_before_in.v with
     | `Fit_or_vertical -> break 1 (-indent) $ str "in"
     | `Auto -> fits_breaks " in" ~hint:(1, -indent) "in"
   in
-  let fmt_binding ~first ~last binding =
-    let parsed_ext = ext in
+  let bindings =
+    List.map bindings ~f:(fun (binding : Sugar.Let_binding.t) ->
+        let punned_in_output =
+          match c.conf.fmt_opts.let_punning.v with
+          | `Preserve_existing_puns ->
+              Ocaml_version.(
+                compare c.conf.opr_opts.ocaml_version.v Releases.v4_13_0 >= 0 )
+              && binding.lb_pun
+          | `Always_pun_if_possible ->
+              let_binding_can_be_punned ~binding ~parsed_ext
+        in
+        (binding, punned_in_output) )
+  in
+  let all_punned = List.for_all bindings ~f:snd in
+  let fmt_binding ~first ~last (binding, punned_in_output) =
     let ext = if first then ext else None in
     let in_ indent = fmt_if_k last (fmt_in indent) in
     let rec_flag = first && Asttypes.is_recursive rec_flag in
-    fmt_value_binding c ~rec_flag ?ext ?parsed_ext ~in_ binding
+    fmt_value_binding c ~rec_flag ~punned_in_output ?ext ~in_ binding
     $ fmt_if (not last)
-        ( match c.conf.fmt_opts.let_and.v with
-        | `Sparse -> "@;<1000 0>"
-        | `Compact -> "@ " )
+        ( match (c.conf.fmt_opts.let_and.v, all_punned) with
+        | `Sparse, _ | `Compact_only_in_let_pun, false -> "@;<1000 0>"
+        | `Compact, _ | `Compact_only_in_let_pun, true -> "@ " )
   in
   let blank_line_after_in =
-    let last_bind = List.last_exn bindings in
+    let last_bind, _ = List.last_exn bindings in
     sequence_blank_line c last_bind.lb_loc body_loc
   in
   Params.Exp.wrap c.conf ~parens:(parens || has_attr) ~fits_breaks:false
@@ -4907,28 +4921,19 @@ and fmt_value_constraint c vc_opt =
             $ fmt_core_type c (sub_typ ~ctx coercion) ) )
   | None -> (noop, noop)
 
-and fmt_value_binding c ~rec_flag ?ext ?parsed_ext ?in_ ?epi
-    ( { lb_op
-      ; lb_pat
-      ; lb_args
-      ; lb_typ
-      ; lb_exp
-      ; lb_attrs
-      ; lb_local
-      ; lb_modes
-      ; lb_loc
-      ; lb_pun= punned_in_source } as binding ) =
+and fmt_value_binding c ~rec_flag ?(punned_in_output = false) ?ext ?in_ ?epi
+    { lb_op
+    ; lb_pat
+    ; lb_args
+    ; lb_typ
+    ; lb_exp
+    ; lb_attrs
+    ; lb_local
+    ; lb_modes
+    ; lb_loc
+    ; lb_pun= punned_in_source } =
   update_config_maybe_disabled c lb_loc lb_attrs
   @@ fun c ->
-  let punned_in_output =
-    match c.conf.fmt_opts.let_punning.v with
-    | `Preserve_existing_puns ->
-        Ocaml_version.(
-          compare c.conf.opr_opts.ocaml_version.v Releases.v4_13_0 >= 0 )
-        && punned_in_source
-    | `Always_pun_if_possible ->
-        let_binding_can_be_punned ~binding ~parsed_ext
-  in
   let doc1, atrs = doc_atrs lb_attrs in
   let doc2, atrs = doc_atrs atrs in
   let fmt_newtypes, fmt_cstr = fmt_value_constraint c lb_typ in

--- a/test/passing/tests/let_punning.ml
+++ b/test/passing/tests/let_punning.ml
@@ -42,6 +42,14 @@ let q =
 
 (* Line breaks *)
 
+let mixed =
+  let%foo a = a
+  and b = b
+  and c = c
+  and d = e + f
+  in 
+  ()
+
 let long =
   let%foo a = a
   and b = b

--- a/test/passing/tests/let_punning.ml
+++ b/test/passing/tests/let_punning.ml
@@ -40,6 +40,50 @@ let q =
   let%foo x = y and z = z in
   (x, z)
 
+(* Line breaks *)
+
+let long =
+  let%foo a = a
+  and b = b
+  and c = c
+  and d = d
+  and e = e
+  and f = f
+  and g = g
+  and h = h
+  and i = i
+  and j = j
+  and k = k
+  and l = l
+  in
+  ()
+
+let looong =
+  let%foo a = a
+  and b = b
+  and c = c
+  and d = d
+  and e = e
+  and f = f
+  and g = g
+  and h = h
+  and i = i
+  and j = j
+  and k = k
+  and l = l
+  and m = m
+  and n = n
+  and o = o
+  and p = p
+  and q = q
+  and r = r
+  and s = s
+  and t = t
+  and u = u
+  and v = v
+  in
+  ()
+
 (* Comments *)
 
 let r =

--- a/test/passing/tests/let_punning.ml.js-ref
+++ b/test/passing/tests/let_punning.ml.js-ref
@@ -55,6 +55,14 @@ let q =
 
 (* Line breaks *)
 
+let mixed =
+  let%foo a
+  and b
+  and c
+  and d = e + f in
+  ()
+;;
+
 let long =
   let%foo a and b and c and d and e and f and g and h and i and j and k and l in
   ()

--- a/test/passing/tests/let_punning.ml.js-ref
+++ b/test/passing/tests/let_punning.ml.js-ref
@@ -13,9 +13,7 @@ let p =
 ;;
 
 let q =
-  let%foo x
-  and y
-  and z in
+  let%foo x and y and z in
   x, y, z
 ;;
 
@@ -27,9 +25,7 @@ let p =
 ;;
 
 let q =
-  let%foo x
-  and y
-  and z in
+  let%foo x and y and z in
   x, y, z
 ;;
 
@@ -55,6 +51,39 @@ let q =
   let%foo x = y
   and z in
   x, z
+;;
+
+(* Line breaks *)
+
+let long =
+  let%foo a and b and c and d and e and f and g and h and i and j and k and l in
+  ()
+;;
+
+let looong =
+  let%foo a
+  and b
+  and c
+  and d
+  and e
+  and f
+  and g
+  and h
+  and i
+  and j
+  and k
+  and l
+  and m
+  and n
+  and o
+  and p
+  and q
+  and r
+  and s
+  and t
+  and u
+  and v in
+  ()
 ;;
 
 (* Comments *)
@@ -108,8 +137,7 @@ let r =
 (* Attribute on let binding *)
 
 let w_attr x y =
-  let%foo[@bar] x
-  and[@baz] y in
+  let%foo[@bar] x and[@baz] y in
   x + y
 ;;
 

--- a/test/passing/tests/let_punning.ml.ref
+++ b/test/passing/tests/let_punning.ml.ref
@@ -42,6 +42,10 @@ let q =
 
 (* Line breaks *)
 
+let mixed =
+  let%foo a = a and b = b and c = c and d = e + f in
+  ()
+
 let long =
   let%foo a = a
   and b = b

--- a/test/passing/tests/let_punning.ml.ref
+++ b/test/passing/tests/let_punning.ml.ref
@@ -40,6 +40,48 @@ let q =
   let%foo x = y and z = z in
   (x, z)
 
+(* Line breaks *)
+
+let long =
+  let%foo a = a
+  and b = b
+  and c = c
+  and d = d
+  and e = e
+  and f = f
+  and g = g
+  and h = h
+  and i = i
+  and j = j
+  and k = k
+  and l = l in
+  ()
+
+let looong =
+  let%foo a = a
+  and b = b
+  and c = c
+  and d = d
+  and e = e
+  and f = f
+  and g = g
+  and h = h
+  and i = i
+  and j = j
+  and k = k
+  and l = l
+  and m = m
+  and n = n
+  and o = o
+  and p = p
+  and q = q
+  and r = r
+  and s = s
+  and t = t
+  and u = u
+  and v = v in
+  ()
+
 (* Comments *)
 
 let r =


### PR DESCRIPTION
Now that we have enabled "let punning," we can also use a more "compact" layout when a let-and contains only punned bindings. So we can rewrite
```ocaml
let long =
  let%foo a = a
  and b = b
  and c = c
  and d = d
  and e = e
  and f = f
  and g = g
  and h = h
  and i = i
  and j = j
  and k = k
  and l = l in
  ()
```
to
```ocaml
let long =
  let%foo a and b and c and d and e and f and g and h and i and j and k and l in
  ()
;;
```

If a single let-and contains both punned and not-punned bindings, or if it contains only punned bindings, but they would not fit on one line, we continue to place each binding on its own line. These cases are exhibited in the tests.