### PR TITLE
Add support for Tof_kind

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1778,8 +1778,8 @@ end = struct
       | Ptyp_constr (_, _ :: _ :: _) -> Some (Comma, Non)
       | Ptyp_constr _ -> Some (Apply, Non)
       | Ptyp_any | Ptyp_var _ | Ptyp_object _ | Ptyp_class _
-      | Ptyp_variant _ | Ptyp_poly _ | Ptyp_package _ | Ptyp_extension _
-      | Ptyp_of_kind _ ->
+       |Ptyp_variant _ | Ptyp_poly _ | Ptyp_package _ | Ptyp_extension _
+       |Ptyp_of_kind _ ->
           None
       | Ptyp_constr_unboxed (_, _ :: _ :: _) -> Some (Comma, Non)
       | Ptyp_constr_unboxed _ -> Some (Apply, Non) )

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -1054,6 +1054,7 @@ end = struct
               | {pof_desc= Otag (_, t1); _} -> typ == t1
               | {pof_desc= Oinherit t1; _} -> typ == t1 ) )
       | Ptyp_class (_, l) -> assert (List.exists l ~f)
+      | Ptyp_of_kind _ -> assert false
       | Ptyp_constr_unboxed (_, t1N) -> assert (List.exists t1N ~f) )
     | Td {ptype_params; ptype_cstrs; ptype_kind; ptype_manifest; _} ->
         assert (
@@ -1777,7 +1778,8 @@ end = struct
       | Ptyp_constr (_, _ :: _ :: _) -> Some (Comma, Non)
       | Ptyp_constr _ -> Some (Apply, Non)
       | Ptyp_any | Ptyp_var _ | Ptyp_object _ | Ptyp_class _
-       |Ptyp_variant _ | Ptyp_poly _ | Ptyp_package _ | Ptyp_extension _ ->
+      | Ptyp_variant _ | Ptyp_poly _ | Ptyp_package _ | Ptyp_extension _
+      | Ptyp_of_kind _ ->
           None
       | Ptyp_constr_unboxed (_, _ :: _ :: _) -> Some (Comma, Non)
       | Ptyp_constr_unboxed _ -> Some (Apply, Non) )
@@ -1914,7 +1916,7 @@ end = struct
       | Ptyp_any | Ptyp_var _ | Ptyp_constr _ | Ptyp_object _
        |Ptyp_class _ | Ptyp_variant _ | Ptyp_poly _ | Ptyp_extension _ ->
           None
-      | Ptyp_constr_unboxed _ -> None )
+      | Ptyp_constr_unboxed _ | Ptyp_of_kind _ -> None )
     | Td _ -> None
     | Tyv _ -> None
     | Kab _ -> None

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1237,9 +1237,11 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
            (sub_typ ~ctx >> fmt_core_type c) )
       $ fmt "@ " $ fmt_longident_loc c lid $ char '#'
   | Ptyp_of_kind jk ->
-    wrap_fits_breaks c.conf "(" ")"
-      (hvbox 0 (
-         fmt "type" $ fmt_jkind_constr ~ctx:(Typ typ) c { txt = jk; loc = typ.ptyp_loc }))
+      wrap_fits_breaks c.conf "(" ")"
+        (hvbox 0
+           ( fmt "type"
+           $ fmt_jkind_constr ~ctx:(Typ typ) c {txt= jk; loc= typ.ptyp_loc}
+           ) )
 
 and fmt_labeled_tuple_type c lbl xtyp =
   match lbl with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1236,6 +1236,10 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
         (list t1N (Params.comma_sep c.conf)
            (sub_typ ~ctx >> fmt_core_type c) )
       $ fmt "@ " $ fmt_longident_loc c lid $ char '#'
+  | Ptyp_of_kind jk ->
+    wrap_fits_breaks c.conf "(" ")"
+      (hvbox 0 (
+         fmt "type" $ fmt_jkind_constr ~ctx:(Typ typ) c { txt = jk; loc = typ.ptyp_loc }))
 
 and fmt_labeled_tuple_type c lbl xtyp =
   match lbl with

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -9830,6 +9830,42 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to of_kind.ml.stdout
+   (with-stderr-to of_kind.ml.stderr
+     (run %{bin:ocamlformat} --margin-check %{dep:tests/of_kind.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/of_kind.ml of_kind.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/of_kind.ml.err of_kind.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to of_kind.ml.js-stdout
+   (with-stderr-to of_kind.ml.js-stderr
+     (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/of_kind.ml})))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/of_kind.ml.js-ref of_kind.ml.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/of_kind.ml.js-err of_kind.ml.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to open-closing-on-separate-line.ml.stdout
    (with-stderr-to open-closing-on-separate-line.ml.stderr
      (run %{bin:ocamlformat} --margin-check --indicate-multiline-delimiters=closing-on-separate-line %{dep:tests/open.ml})))))

