### PR TITLE
Fix for latest Base.Comparator interface

### DIFF
--- a/lib/Non_overlapping_interval_tree.ml
+++ b/lib/Non_overlapping_interval_tree.ml
@@ -102,7 +102,7 @@ module Make (Itv : IN) = struct
         (list roots "@," (fun root ->
              let children = children tree root in
              vbox 1
-               ( str (Sexp.to_string_hum (Itv.comparator.sexp_of_t root))
+               ( str (Sexp.to_string_hum (Comparator.sexp_of_t Itv.comparator root))
                $ wrap_if
                    (not (List.is_empty children))
                    "@,{" " }" (dump_ tree children) ) ) )


### PR DESCRIPTION
The latest release of base `v0.18~preview.130.31+242` on @janestreet/opam-repository#with-extensions introduced a breaking change (cc @d-kalinichenko)