### PR TITLE
Drop parentheses in kind annotations in types with multiple arguments

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1957,8 +1957,13 @@ end = struct
     | { ast= {ptyp_desc= Ptyp_poly _; _}
       ; ctx= Typ {ptyp_desc= Ptyp_arrow _; _} } ->
         true
-    | {ast= {ptyp_desc= Ptyp_var (_, l); _}; ctx= _} when Option.is_some l ->
-        true
+    | {ast= {ptyp_desc= Ptyp_var (_, l); _}; ctx} when Option.is_some l -> (
+      match ctx with
+      | Typ {ptyp_desc= Ptyp_constr (_, _ :: _ :: _); _} ->
+          (* annotations on one of multiple arguments to a type do not
+             warrant parens *)
+          false
+      | _ -> true )
     | { ast= {ptyp_desc= Ptyp_tuple ((Some _, _) :: _); _}
       ; ctx= Typ {ptyp_desc= Ptyp_arrow (args, _, _); _} }
       when List.exists args ~f:(fun arg -> arg.pap_type == typ) ->

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -63,6 +63,19 @@ let f : (_ : immediate) -> unit = fun _ -> ()
 let g : (_ : value) -> unit = fun _ -> ()
 let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
+let f : ((_ : any), _) t = ()
+let g : (_, (_ : any)) t = ()
+let f : ((_ : any), _) t -> t = ()
+let g : (_, (_ : any)) t -> t = ()
+
+let f
+  :  (_, (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any)) t
+  -> t
+  =
+  ()
+;;
+
+let g : (_, _, _, _, _, _, _, _, (_ : any)) t -> t = ()
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)

--- a/test/passing/tests/layout_annotation-erased.ml.js-ref
+++ b/test/passing/tests/layout_annotation-erased.ml.js-ref
@@ -63,19 +63,12 @@ let f : (_ : immediate) -> unit = fun _ -> ()
 let g : (_ : value) -> unit = fun _ -> ()
 let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
