### PR TITLE
Fix extension shorthand for type nonrec

### DIFF
--- a/test/passing/tests/extensions-indent.ml.js-ref
+++ b/test/passing/tests/extensions-indent.ml.js-ref
@@ -194,6 +194,9 @@ let%lwt f = function
 ;;
 
 type%any_extension t = < a : 'a >
+[%%any_extension type t = < a : 'a > ]
+type%any_extension nonrec t = < a : 'a >
+[%%any_extension type nonrec t = < a : 'a > ]
 
 let value =
   f

--- a/test/passing/tests/extensions-indent.ml.ref
+++ b/test/passing/tests/extensions-indent.ml.ref
@@ -144,6 +144,12 @@ let%lwt f = function _ -> ()
 
 type%any_extension t = < a: 'a >
 
+[%%any_extension type t = < a: 'a > ]
+
+type%any_extension nonrec t = < a: 'a >
+
+[%%any_extension type nonrec t = < a: 'a > ]
+
 let value = f [%any_extension function 0 -> false | _ -> true]
 
 let value = [%any_extension fun x -> y] x

--- a/test/passing/tests/extensions.ml
+++ b/test/passing/tests/extensions.ml
@@ -130,6 +130,17 @@ let%lwt f = function
 type%any_extension t =
   < a: 'a >
 
+[%%any_extension
+  type t = < a: 'a >
+]
+
+type%any_extension nonrec t =
+  < a: 'a >
+
+[%%any_extension
+  type nonrec t = < a: 'a >
+]
+
 let value =
   f
     [%any_extension

--- a/test/passing/tests/extensions.ml.js-ref
+++ b/test/passing/tests/extensions.ml.js-ref
@@ -194,6 +194,9 @@ let%lwt f = function
 ;;
 
 type%any_extension t = < a : 'a >
+[%%any_extension type t = < a : 'a > ]
+type%any_extension nonrec t = < a : 'a >
+[%%any_extension type nonrec t = < a : 'a > ]
 
 let value =
   f

--- a/test/passing/tests/extensions.ml.ref
+++ b/test/passing/tests/extensions.ml.ref
@@ -144,6 +144,12 @@ let%lwt f = function _ -> ()
 
 type%any_extension t = < a: 'a >
 
+[%%any_extension type t = < a: 'a > ]
+
+type%any_extension nonrec t = < a: 'a >
+
+[%%any_extension type nonrec t = < a: 'a > ]
+
 let value = f [%any_extension function 0 -> false | _ -> true]
 
 let value = [%any_extension fun x -> y] x


### PR DESCRIPTION
When given
```ocaml
type%ext nonrec t = T
```

`ocamlformat` attempts to generate
```ocaml
type nonrec%ext t = T
```

Which is not valid syntax. This PR contains a simple fix.