### PR TITLE
Fix modalities on externals

### DIFF
--- a/HACKING.jst.md
+++ b/HACKING.jst.md
@@ -83,7 +83,7 @@ Before building
 You will need to install several libraries. This command may work:
 
 ```
-opam install menhir.20210419 fix ocp-indent bechamel-js alcotest camlp-streams fpath either dune-build-info uuseg ocaml-version
+opam install menhir.20210419 fix ocp-indent bechamel-js alcotest camlp-streams fpath either dune-build-info uuseg ocaml-version stdio
 ```
 
 Building

--- a/test/passing/tests/modes-ocaml_version.ml.ref
+++ b/test/passing/tests/modes-ocaml_version.ml.ref
@@ -41,6 +41,14 @@ module Let_bindings = struct
     let%ext x : typ @@ mode = y in
     let%ext x @ mode = x and y @ mode = y and z : typ @@ mode = z in
     ()
+
+  external x : typ @@ mode1 mode2 = ""
+
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Expressions = struct
@@ -231,6 +239,14 @@ module type Value_descriptions = sig
   val x : typ1 -> typ2 @@ mode1 mode2
 
   val x : typ1 * typ2 @@ mode1 mode2
+
+  external x : typ @@ mode1 mode2 = ""
+
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Let_bound_functions = struct

--- a/test/passing/tests/modes.ml
+++ b/test/passing/tests/modes.ml
@@ -39,6 +39,11 @@ module Let_bindings = struct
     and z : typ @@ mode = z in
     ()
   ;;
+
+  external x : typ @@ mode1 mode2 = ""
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Expressions = struct
@@ -254,6 +259,10 @@ module type Value_descriptions = sig
   val x : typ1 typ2 @@ mode1 mode2
   val x : typ1 -> typ2 @@ mode1 mode2
   val x : typ1 * typ2 @@ mode1 mode2
+  external x : typ @@ mode1 mode2 = ""
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Let_bound_functions = struct

--- a/test/passing/tests/modes.ml.js-ref
+++ b/test/passing/tests/modes.ml.js-ref
@@ -39,6 +39,11 @@ module Let_bindings = struct
     and z : typ @@ mode = z in
     ()
   ;;
+
+  external x : typ @@ mode1 mode2 = ""
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Expressions = struct
@@ -254,6 +259,10 @@ module type Value_descriptions = sig
   val x : typ1 typ2 @@ mode1 mode2
   val x : typ1 -> typ2 @@ mode1 mode2
   val x : typ1 * typ2 @@ mode1 mode2
+  external x : typ @@ mode1 mode2 = ""
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Let_bound_functions = struct

--- a/test/passing/tests/modes.ml.ref
+++ b/test/passing/tests/modes.ml.ref
@@ -41,6 +41,14 @@ module Let_bindings = struct
     let%ext x : typ @@ mode = y in
     let%ext x @ mode = x and y @ mode = y and z : typ @@ mode = z in
     ()
+
+  external x : typ @@ mode1 mode2 = ""
+
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Expressions = struct
@@ -231,6 +239,14 @@ module type Value_descriptions = sig
   val x : typ1 -> typ2 @@ mode1 mode2
 
   val x : typ1 * typ2 @@ mode1 mode2
+
+  external x : typ @@ mode1 mode2 = ""
+
+  external x : typ1 typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 -> typ2 @@ mode1 mode2 = ""
+
+  external x : typ1 * typ2 @@ mode1 mode2 = ""
 end
 
 module Let_bound_functions = struct

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -3474,13 +3474,14 @@ primitive_declaration:
   id = mkrhs(val_ident)
   COLON
   ty = possibly_poly(core_type)
+  modalities = optional_atat_modalities_expr
   EQUAL
   prim = mkrhs(raw_string)+
   attrs2 = post_item_attributes
     { let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       let docs = symbol_docs $sloc in
-      Val.mk id ty ~prim ~attrs ~loc ~docs,
+      Val.mk id ty ~prim ~attrs ~modalities ~loc ~docs,
       ext }
 ;
 

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -3760,13 +3760,14 @@ primitive_declaration:
   id = mkrhs(val_ident)
   COLON
   ty = possibly_poly(core_type)
+  modalities = optional_atat_modalities_expr
   EQUAL
   prim = raw_string+
   attrs2 = post_item_attributes
     { let attrs = attrs1 @ attrs2 in
       let loc = make_loc $sloc in
       let docs = symbol_docs $sloc in
-      Val.mk id ty ~prim ~attrs ~loc ~docs,
+      Val.mk id ty ~prim ~attrs ~modalities ~loc ~docs,
       ext }
 ;
 


### PR DESCRIPTION
The original support for the new modes syntax left out modalities on external definitions. Add it.

Also updated the internal hacking doc with an additional library that needs to be installed.