--- a/test/passing/tests/of_kind.ml
+++ b/test/passing/tests/of_kind.ml
@@ -1,0 +1,59 @@
+type t : immutable_data with (type : value mod portable) u
+
+type t = (type : value mod portable)
+
+type u =
+  ( type :
+    value
+    mod portable
+    with t
+    with u
+    with ( type :
+           value
+           mod contended many
+           with ('a :
+                value mod portable with (type : (bits8 & bits8) mod external_)
+                )
+                u )
+         v )
+  y
+
+(* Comment attachment *)
+
+type u =
+  ( type :
+    (* comment *)
+    value
+    (* a *)
+    mod (* b *) portable
+    with (* c d *) t
+    with u
+    with ( type :
+           (* f f *)
+           value
+           mod contended many
+           with ('a :
+                value mod portable with (type : (bits8 & bits8) mod external_)
+                )
+                u )
+         v )
+  y
+
+(* Attributes *)
+
+type u =
+  ( type :
+    value
+    mod portable
+    with t
+    with (u[@foo])
+    with ( type :
+           (* f f *)
+           value
+           mod contended many
+           with ('a :
+                value mod portable with (type : (bits8 & bits8) mod external_)
+                )
+                u )
+         v )
+  y

--- a/test/passing/tests/of_kind.ml
+++ b/test/passing/tests/of_kind.ml
@@ -18,6 +18,30 @@ type u =
          v )
   y
 
