### PR TITLE
Fix set-up documentation and CLI tests for new CI packages

### DIFF
--- a/HACKING.jst.md
+++ b/HACKING.jst.md
@@ -80,10 +80,12 @@ time.
 Before building
 ---------------
 
-You will need to install several libraries. This command may work:
+You will need to create a switch on ocaml5.2.1 and install several
+libraries. These commands may work:
 
 ```
-opam install menhir.20210419 fix ocp-indent bechamel-js alcotest camlp-streams fpath either dune-build-info uuseg ocaml-version stdio
+opam switch create ocamlformat 5.2.1
+opam install menhir.20210419 fix ocp-indent bechamel-js alcotest camlp-streams fpath either dune-build-info uuseg ocaml-version stdio cmdliner.2.0.0
 ```
 
 Building

--- a/test/cli/conf.t
+++ b/test/cli/conf.t
@@ -1,3 +1,7 @@
+Make CI & local builds behave the same
+
+  $ export TERM=dumb
+
 Invalid version:
 
   $ echo 'version = bad' > .ocamlformat

--- a/test/cli/env.t
+++ b/test/cli/env.t
@@ -1,3 +1,7 @@
+Make CI & local builds behave the same
+
+  $ export TERM=dumb
+
 Invalid option:
 
   $ echo 'let x = 1' | OCAMLFORMAT="unknown=true" ocamlformat --impl -

--- a/test/cli/removed_option.t
+++ b/test/cli/removed_option.t
@@ -1,3 +1,7 @@
+Make CI & local builds behave the same
+
+  $ export TERM=dumb
+
   $ echo 'let x = y' > a.ml
 
 Setting a removed option on the command line should display an error message:


### PR DESCRIPTION
As per title. Local builds that follow the set-up instructions should now agree with GitHub CI.