### PR TITLE
Fix precedence of `stack_` keyword

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -2464,10 +2464,15 @@ end = struct
             ( Pexp_apply _ | Pexp_fun _ | Pexp_function _ | Pexp_lazy _
             | Pexp_new _ | Pexp_tuple _
             | Pexp_construct (_, Some _)
+            | Pexp_cons _ | Pexp_infix _ | Pexp_prefix _ | Pexp_stack _
+            | Pexp_let _ | Pexp_letop _ | Pexp_letopen _ | Pexp_letmodule _
+            | Pexp_send _ | Pexp_setfield _ | Pexp_ifthenelse _
             | Pexp_variant (_, Some _) )
         ; _ } ) ->
         true
-    | Exp {pexp_desc= Pexp_apply _; _}, {pexp_desc= Pexp_stack _; _} -> true
+    | ( Exp {pexp_desc= Pexp_apply _ | Pexp_construct _; _}
+      , {pexp_desc= Pexp_stack _; _} ) ->
+        true
     | ( Str
           { pstr_desc=
               Pstr_value

--- a/test/passing/tests/stack-erased.ml.js-ref
+++ b/test/passing/tests/stack-erased.ml.js-ref
@@ -110,3 +110,30 @@ let x =
          (* 12 *)
          (Foo x)) )
 ;;
+
+(* Constructor precedence *)
+
+let x = Foo (stack_ ((), ()))
+let x = stack_ (() :: [])
+
+(* Tuples *)
+
+let x = stack_ (1, 2)
+let x = stack_ #(1, 2)
+let x = stack_ (~x:1, ~y:2)
+
+(* Expressions rejected by the typechecker *)
+
+let x = stack_ (x + y)
+let x = stack_ (-x)
+let x = stack_ (stack_ (Foo x))
+
+let x =
+  stack_
+    (let y = 1 in
+     Some y)
+;;
+
+let x = stack_ (c#x)
+let x = stack_ (r.x <- x)
+let x = stack_ (if x then y else z)

--- a/test/passing/tests/stack-erased.ml.ref
+++ b/test/passing/tests/stack-erased.ml.ref
@@ -119,3 +119,29 @@ let x =
 let x = Foo ((), ())
 
 let x = () :: []
+
+(* Tuples *)
+
+let x = (1, 2)
+
+let x = #(1, 2)
+
+let x = (~x:1, ~y:2)
+
+(* Expressions rejected by the typechecker *)
+
+let x = x + y
+
+let x = -x
+
+let x = Foo x
+
+let x =
+  let y = 1 in
+  Some y
+
+let x = c#x
+
+let x = r.x <- x
+
+let x = if x then y else z

--- a/test/passing/tests/stack-erased.ml.ref
+++ b/test/passing/tests/stack-erased.ml.ref
@@ -113,3 +113,9 @@ let x =
       (* 12 *)
         Foo
         x ) )
+
+(* Constructor precedence *)
+
+let x = Foo ((), ())
+
+let x = () :: []

--- a/test/passing/tests/stack.ml
+++ b/test/passing/tests/stack.ml
@@ -101,3 +101,31 @@ let x = (* 1 *) stack_ (* 2 *) ((* 3 *) stack_ (* 4 *) ((* 5 *) 1 (* 6 *),
 let x = Foo (stack_ ((), ()))
 
 let x = stack_ (() :: [])
+
+(* Tuples *)
+
+let x = stack_ (1, 2)
+
+let x = stack_ #(1, 2)
+
+let x = stack_ (~x:1, ~y:2)
+
+(* Expressions rejected by the typechecker *)
+
+let x = stack_ (x + y)
+
+let x = stack_ (-x)
+
+let x = stack_ (stack_ (Foo x))
+
+let x = stack_ (let y = 1 in Some y)
+
+let x = stack_ (c # x)
+
+let x = stack_ (r.x <- x)
+
+let x = stack_ (
+  if x
+  then y
+  else z
+)

--- a/test/passing/tests/stack.ml
+++ b/test/passing/tests/stack.ml
@@ -95,3 +95,9 @@ let x = stack_ (stack_ ( 2 , stack_ "hello" ),  ~x:(stack_ (Foo x)))
 
 let x = (* 1 *) stack_ (* 2 *) ((* 3 *) stack_ (* 4 *) ((* 5 *) 1 (* 6 *),
         stack_ (* 7 *) "hello" (* 8 *)) (* 9 *), (* 10 *) ~x:((* 11 *)stack_ (* 12 *) (Foo x)))
+
+(* Constructor precedence *)
+
+let x = Foo (stack_ ((), ()))
+
+let x = stack_ (() :: [])

--- a/test/passing/tests/stack.ml.js-ref
+++ b/test/passing/tests/stack.ml.js-ref
@@ -110,3 +110,30 @@ let x =
          (* 12 *)
          (Foo x)) )
 ;;
+
+(* Constructor precedence *)
+
+let x = Foo (stack_ ((), ()))
+let x = stack_ (() :: [])
+
+(* Tuples *)
+
+let x = stack_ (1, 2)
+let x = stack_ #(1, 2)
+let x = stack_ (~x:1, ~y:2)
+
+(* Expressions rejected by the typechecker *)
+
+let x = stack_ (x + y)
+let x = stack_ (-x)
+let x = stack_ (stack_ (Foo x))
+
+let x =
+  stack_
+    (let y = 1 in
+     Some y)
+;;
+
+let x = stack_ (c#x)
+let x = stack_ (r.x <- x)
+let x = stack_ (if x then y else z)

--- a/test/passing/tests/stack.ml.ref
+++ b/test/passing/tests/stack.ml.ref
@@ -117,3 +117,36 @@ let x =
          (* 11 *)
          (* 12 *)
          (Foo x ) ) )
+
+(* Constructor precedence *)
+
+let x = Foo (stack_ ((), ()))
+
+let x = stack_ (() :: [])
+
+(* Tuples *)
+
+let x = stack_ (1, 2)
+
+let x = stack_ #(1, 2)
+
+let x = stack_ (~x:1, ~y:2)
+
+(* Expressions rejected by the typechecker *)
+
+let x = stack_ (x + y)
+
+let x = stack_ (-x)
+
+let x = stack_ (stack_ (Foo x))
+
+let x =
+  stack_
+    (let y = 1 in
+     Some y )
+
+let x = stack_ (c#x)
+
+let x = stack_ (r.x <- x)
+
+let x = stack_ (if x then y else z)


### PR DESCRIPTION
#85 added support for the `stack_` keyword. Internal adoption has revealed some bugs in the parenthesization behavior. Two examples:

1.
```ocaml
Foo (stack_ ((), ()))
```
becomes
```ocaml
Foo stack_ ((), ())
```
(invalid syntax)

2.
```ocaml
stack_ (() :: [])
```
becomes
```ocaml
stack_ () :: []
```
(parsetree change)

This PR fixes the precedence associated with `Pexp_stack` in the extended AST for these two patterns, as well as for a number of patterns that should be uncommon (because there `stack_` does not enclose an allocation, and so the code is rejected by the typechecker). We should still aim to support these cases, because:
1. We should succeed in formatting any code that parses. If someone writes one of these forbidden patterns, they should get a (ostensibly helpful) error from the typechecker, not a mysterious formatting failure.
2. These patterns could be used in ppx payloads and then transformed to code that actually compiles.

It might be worth testing `ocamlformat`'s treatment of `stack_` more thoroughly in the near future, but I think it makes sense to merge this PR before doing so, since it fixes problems people have actually started to encounter.