### PR TITLE
Fix quadratic command-line parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ profile. This started with version 0.26.0.
 - Fixed bug with attributes on sub-expressions of infix operators (#2459, @tdelvecchio-jsc)
 - \* Fix cinaps comment formatting to not change multiline string contents (#2463, @tdelvecchio-jsc)
 - Fix position of comments around function parameters (#2471, @gpetiot)
+- Fix commandline parsing being quadratic in the number of arguments
+  (#2724, @let-def)
 
 ## 0.26.1 (2023-09-15)
 
@@ -1553,3 +1555,4 @@ profile. This started with version 0.26.0.
 ## 0.1 (2017-10-19)
 
 - Initial release.
+

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -539,7 +539,7 @@ let global_lib_term =
         new_global.lib_conf )
     $ global_term )
 
-let update_using_cmdline info config =
+let update_using_cmdline config =
   match
     Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
       (Cmd.v info global_lib_term)
@@ -563,7 +563,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
       read_config_file ~version_check:false ~disable_conf_attrs:false
     in
     List.fold fs.configuration_files ~init:Conf.default ~f:read_config_file
-    |> update_using_env |> update_using_cmdline info
+    |> update_using_env |> update_using_cmdline
   in
   let conf =
     let opr_opts =
@@ -575,7 +575,7 @@ let build_config ~enable_outside_detected_project ~root ~file ~is_stdin =
   in
   let conf =
     List.fold fs.configuration_files ~init:conf ~f:read_config_file
-    |> update_using_env |> update_using_cmdline info
+    |> update_using_env |> update_using_cmdline
   in
   if
     (not is_stdin)

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -539,10 +539,10 @@ let global_lib_term =
         new_global.lib_conf )
     $ global_term )
 
-let global_lib_term_eval = lazy (
-  Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
-    (Cmd.v info global_lib_term)
-)
+let global_lib_term_eval =
+  lazy
+    (Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
+       (Cmd.v info global_lib_term) )
 
 let update_using_cmdline config =
   match Lazy.force global_lib_term_eval with

--- a/lib/bin_conf/Bin_conf.ml
+++ b/lib/bin_conf/Bin_conf.ml
@@ -539,11 +539,13 @@ let global_lib_term =
         new_global.lib_conf )
     $ global_term )
 
+let global_lib_term_eval = lazy (
+  Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
+    (Cmd.v info global_lib_term)
+)
+
 let update_using_cmdline config =
-  match
-    Cmd.eval_value ~err:discard_formatter ~help:discard_formatter
-      (Cmd.v info global_lib_term)
-  with
+  match Lazy.force global_lib_term_eval with
   | Ok (`Ok conf_modif) -> conf_modif config
   | Error _ | Ok (`Version | `Help) -> config
 


### PR DESCRIPTION
This PR has also been opened on upstream ocamlformat: https://github.com/ocaml-ppx/ocamlformat/pull/2724
I rebased it to oxcaml in priority to pave the way for efficient automated testing (@ccasin).

---

Command‑line parsing occurs in two passes: one pass parses the actions, and a second pass parses the configuration.
Because the configuration parser is invoked for every input file, the overall parsing time grows quadratically with the number of files.

This patch memoizes the configuration so that the parser runs only once. The configuration changes are still applied to each input file, preserving the original ocamlformat behaviour while making the runtime independent of the number of inputs.

Below are two plots that illustrate the performance before and after the change. They show the time spent and the number of stat calls as functions of the number of input files, clearly demonstrating the quadratic behaviour that the patch removes.

![stat](https://github.com/user-attachments/assets/b2ddfea4-7459-44a4-a082-ec2678880960)
![time](https://github.com/user-attachments/assets/51c0c64c-0373-4d25-a0af-f1570abde192)
