### PR TITLE
Make more compatible with bleeding-edge-with-extensions & remove windows CI

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
-          - 4.14.x
+          - 5.2.x
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -18,7 +18,8 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - windows-latest
+          # Don't include windows. At time of writing, its opam repository doesn't have 5.2.
+          # - windows-latest
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
           - 5.2.x

--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -21,7 +21,7 @@ jobs:
           - windows-latest
         ocaml-compiler:
           # Don't include every versions. OCaml-CI already covers that
-          - 4.14.x
+          - 5.2.x
 
     runs-on: ${{ matrix.os }}
 

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -27,10 +27,11 @@ let string_at t (l : Location.t) =
   and len = Position.distance l.loc_start l.loc_end in
   String.sub t.text ~pos ~len
 
-let find_token t k pos = exclave_
+let find_token t k pos =
   Array.binary_search t.tokens
     ~compare:(fun (_, elt) pos -> Position.compare elt.Location.loc_start pos)
     k pos
+  |> Option.globalize (fun x -> x)
 
 let find_first_token_on_line t line =
   match

--- a/lib/Source.ml
+++ b/lib/Source.ml
@@ -27,7 +27,7 @@ let string_at t (l : Location.t) =
   and len = Position.distance l.loc_start l.loc_end in
   String.sub t.text ~pos ~len
 
-let find_token t k pos =
+let find_token t k pos = exclave_
   Array.binary_search t.tokens
     ~compare:(fun (_, elt) pos -> Position.compare elt.Location.loc_start pos)
     k pos

--- a/lib/Translation_unit.ml
+++ b/lib/Translation_unit.ml
@@ -14,9 +14,9 @@
 module Location = Migrate_ast.Location
 open Parse_with_comments
 
-let ( let* ) = Result.( >>= )
+let ( let* ) x f = Result.( >>= ) x f
 
-let ( let+ ) = Result.( >>| )
+let ( let+ ) x f = Result.( >>| ) x f
 
 exception
   Internal_error of

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -629,9 +629,9 @@ type action =
   | Check of input list
   | Print_config of Conf.t
 
-let ( let* ) = Result.( >>= )
+let ( let* ) x f = Result.( >>= ) x f
 
-let ( let+ ) = Result.( >>| )
+let ( let+ ) x f = Result.( >>| ) x f
 
 let make_action ~enable_outside_detected_project ~root action inputs =
   let make_file ?name kind file =

--- a/lib/erase_jane_syntax/dune
+++ b/lib/erase_jane_syntax/dune
@@ -1,3 +1,3 @@
 (library
- (public_name ocamlformat.erase_jane_syntax)
+ (public_name ocamlformat-lib.erase_jane_syntax)
  (name erase_jane_syntax))

--- a/vendor/ocaml-common/location.ml
+++ b/vendor/ocaml-common/location.ml
@@ -216,7 +216,7 @@ let print_updating_num_loc_lines ppf f arg =
   pp_set_formatter_out_functions ppf out_functions
 
 let setup_colors () =
-  Misc.Color.setup !Clflags.color
+  Misc.Style.setup !Clflags.color
 
 (******************************************************************************)
 (* Printing locations, e.g. 'File "foo.ml", line 3, characters 10-12' *)


### PR DESCRIPTION
A grab bag of fixes that allow the [5.2 version of bleeding-edge-with-extensions](https://github.com/janestreet/opam-repository/tree/with-extensions-dev) to build ocamlformat.

* Switch CI to use 5.2 so I can switch to use `Misc.Style` instead of `Misc.Color`. This requires disabling windows CI, whose opam repository doesn't yet have 5.2. (Discussed with @ceastlund .)
* Globalize a value that's stack-allocated under bleeding-edge-with-extensions
* Eta-expand some functions to help the mode inference engine along
* Fix a circular dependency in packages