-let f : ((_ : any), _) t = ()
-let g : (_, (_ : any)) t = ()
-let f : ((_ : any), _) t -> t = ()
-let g : (_, (_ : any)) t -> t = ()
-
-let f
-  :  (_, (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any)) t
-  -> t
-  =
-  ()
-;;
-
-let g : (_, _, _, _, _, _, _, _, (_ : any)) t -> t = ()
+let f : (_ : any, _) t = ()
+let g : (_, _ : any) t = ()
+let f : (_ : any, _) t -> t = ()
+let g : (_, _ : any) t -> t = ()
+let f : (_, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any) t -> t = ()
+let g : (_, _, _, _, _, _, _, _, _ : any) t -> t = ()
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)
@@ -211,7 +204,7 @@ let f_val : ('a : value). 'a -> 'a = fun x -> f_imm x
 
 type (_ : value) g = MkG : ('a : immediate). 'a g
 type t = int as (_ : immediate)
-type t = (('a : value), ('b : value)) t2
+type t = ('a : value, 'b : value) t2
 type ('a, 'b) t = ('a : value) * ('b : value)
 
 class c : object

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -94,6 +94,18 @@ let f : _ -> _ = fun _ -> assert false
 
 let g : _ -> _ = fun _ -> assert false
 
+let f : (_, _) t = ()
+
+let g : (_, _) t = ()
+
+let f : (_, _) t -> t = ()
+
+let g : (_, _) t -> t = ()
+
+let f : (_, _, _, _, _, _, _, _) t -> t = ()
+
+let g : (_, _, _, _, _, _, _, _, _) t -> t = ()
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -97,6 +97,18 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
+let f : (_ : any, _) t = ()
+
+let g : (_, _ : any) t = ()
+
+let f : (_ : any, _) t -> t = ()
+
+let g : (_, _ : any) t -> t = ()
+
+let f : (_, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any) t -> t = ()
+
+let g : (_, _, _, _, _, _, _, _, _ : any) t -> t = ()
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -63,6 +63,19 @@ let f : (_ : immediate) -> unit = fun _ -> ()
 let g : (_ : value) -> unit = fun _ -> ()
 let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
+let f : ((_ : any), _) t = ()
+let g : (_, (_ : any)) t = ()
+let f : ((_ : any), _) t -> t = ()
+let g : (_, (_ : any)) t -> t = ()
+
+let f
+  :  (_, (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any)) t
+  -> t
+  =
+  ()
+;;
+
+let g : (_, _, _, _, _, _, _, _, (_ : any)) t -> t = ()
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -63,19 +63,12 @@ let f : (_ : immediate) -> unit = fun _ -> ()
 let g : (_ : value) -> unit = fun _ -> ()
 let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
-let f : ((_ : any), _) t = ()
-let g : (_, (_ : any)) t = ()
-let f : ((_ : any), _) t -> t = ()
-let g : (_, (_ : any)) t -> t = ()
-
-let f
-  :  (_, (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any), (_ : any)) t
-  -> t
-  =
-  ()
-;;
-
-let g : (_, _, _, _, _, _, _, _, (_ : any)) t -> t = ()
+let f : (_ : any, _) t = ()
+let g : (_, _ : any) t = ()
+let f : (_ : any, _) t -> t = ()
+let g : (_, _ : any) t -> t = ()
+let f : (_, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any) t -> t = ()
+let g : (_, _, _, _, _, _, _, _, _ : any) t -> t = ()
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)
@@ -211,7 +204,7 @@ let f_val : ('a : value). 'a -> 'a = fun x -> f_imm x
 
 type (_ : value) g = MkG : ('a : immediate). 'a g
 type t = int as (_ : immediate)
-type t = (('a : value), ('b : value)) t2
+type t = ('a : value, 'b : value) t2
 type ('a, 'b) t = ('a : value) * ('b : value)
 
 class c : object

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -96,6 +96,29 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
+let f : ((_ : any), _) t = ()
+
+let g : (_, (_ : any)) t = ()
+
+let f : ((_ : any), _) t -> t = ()
+
+let g : (_, (_ : any)) t -> t = ()
+
+let f :
+       ( _
+       , (_ : any)
+       , (_ : any)
+       , (_ : any)
+       , (_ : any)
+       , (_ : any)
+       , (_ : any)
+       , (_ : any) )
+       t
+    -> t =
+  ()
+
+let g : (_, _, _, _, _, _, _, _, (_ : any)) t -> t = ()
+
 (********************************************)
 (* Test 3: Annotation on types in functions *)
 

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -96,28 +96,20 @@ let f : (_ : immediate) -> (_ : value) = fun _ -> assert false
 
 let g : (_ : value) -> (_ : immediate) = fun _ -> assert false
 
-let f : ((_ : any), _) t = ()
+let f : (_ : any, _) t = ()
 
-let g : (_, (_ : any)) t = ()
+let g : (_, _ : any) t = ()
 
-let f : ((_ : any), _) t -> t = ()
+let f : (_ : any, _) t -> t = ()
 
-let g : (_, (_ : any)) t -> t = ()
+let g : (_, _ : any) t -> t = ()
 
 let f :
-       ( _
-       , (_ : any)
-       , (_ : any)
-       , (_ : any)
-       , (_ : any)
-       , (_ : any)
-       , (_ : any)
-       , (_ : any) )
-       t
-    -> t =
+    (_, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any, _ : any) t -> t
+    =
   ()
 
-let g : (_, _, _, _, _, _, _, _, (_ : any)) t -> t = ()
+let g : (_, _, _, _, _, _, _, _, _ : any) t -> t = ()
 
 (********************************************)
 (* Test 3: Annotation on types in functions *)
@@ -275,7 +267,7 @@ type (_ : value) g = MkG : ('a : immediate). 'a g
 
 type t = int as (_ : immediate)
 
-type t = (('a : value), ('b : value)) t2
+type t = ('a : value, 'b : value) t2
 
 type ('a, 'b) t = ('a : value) * ('b : value)
 

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -4346,8 +4346,22 @@ atomic_type:
       { [] }
   | ty = atomic_type
       { [ty] }
-  | LPAREN tys = separated_nontrivial_llist(COMMA, core_type) RPAREN
+  | LPAREN
+    tys = separated_nontrivial_llist(COMMA, one_type_parameter_of_several)
+    RPAREN
       { tys }
+;
+
+(* Layout annotations on type expressions typically require parens, as in [('a :
+   float64)].  But this is unnecessary when the type expression is used as the
+   parameter of a tconstr with more than one argument, as in [(int, 'b :
+   float64) t]. *)
+%inline one_type_parameter_of_several:
+  | core_type { $1 }
+  | QUOTE id=mkrhs(ident {Some $1}) COLON jkind=jkind_annotation
+    { mktyp ~loc:$sloc (Ptyp_var (id, jkind)) }
+  | mkrhs(UNDERSCORE {None}) COLON jkind=jkind_annotation
+    { mktyp ~loc:$sloc (Ptyp_var ($1, jkind)) }
 ;
 
 %inline package_core_type: module_type


### PR DESCRIPTION
Compiler PR [#2688](https://github.com/ocaml-flambda/flambda-backend/pull/2688) makes parentheses in kind annotations on one of several type arguments optional. For example, the following now parses:
```ocaml
type t = (_, _ : any) t
```

Previously, one was required to write:
```ocaml
type t = (_, (_ : any)) t
```

This PR adjusts ocamlformat to recognize the relaxed syntax.
1. The first commit adds tests with the new syntax. ocamlformat fails to parse them, because the extended parser lags behind the standard parser.
2. The second commit fixes the extended parser. The tests now pass, although ocamlformat still produces the now-redundant parentheses.
3. The third commit teaches ocamlformat to elide these parentheses, now that they are no longer needed.