### PR TITLE
Fix printing of `(local_ x) |> f` and some related forms

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2398,6 +2398,20 @@ end = struct
              ~test:extension_exclave ->
         false
     | _, {pexp_desc= Pexp_infix _; pexp_attributes= _ :: _; _} -> true
+    | ( Exp {pexp_desc= Pexp_infix (_, e1, _); _}
+      , { pexp_desc=
+            Pexp_apply
+              ( { pexp_desc=
+                    Pexp_extension ({txt= extension_local; _}, PStr [])
+                ; _ }
+              , [(Nolabel, _)] )
+        ; _ } )
+      when e1 == exp
+           && ( Conf.is_jane_street_local_annotation "local"
+                  ~test:extension_local
+              || Conf.is_jane_street_local_annotation "exclave"
+                   ~test:extension_local ) ->
+        true
     | ( Str
           { pstr_desc=
               Pstr_value

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -118,3 +118,13 @@ let () =
   ()
 
 type t : value
+
+let _ = (local_ x) + y
+let _ = (local_ x) |> f
+let _ = local_ x + y
+let _ = local_ x |> f
+
+let _ = (exclave_ x) + y
+let _ = (exclave_ x) |> f
+let _ = exclave_ x + y
+let _ = exclave_ x |> f

--- a/test/passing/tests/local.ml.js-ref
+++ b/test/passing/tests/local.ml.js-ref
@@ -172,3 +172,12 @@ let () =
 ;;
 
 type t : value
+
+let _ = (local_ x) + y
+let _ = (local_ x) |> f
+let _ = local_ x + y
+let _ = local_ x |> f
+let _ = (exclave_ x) + y
+let _ = (exclave_ x) |> f
+let _ = exclave_ x + y
+let _ = exclave_ x |> f

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -180,3 +180,19 @@ let () =
   ()
 
 type t : value
+
+let _ = (local_ x) + y
+
+let _ = (local_ x) |> f
+
+let _ = local_ x + y
+
+let _ = local_ x |> f
+
+let _ = (exclave_ x) + y
+
+let _ = (exclave_ x) |> f
+
+let _ = exclave_ x + y
+
+let _ = exclave_ x |> f


### PR DESCRIPTION
This fixes an issue where:
```ocaml
let _ = (local_ x) |> f
```
was being printed as
```ocaml
let _ = local_ x |> f
```
which is a different thing, triggering the round trip check.  I fixed this by adding a parenthesization rule for the lhs of infix operators - an alternative would be to add logic in the printing of infix operators, but since that is split out into several cases this felt cleaner.

This also fixes (and adds tests for) `exclave_` in the same position.  That is nonsense, but ocamlformat shouldn't blow up on it.