### PR TITLE
Eol_compat: fix crash triggered by ocamlgrammarfuzzer

### DIFF
--- a/lib/Eol_compat.ml
+++ b/lib/Eol_compat.ml
@@ -34,8 +34,10 @@ let normalize_eol ?(exclude_locs = []) ~line_endings s =
         normalize_segment ~seen_cr:0 i (String.length s) ;
         Buffer.contents buf
     | (start, stop) :: xs ->
-        normalize_segment ~seen_cr:0 i start ;
-        Buffer.add_substring buf s ~pos:start ~len:(stop - start) ;
-        loop xs stop
+        if i < stop then (
+          if i < start then normalize_segment ~seen_cr:0 i start ;
+          Buffer.add_substring buf s ~pos:start ~len:(stop - start) ;
+          loop xs stop )
+        else loop xs i
   in
   loop exclude_locs 0


### PR DESCRIPTION
`Eol_compat` assumes that the excluded locations are non‑overlapping and strictly increasing.  This assumption does not hold in all cases, as illustrated by the following sentence:

```ocaml
object method ! x1 : type x2 . x3 * {%ext|s|} = X4 end
```

The proposed change does not introduce a regression: it only triggers for situations that were not previously covered.  However, I do not fully understand `Eol_compat`, so I cannot guarantee that it behaves as intended on sentences that were failing before.

This fix is a prerequisite for integrating the fuzzer, because the current issue makes `ocamlformat` crash and prevents further analysis.  (Exceptions are usually caught by the `ocamlformat` driver and turned into an error message, not this one.)