+let f (x : (type : value mod portable) @ contended) :
+    [`A of (type : value mod unyielding with 'a @@ contended) | `Z] =
+  ()
+
+type t = T : u t -> (type : value mod stateless)
+
+let x :
+    foo:(type : value mod contended stateless)
+    * bar:( type :
+            (bits8 & bits8 & bits8)
+            mod stateless unyielding
+            with 'a @@ portable ) =
+  y
+
+module type X =
+  Y
+    with type a =
+      ( type :
+        (b & c & d & e) mod adsf asd asd asdf fasd with asdf @@ falskdf fo )
+
+let a (a : (type : a with (type : a) a with (type : a with a) a * (type : a)))
+    : (type : (a & a & a) mod a with a) @ a =
+  a ~a:(a :> (type : a))
+
 (* Comment attachment *)
 
 type u =

--- a/test/passing/tests/of_kind.ml
+++ b/test/passing/tests/of_kind.ml
@@ -42,18 +42,22 @@ type u =
 (* Attributes *)
 
 type u =
-  ( type :
-    value
-    mod portable
-    with t
-    with (u[@foo])
-    with ( type :
-           (* f f *)
-           value
-           mod contended many
-           with ('a :
-                value mod portable with (type : (bits8 & bits8) mod external_)
-                )
-                u )
-         v )
-  y
+  (( type :
+     value
+     mod portable
+     with t
+     with (u[@foo])
+     with (( type :
+             (* f f *)
+             value
+             mod contended many
+             with (('a :
+                   value
+                   mod portable
+                   with (type : (bits8 & bits8) mod external_) )
+                   u
+                  [@bar] ) )
+           v
+          [@baz] ) )
+   y
+  [@fnord] )

--- a/test/passing/tests/of_kind.ml.err
+++ b/test/passing/tests/of_kind.ml.err
@@ -1,3 +1,2 @@
 Warning: tests/of_kind.ml:14 exceeds the margin
 Warning: tests/of_kind.ml:35 exceeds the margin
-Warning: tests/of_kind.ml:54 exceeds the margin

--- a/test/passing/tests/of_kind.ml.err
+++ b/test/passing/tests/of_kind.ml.err
@@ -1,0 +1,3 @@
+Warning: tests/of_kind.ml:14 exceeds the margin
+Warning: tests/of_kind.ml:35 exceeds the margin
+Warning: tests/of_kind.ml:54 exceeds the margin

--- a/test/passing/tests/of_kind.ml.err
+++ b/test/passing/tests/of_kind.ml.err
@@ -1,2 +1,3 @@
 Warning: tests/of_kind.ml:14 exceeds the margin
-Warning: tests/of_kind.ml:35 exceeds the margin
+Warning: tests/of_kind.ml:40 exceeds the margin
+Warning: tests/of_kind.ml:59 exceeds the margin

--- a/test/passing/tests/of_kind.ml.js-ref
+++ b/test/passing/tests/of_kind.ml.js-ref
@@ -1,0 +1,49 @@
+type t : immutable_data with (type : value mod portable) u
+type t = (type : value mod portable)
+
+type u =
+  ( type :
+    value
+    mod portable
+    with t
+    with u
+    with ( type :
+           value
+           mod contended many
+           with ('a : value mod portable with (type : (bits8 & bits8) mod external_)) u )
+           v )
+    y
+
+(* Comment attachment *)
+
+type u =
+  ( type :
+    (* comment *)
+    value
+    (* a *)
+    mod (* b *) portable
+    with (* c d *) t
+    with u
+    with ( type :
+           (* f f *)
+           value
+           mod contended many
+           with ('a : value mod portable with (type : (bits8 & bits8) mod external_)) u )
+           v )
+    y
+
+(* Attributes *)
+
+type u =
+  ( type :
+    value
+    mod portable
+    with t
+    with (u[@foo])
+    with ( type :
+           (* f f *)
+           value
+           mod contended many
+           with ('a : value mod portable with (type : (bits8 & bits8) mod external_)) u )
+           v )
+    y

--- a/test/passing/tests/of_kind.ml.js-ref
+++ b/test/passing/tests/of_kind.ml.js-ref
@@ -14,6 +14,31 @@ type u =
            v )
     y
 
+let f (x : (type : value mod portable) @ contended)
+  : [ `A of (type : value mod unyielding with 'a @@ contended) | `Z ]
+  =
+  ()
+;;
+
+type t = T : u t -> (type : value mod stateless)
+
+let x
+  : foo:(type : value mod contended stateless)
+    * bar:(type : (bits8 & bits8 & bits8) mod stateless unyielding with 'a @@ portable)
+  =
+  y
+;;
+
+module type X =
+  Y
+  with type a = (type : (b & c & d & e) mod adsf asd asd asdf fasd with asdf @@ falskdf fo)
+
+let a (a : (type : a with (type : a) a with (type : a with a) a * (type : a)))
+  : (type : (a & a & a) mod a with a) @ a
+  =
+  a ~a:(a :> (type : a))
+;;
+
 (* Comment attachment *)
 
 type u =

--- a/test/passing/tests/of_kind.ml.js-ref
+++ b/test/passing/tests/of_kind.ml.js-ref
@@ -35,15 +35,18 @@ type u =
 (* Attributes *)
 
 type u =
-  ( type :
-    value
-    mod portable
-    with t
-    with (u[@foo])
-    with ( type :
-           (* f f *)
-           value
-           mod contended many
-           with ('a : value mod portable with (type : (bits8 & bits8) mod external_)) u )
-           v )
-    y
+  (( type :
+     value
+     mod portable
+     with t
+     with (u[@foo])
+     with (( type :
+             (* f f *)
+             value
+             mod contended many
+             with (('a : value mod portable with (type : (bits8 & bits8) mod external_)) u
+                  [@bar]) )
+             v
+          [@baz]) )
+     y
+  [@fnord])

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -82,6 +82,7 @@ module Typ = struct
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ptyp_extension a)
 
   (* Jane Street extension *)
+  let of_kind ?loc ?attrs a = mk ?loc ?attrs (Ptyp_of_kind a)
   let constr_unboxed ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_constr_unboxed (a, b))
   (* End Jane Street extension *)
 end

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -235,6 +235,8 @@ module T = struct
     | Ptyp_extension x -> extension ~loc ~attrs (sub.extension sub x)
 
     (* Jane Street extension *)
+    | Ptyp_of_kind jkind ->
+        of_kind ~loc ~attrs (sub.jkind_annotation sub jkind)
     | Ptyp_constr_unboxed (lid, tl) ->
         constr_unboxed ~loc ~attrs (map_loc sub lid) (List.map (sub.typ sub) tl)
     (* End Jane Street extension *)

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -4591,6 +4591,10 @@ atomic_type:
       { Ptyp_var (name, jkind) }
     | LPAREN mkrhs(UNDERSCORE {None}) COLON jkind=jkind_annotation RPAREN
       { Ptyp_var ($2, jkind) }
+    | LPAREN TYPE COLON jkind=jkind RPAREN
+      { if Erase_jane_syntax.should_erase ()
+        then Ptyp_any
+        else Ptyp_of_kind jkind }
 
   )
   { $1 } /* end mktyp group */

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -4592,9 +4592,7 @@ atomic_type:
     | LPAREN mkrhs(UNDERSCORE {None}) COLON jkind=jkind_annotation RPAREN
       { Ptyp_var ($2, jkind) }
     | LPAREN TYPE COLON jkind=jkind RPAREN
-      { if Erase_jane_syntax.should_erase ()
-        then Ptyp_any
-        else Ptyp_of_kind jkind }
+      { Ptyp_of_kind jkind }
 
   )
   { $1 } /* end mktyp group */

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -223,6 +223,7 @@ and core_type_desc =
   | Ptyp_extension of extension  (** [[%id]]. *)
 
   (* Jane Street extension *)
+  | Ptyp_of_kind of jkind_annotation (** [(type : k)] *)
   | Ptyp_constr_unboxed of Longident.t loc * core_type list
   (* End Jane Street extension *)
 

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -273,6 +273,8 @@ let rec core_type i ppf x =
   | Ptyp_package pt ->
       line i ppf "Ptyp_package\n";
       package_type i ppf pt
+  | Ptyp_of_kind jkind ->
+      line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i + 1)) jkind
   | Ptyp_extension (s, arg) ->
       line i ppf "Ptyp_extension %a\n" fmt_string_loc s;
       payload i ppf arg

--- a/vendor/parser-standard/ast_helper.ml
+++ b/vendor/parser-standard/ast_helper.ml
@@ -74,6 +74,7 @@ module Typ = struct
   let package ?loc ?attrs a b = mk ?loc ?attrs (Ptyp_package (a, b))
   let extension ?loc ?attrs a = mk ?loc ?attrs (Ptyp_extension a)
   let open_ ?loc ?attrs mod_ident t = mk ?loc ?attrs (Ptyp_open (mod_ident, t))
+  let of_kind ?loc ?attrs a = mk ?loc ?attrs (Ptyp_of_kind a)
 
   let force_poly t =
     match t.ptyp_desc with
@@ -132,6 +133,8 @@ module Typ = struct
             Ptyp_package(longident,List.map (fun (n,typ) -> (n,loop typ) ) lst)
         | Ptyp_open (mod_ident, core_type) ->
             Ptyp_open (mod_ident, loop core_type)
+        | Ptyp_of_kind jkind ->
+            Ptyp_of_kind (loop_jkind jkind)
         | Ptyp_extension (s, arg) ->
             Ptyp_extension (s, arg)
       in

--- a/vendor/parser-standard/ast_mapper.ml
+++ b/vendor/parser-standard/ast_mapper.ml
@@ -193,6 +193,8 @@ module T = struct
           (List.map (map_tuple (map_loc sub) (sub.typ sub)) l)
     | Ptyp_open (mod_ident, t) ->
         open_ ~loc ~attrs (map_loc sub mod_ident) (sub.typ sub t)
+    | Ptyp_of_kind jkind ->
+        of_kind ~loc ~attrs (sub.jkind_annotation sub jkind)
     | Ptyp_extension x -> extension ~loc ~attrs (sub.extension sub x)
 
   let map_type_declaration sub

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -4759,6 +4759,8 @@ atomic_type:
       { mktyp ~loc:$sloc (Ptyp_var (name, Some jkind)) }
   | LPAREN UNDERSCORE COLON jkind=jkind_annotation RPAREN
       { mktyp ~loc:$sloc (Ptyp_any (Some jkind)) }
+  | LPAREN TYPE COLON jkind=jkind_annotation RPAREN
+      { mktyp ~loc:$loc (Ptyp_of_kind jkind) }
 
 
 (* This is the syntax of the actual type parameters in an application of

--- a/vendor/parser-standard/parsetree.mli
+++ b/vendor/parser-standard/parsetree.mli
@@ -202,6 +202,7 @@ and core_type_desc =
          *)
   | Ptyp_package of package_type  (** [(module S)]. *)
   | Ptyp_open of Longident.t loc * core_type (** [M.(T)] *)
+  | Ptyp_of_kind of jkind_annotation (** [(type : k)] *)
   | Ptyp_extension of extension  (** [[%id]]. *)
 
 and arg_label = Asttypes.arg_label =

--- a/vendor/parser-standard/printast.ml
+++ b/vendor/parser-standard/printast.ml
@@ -220,6 +220,8 @@ let rec core_type i ppf x =
   | Ptyp_open (mod_ident, t) ->
       line i ppf "Ptyp_open \"%a\"\n" fmt_longident_loc mod_ident;
       core_type i ppf t
+  | Ptyp_of_kind jkind ->
+    line i ppf "Ptyp_of_kind %a\n" (jkind_annotation (i + 1)) jkind
   | Ptyp_extension (s, arg) ->
       line i ppf "Ptyp_extension \"%s\"\n" s.txt;
       payload i ppf arg


### PR DESCRIPTION
This is a new core_type_desc, used for referring to the kinds of existential types in with-bounds for GADTs.