### PR TITLE
Add syntax for mode constraint without type

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -2748,7 +2748,16 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
           (parens || not (List.is_empty pexp_attributes))
           c.conf
           (str (if b then "#true" else "#false") $ fmt_atrs)
-  | Pexp_constraint (_, None, _) -> assert false
+  | Pexp_constraint (e, None, modes) ->
+      pro
+      $ hvbox
+          (Params.Indent.exp_constraint c.conf)
+          (Params.parens_if (parens && has_attr) c.conf
+             ( wrap_fits_breaks ~space:false c.conf "(" ")"
+                 ( fmt_expression c (sub_exp ~ctx e)
+                 $ fmt "@ :"
+                 $ fmt_modals c (Modes modes) )
+             $ fmt_atrs ) )
   | Pexp_constraint (e, Some t, modes) ->
       pro
       $ hvbox

--- a/test/passing/tests/modes-erased.ml.ref
+++ b/test/passing/tests/modes-erased.ml.ref
@@ -62,6 +62,15 @@ module Expressions = struct
 
   let x = (expr : typ1 * typ2)
 
+  (* mode-only constraints without a type *)
+  let x = expr
+
+  let x = expr
+
+  let x = f expr
+
+  let x = expr.field
+
   (* mode constraints in expressions *)
   let x =
     { let1=
@@ -206,6 +215,134 @@ module Expressions = struct
     ; cons1= (x :: y :: z : _)
     ; prefix1= (!x : _)
     ; infix1= (x + y : _) }
+
+  (* mode-only constraints in expressions *)
+  let x =
+    { let1=
+        (let x = x and y = y in
+         z )
+    ; function1= (function x -> x | y -> y)
+    ; fun1= (fun ?(x = x) () -> y)
+    ; fun2= (fun ?(x = x) () -> y)
+    ; fun3= (fun ?(x = x) () -> y)
+    ; apply1= x y
+    ; apply2= f ~lbl:x
+    ; apply3= f ~x
+    ; apply4= f ?lbl:x
+    ; apply5= f ?x
+    ; match1= (match x with y -> y | z -> z)
+    ; try1= (try x with y -> y)
+    ; tuple1= (x, y)
+    ; tuple2= (~x, ~y:z)
+    ; construct1= A x
+    ; construct2= A (x, y)
+    ; variant1= `A x
+    ; variant2= `A (x, y)
+    ; field1= x.x
+    ; setfield1= x.x <- y
+    ; array1= [|x; y|]
+    ; array2= [:x; y:]
+    ; list1= [x; y]
+    ; ite1= (if x then y else z)
+    ; sequence1= (x ; y)
+    ; while1=
+        while x do
+          y
+        done
+    ; for1=
+        for i = x to y do
+          z
+        done
+    ; constraint1= x
+    ; constraint2= (x : _)
+    ; constraint3= (x : _)
+    ; coerce1= (x :> _)
+    ; send1= x#y
+    ; setinstvar1= x <- x
+    ; override1= {<x; y>}
+    ; letmodule1=
+        (let module M = ME in
+        x )
+    ; letexception1=
+        (let exception E in
+        x )
+    ; assert1= assert x
+    ; lazy1= lazy x
+    ; newtype1= (fun (type t) -> x)
+    ; open1= M.(x)
+    ; letopen1=
+        (let open M in
+         x )
+    ; letop1=
+        (let* x = x in
+         y )
+    ; extension1= [%ext x]
+    ; cons1= x :: y :: z
+    ; prefix1= !x
+    ; infix1= x + y }
+
+  (* expressions in mode-only constraints *)
+  let x =
+    { ident1= x
+    ; constant1= ""
+    ; let1=
+        (let x = y in
+         z )
+    ; function1= (function x -> x | y -> y)
+    ; fun1= (fun x -> y)
+    ; fun2= (fun x -> y)
+    ; fun3= (fun x -> y)
+    ; apply1= f x
+    ; match1= (match x with y -> y | z -> z)
+    ; try1= (try x with y -> y | z -> z)
+    ; tuple1= (x, y)
+    ; tuple2= (~x, ~y)
+    ; construct1= A
+    ; construct2= A x
+    ; construct3= A (x, y)
+    ; construct4= A {x}
+    ; variant1= `A
+    ; variant2= `A x
+    ; record1= {x}
+    ; field1= x.y
+    ; setfield1= x.y <- z
+    ; array1= [|x|]
+    ; array2= [:x:]
+    ; list1= [x]
+    ; ite1= (if x then y else z)
+    ; sequence1= (x ; y)
+    ; constraint1= x
+    ; constraint2= (x : _)
+    ; constraint3= (x : _)
+    ; coerce1= (x :> _)
+    ; send1= x#y
+    ; new1= new x
+    ; setinstvar1= x <- 2
+    ; override1= {<y = z>}
+    ; letmodule1=
+        (let module M = ME in
+        x )
+    ; letexception1=
+        (let exception E in
+        x )
+    ; assert1= assert x
+    ; lazy1= lazy x
+    ; object1= object end
+    ; newtype1= (fun (type t) -> x)
+    ; pack1= (module M)
+    ; pack2= (module M : S)
+    ; open1= M.(x y)
+    ; letopen1=
+        (let open M in
+         x )
+    ; letop1=
+        (let* x = y in
+         z )
+    ; extension1= [%ext]
+    ; hole1= _
+    ; cons1= x :: y :: z
+    ; prefix1= !x
+    ; infix1= x + y }
 end
 
 module Arrow_params = struct

--- a/test/passing/tests/modes-ocaml_version.ml.ref
+++ b/test/passing/tests/modes-ocaml_version.ml.ref
@@ -62,6 +62,15 @@ module Expressions = struct
 
   let x = (expr : (typ1 * typ2) @ mode1 mode2)
 
+  (* mode-only constraints without a type *)
+  let x = (expr : @ mode1)
+
+  let x = (expr : @ mode1 mode2)
+
+  let x = f (expr : @ mode1)
+
+  let x = (expr : @ mode1).field
+
   (* mode constraints in expressions *)
   let x =
     { let1=
@@ -214,6 +223,147 @@ module Expressions = struct
     ; cons1= (x :: y :: z : _ @ mode)
     ; prefix1= (!x : _ @ mode)
     ; infix1= (x + y : _ @ mode) }
+
+  (* mode-only constraints in expressions *)
+  let x =
+    { let1=
+        (let x = (x : @ mode) and y = (y : @ mode) in
+         (z : @ mode) )
+    ; function1= (function x -> (x : @ mode) | y -> (y : @ mode))
+    ; fun1= (fun ?(x = (x : @ mode)) () @ mode -> (y : @ mode))
+    ; fun2= (fun ?(x = (x : @ mode)) () @ mode1 -> (y : @ mode2))
+    ; fun3= (fun ?(x = (x : @ mode)) () @ mode -> y)
+    ; apply1= (x : @ mode) (y : @ mode)
+    ; apply2= f ~lbl:(x : @ mode)
+    ; apply3= f ~x:(x : @ mode)
+    ; apply4= f ?lbl:(x : @ mode)
+    ; apply5= f ?x:(x : @ mode)
+    ; match1=
+        (match (x : @ mode) with y -> (y : @ mode) | z -> (z : @ mode))
+    ; try1= (try (x : @ mode) with y -> (y : @ mode))
+    ; tuple1= ((x : @ mode), (y : @ mode))
+    ; tuple2= (~x:(x : @ mode), ~y:(z : @ mode))
+    ; construct1= A (x : @ mode)
+    ; construct2= A ((x : @ mode), (y : @ mode))
+    ; variant1= `A (x : @ mode)
+    ; variant2= `A ((x : @ mode), (y : @ mode))
+    ; field1= (x : @ mode).x
+    ; setfield1= (x : @ mode).x <- (y : @ mode)
+    ; array1= [|(x : @ mode); (y : @ mode)|]
+    ; array2= [:(x : @ mode); (y : @ mode):]
+    ; list1= [(x : @ mode); (y : @ mode)]
+    ; ite1= (if (x : @ mode) then (y : @ mode) else (z : @ mode))
+    ; sequence1=
+        ( (x : @ mode) ;
+          (y : @ mode) )
+    ; while1=
+        while (x : @ mode) do
+          (y : @ mode)
+        done
+    ; for1=
+        for i = (x : @ mode) to (y : @ mode) do
+          (z : @ mode)
+        done
+    ; constraint1= ((x : @ mode) : @ mode)
+    ; constraint2= ((x : @ mode) : _ @ mode)
+    ; constraint3= ((x : _ @ mode) : @ mode)
+    ; coerce1= ((x : @ mode) :> _)
+    ; send1= (x : @ mode)#y
+    ; setinstvar1= x <- (x : @ mode)
+    ; override1= {<x = (x : @ mode); y = (y : @ mode)>}
+    ; letmodule1=
+        (let module M = ME in
+        (x : @ mode) )
+    ; letexception1=
+        (let exception E in
+        (x : @ mode) )
+    ; assert1= assert (x : @ mode)
+    ; lazy1= lazy (x : @ mode)
+    ; newtype1= (fun (type t) @ mode -> (x : @ mode))
+    ; open1= M.((x : @ mode))
+    ; letopen1=
+        (let open M in
+         (x : @ mode) )
+    ; letop1=
+        (let* x = (x : @ mode) in
+         (y : @ mode) )
+    ; extension1= [%ext (x : @ mode)]
+    ; cons1= (x : @ mode) :: (y : @ mode) :: (z : @ mode)
+    ; prefix1= !(x : @ mode)
+    ; infix1= (x : @ mode) + (y : @ mode) }
+
+  (* expressions in mode-only constraints *)
+  let x =
+    { ident1= (x : @ mode)
+    ; constant1= ("" : @ mode)
+    ; let1=
+        ( let x = y in
+          z
+          :
+          @ mode )
+    ; function1= (function x -> x | y -> y : @ mode)
+    ; fun1= (fun x @ mode -> y : @ mode)
+    ; fun2= (fun x @ mode1 -> y : @ mode2)
+    ; fun3= (fun x -> y : @ mode)
+    ; apply1= (f x : @ mode)
+    ; match1= (match x with y -> y | z -> z : @ mode)
+    ; try1= (try x with y -> y | z -> z : @ mode)
+    ; tuple1= ((x, y) : @ mode)
+    ; tuple2= ((~x, ~y) : @ mode)
+    ; construct1= (A : @ mode)
+    ; construct2= (A x : @ mode)
+    ; construct3= (A (x, y) : @ mode)
+    ; construct4= (A {x} : @ mode)
+    ; variant1= (`A : @ mode)
+    ; variant2= (`A x : @ mode)
+    ; record1= ({x} : @ mode)
+    ; field1= (x.y : @ mode)
+    ; setfield1= (x.y <- z : @ mode)
+    ; array1= ([|x|] : @ mode)
+    ; array2= ([:x:] : @ mode)
+    ; list1= ([x] : @ mode)
+    ; ite1= (if x then y else z : @ mode)
+    ; sequence1= (x ; y : @ mode)
+    ; constraint1= ((x : @ mode) : @ mode)
+    ; constraint2= ((x : _ @ mode) : @ mode)
+    ; constraint3= ((x : @ mode) : _ @ mode)
+    ; coerce1= ((x :> _) : @ mode)
+    ; send1= (x#y : @ mode)
+    ; new1= (new x : @ mode)
+    ; setinstvar1= (x <- 2 : @ mode)
+    ; override1= ({<y = z>} : @ mode)
+    ; letmodule1=
+        ( let module M = ME in
+          x
+          :
+          @ mode )
+    ; letexception1=
+        ( let exception E in
+          x
+          :
+          @ mode )
+    ; assert1= (assert x : @ mode)
+    ; lazy1= (lazy x : @ mode)
+    ; object1= (object end : @ mode)
+    ; newtype1= (fun (type t) @ mode -> x : @ mode)
+    ; pack1= ((module M) : @ mode)
+    ; pack2= ((module M : S) : @ mode)
+    ; open1= (M.(x y) : @ mode)
+    ; letopen1=
+        ( let open M in
+          x
+          :
+          @ mode )
+    ; letop1=
+        ( let* x = y in
+          z
+          :
+          @ mode )
+    ; extension1= ([%ext] : @ mode)
+    ; hole1= (_ : @ mode)
+    ; cons1= (x :: y :: z : @ mode)
+    ; prefix1= (!x : @ mode)
+    ; infix1= (x + y : @ mode) }
 end
 
 module Arrow_params = struct

--- a/test/passing/tests/modes.ml
+++ b/test/passing/tests/modes.ml
@@ -53,6 +53,12 @@ module Expressions = struct
   let x = (expr : (typ1 -> typ2) @ mode1 mode2)
   let x = (expr : typ1 * typ2 @ mode1 mode2)
 
+  (* mode-only constraints without a type *)
+  let x = (expr : @ mode1)
+  let x = (expr : @ mode1 mode2)
+  let x = f (expr : @ mode1)
+  let x = (expr : @ mode1).field
+
   (* mode constraints in expressions *)
   let x =
     { let1 =
@@ -232,6 +238,169 @@ module Expressions = struct
     ; cons1 = (x :: y :: z : _ @ mode)
     ; prefix1 = (!x : _ @ mode)
     ; infix1 = (x + y : _ @ mode)
+    }
+  ;;
+
+  (* mode-only constraints in expressions *)
+  let x =
+    { let1 =
+        (let x = (x : @ mode)
+         and y = (y : @ mode) in
+         (z : @ mode))
+    ; function1 =
+        (function
+          | x -> (x : @ mode)
+          | y -> (y : @ mode))
+    ; fun1 = (fun ?(x = (x : @ mode)) () @ mode -> (y : @ mode))
+    ; fun2 = (fun ?(x = (x : @ mode)) () @ mode1 -> (y : @ mode2))
+    ; fun3 = (fun ?(x = (x : @ mode)) () -> (y : @ mode))
+    ; apply1 = (x : @ mode) (y : @ mode)
+    ; apply2 = f ~lbl:(x : @ mode)
+    ; apply3 = f ~x:(x : @ mode)
+    ; apply4 = f ?lbl:(x : @ mode)
+    ; apply5 = f ?x:(x : @ mode)
+    ; match1 =
+        (match (x : @ mode) with
+         | y -> (y : @ mode)
+         | z -> (z : @ mode))
+    ; try1 =
+        (try (x : @ mode) with
+         | y -> (y : @ mode))
+    ; tuple1 = (x : @ mode), (y : @ mode)
+    ; tuple2 = ~x:(x : @ mode), ~y:(z : @ mode)
+    ; construct1 = A (x : @ mode)
+    ; construct2 = A ((x : @ mode), (y : @ mode))
+    ; variant1 = `A (x : @ mode)
+    ; variant2 = `A ((x : @ mode), (y : @ mode))
+    ; field1 = (x : @ mode).x
+    ; setfield1 = (x : @ mode).x <- (y : @ mode)
+    ; array1 = [| (x : @ mode); (y : @ mode) |]
+    ; array2 = [: (x : @ mode); (y : @ mode) :]
+    ; list1 = [ (x : @ mode); (y : @ mode) ]
+    ; ite1 = (if (x : @ mode) then (y : @ mode) else (z : @ mode))
+    ; sequence1 =
+        ((x : @ mode);
+         (y : @ mode))
+    ; while1 =
+        while (x : @ mode) do
+          (y : @ mode)
+        done
+    ; for1 =
+        for i = (x : @ mode) to (y : @ mode) do
+          (z : @ mode)
+        done
+    ; constraint1 = ((x : @ mode) : @ mode)
+    ; constraint2 = ((x : @ mode) : _ @ mode)
+    ; constraint3 = ((x : _ @ mode) : @ mode)
+    ; coerce1 = ((x : @ mode) :> _)
+    ; send1 = (x : @ mode)#y
+    ; setinstvar1 = x <- (x : @ mode)
+    ; override1 = {<x = (x : @ mode); y = (y : @ mode)>}
+    ; letmodule1 =
+        (let module M = ME in
+        (x : @ mode))
+    ; letexception1 =
+        (let exception E in
+        (x : @ mode))
+    ; assert1 = assert (x : @ mode)
+    ; lazy1 = lazy (x : @ mode)
+    ; newtype1 = (fun (type t) @ mode -> (x : @ mode))
+    ; open1 = M.((x : @ mode))
+    ; letopen1 =
+        (let open M in
+         (x : @ mode))
+    ; letop1 =
+        (let* x = (x : @ mode) in
+         (y : @ mode))
+    ; extension1 = [%ext (x : @ mode)]
+    ; cons1 = (x : @ mode) :: (y : @ mode) :: (z : @ mode)
+    ; prefix1 = !(x : @ mode)
+    ; infix1 = (x : @ mode) + (y : @ mode)
+    }
+  ;;
+
+  (* expressions in mode-only constraints *)
+  let x =
+    { ident1 = (x : @ mode)
+    ; constant1 = ("" : @ mode)
+    ; let1 =
+        (let x = y in
+         z
+         : @ mode)
+    ; function1 =
+        (function
+         | x -> x
+         | y -> y
+         : @ mode)
+    ; fun1 = (fun x @ mode -> y : @ mode)
+    ; fun2 = (fun x @ mode1 -> y : @ mode2)
+    ; fun3 = (fun x -> y : @ mode)
+    ; apply1 = (f x : @ mode)
+    ; match1 =
+        ((match x with
+          | y -> y
+          | z -> z)
+         : @ mode)
+    ; try1 =
+        ((try x with
+          | y -> y
+          | z -> z)
+         : @ mode)
+    ; tuple1 = ((x, y) : @ mode)
+    ; tuple2 = ((~x, ~y) : @ mode)
+    ; construct1 = (A : @ mode)
+    ; construct2 = (A x : @ mode)
+    ; construct3 = (A (x, y) : @ mode)
+    ; construct4 = (A { x } : @ mode)
+    ; variant1 = (`A : @ mode)
+    ; variant2 = (`A x : @ mode)
+    ; record1 = ({ x } : @ mode)
+    ; field1 = (x.y : @ mode)
+    ; setfield1 = (x.y <- z : @ mode)
+    ; array1 = ([| x |] : @ mode)
+    ; array2 = ([: x :] : @ mode)
+    ; list1 = ([ x ] : @ mode)
+    ; ite1 = (if x then y else z : @ mode)
+    ; sequence1 =
+        (x;
+         y
+         : @ mode)
+    ; constraint1 = ((x : @ mode) : @ mode)
+    ; constraint2 = ((x : _ @ mode) : @ mode)
+    ; constraint3 = ((x : @ mode) : _ @ mode)
+    ; coerce1 = ((x :> _) : @ mode)
+    ; send1 = (x#y : @ mode)
+    ; new1 = (new x : @ mode)
+    ; setinstvar1 = (x <- 2 : @ mode)
+    ; override1 = ({<y = z>} : @ mode)
+    ; letmodule1 =
+        (let module M = ME in
+         x
+         : @ mode)
+    ; letexception1 =
+        (let exception E in
+         x
+         : @ mode)
+    ; assert1 = (assert x : @ mode)
+    ; lazy1 = (lazy x : @ mode)
+    ; object1 = (object end : @ mode)
+    ; newtype1 = (fun (type t) @ mode -> x : @ mode)
+    ; pack1 = ((module M) : @ mode)
+    ; pack2 = ((module M : S) : @ mode)
+    ; open1 = (M.(x y) : @ mode)
+    ; letopen1 =
+        (let open M in
+         x
+         : @ mode)
+    ; letop1 =
+        (let* x = y in
+         z
+         : @ mode)
+    ; extension1 = ([%ext] : @ mode)
+    ; hole1 = (_ : @ mode)
+    ; cons1 = (x :: y :: z : @ mode)
+    ; prefix1 = (!x : @ mode)
+    ; infix1 = (x + y : @ mode)
     }
   ;;
 end

--- a/test/passing/tests/modes.ml.js-ref
+++ b/test/passing/tests/modes.ml.js-ref
@@ -53,6 +53,12 @@ module Expressions = struct
   let x = (expr : (typ1 -> typ2) @ mode1 mode2)
   let x = (expr : (typ1 * typ2) @ mode1 mode2)
 
+  (* mode-only constraints without a type *)
+  let x = (expr : @ mode1)
+  let x = (expr : @ mode1 mode2)
+  let x = f (expr : @ mode1)
+  let x = (expr : @ mode1).field
+
   (* mode constraints in expressions *)
   let x =
     { let1 =
@@ -232,6 +238,178 @@ module Expressions = struct
     ; cons1 = (x :: y :: z : _ @ mode)
     ; prefix1 = (!x : _ @ mode)
     ; infix1 = (x + y : _ @ mode)
+    }
+  ;;
+
+  (* mode-only constraints in expressions *)
+  let x =
+    { let1 =
+        (let x = (x : @ mode)
+         and y = (y : @ mode) in
+         (z : @ mode))
+    ; function1 =
+        (function
+          | x -> (x : @ mode)
+          | y -> (y : @ mode))
+    ; fun1 = (fun ?(x = (x : @ mode)) () @ mode -> (y : @ mode))
+    ; fun2 = (fun ?(x = (x : @ mode)) () @ mode1 -> (y : @ mode2))
+    ; fun3 = (fun ?(x = (x : @ mode)) () @ mode -> y)
+    ; apply1 = (x : @ mode) (y : @ mode)
+    ; apply2 = f ~lbl:(x : @ mode)
+    ; apply3 = f ~x:(x : @ mode)
+    ; apply4 = f ?lbl:(x : @ mode)
+    ; apply5 = f ?x:(x : @ mode)
+    ; match1 =
+        (match (x : @ mode) with
+         | y -> (y : @ mode)
+         | z -> (z : @ mode))
+    ; try1 =
+        (try (x : @ mode) with
+         | y -> (y : @ mode))
+    ; tuple1 = (x : @ mode), (y : @ mode)
+    ; tuple2 = ~x:(x : @ mode), ~y:(z : @ mode)
+    ; construct1 = A (x : @ mode)
+    ; construct2 = A ((x : @ mode), (y : @ mode))
+    ; variant1 = `A (x : @ mode)
+    ; variant2 = `A ((x : @ mode), (y : @ mode))
+    ; field1 = (x : @ mode).x
+    ; setfield1 = (x : @ mode).x <- (y : @ mode)
+    ; array1 = [| (x : @ mode); (y : @ mode) |]
+    ; array2 = [: (x : @ mode); (y : @ mode) :]
+    ; list1 = [ (x : @ mode); (y : @ mode) ]
+    ; ite1 = (if (x : @ mode) then (y : @ mode) else (z : @ mode))
+    ; sequence1 =
+        ((x : @ mode);
+         (y : @ mode))
+    ; while1 =
+        while (x : @ mode) do
+          (y : @ mode)
+        done
+    ; for1 =
+        for i = (x : @ mode) to (y : @ mode) do
+          (z : @ mode)
+        done
+    ; constraint1 = ((x : @ mode) : @ mode)
+    ; constraint2 = ((x : @ mode) : _ @ mode)
+    ; constraint3 = ((x : _ @ mode) : @ mode)
+    ; coerce1 = ((x : @ mode) :> _)
+    ; send1 = (x : @ mode)#y
+    ; setinstvar1 = x <- (x : @ mode)
+    ; override1 = {<x = (x : @ mode); y = (y : @ mode)>}
+    ; letmodule1 =
+        (let module M = ME in
+        (x : @ mode))
+    ; letexception1 =
+        (let exception E in
+        (x : @ mode))
+    ; assert1 = assert (x : @ mode)
+    ; lazy1 = lazy (x : @ mode)
+    ; newtype1 = (fun (type t) @ mode -> (x : @ mode))
+    ; open1 = M.((x : @ mode))
+    ; letopen1 =
+        (let open M in
+         (x : @ mode))
+    ; letop1 =
+        (let* x = (x : @ mode) in
+         (y : @ mode))
+    ; extension1 = [%ext (x : @ mode)]
+    ; cons1 = (x : @ mode) :: (y : @ mode) :: (z : @ mode)
+    ; prefix1 = !(x : @ mode)
+    ; infix1 = (x : @ mode) + (y : @ mode)
+    }
+  ;;
+
+  (* expressions in mode-only constraints *)
+  let x =
+    { ident1 = (x : @ mode)
+    ; constant1 = ("" : @ mode)
+    ; let1 =
+        (let x = y in
+         z
+         :
+         @ mode)
+    ; function1 =
+        (function
+         | x -> x
+         | y -> y
+         :
+         @ mode)
+    ; fun1 = (fun x @ mode -> y : @ mode)
+    ; fun2 = (fun x @ mode1 -> y : @ mode2)
+    ; fun3 = (fun x -> y : @ mode)
+    ; apply1 = (f x : @ mode)
+    ; match1 =
+        ((match x with
+          | y -> y
+          | z -> z)
+         :
+         @ mode)
+    ; try1 =
+        ((try x with
+          | y -> y
+          | z -> z)
+         :
+         @ mode)
+    ; tuple1 = ((x, y) : @ mode)
+    ; tuple2 = ((~x, ~y) : @ mode)
+    ; construct1 = (A : @ mode)
+    ; construct2 = (A x : @ mode)
+    ; construct3 = (A (x, y) : @ mode)
+    ; construct4 = (A { x } : @ mode)
+    ; variant1 = (`A : @ mode)
+    ; variant2 = (`A x : @ mode)
+    ; record1 = ({ x } : @ mode)
+    ; field1 = (x.y : @ mode)
+    ; setfield1 = (x.y <- z : @ mode)
+    ; array1 = ([| x |] : @ mode)
+    ; array2 = ([: x :] : @ mode)
+    ; list1 = ([ x ] : @ mode)
+    ; ite1 = (if x then y else z : @ mode)
+    ; sequence1 =
+        (x;
+         y
+         :
+         @ mode)
+    ; constraint1 = ((x : @ mode) : @ mode)
+    ; constraint2 = ((x : _ @ mode) : @ mode)
+    ; constraint3 = ((x : @ mode) : _ @ mode)
+    ; coerce1 = ((x :> _) : @ mode)
+    ; send1 = (x#y : @ mode)
+    ; new1 = (new x : @ mode)
+    ; setinstvar1 = (x <- 2 : @ mode)
+    ; override1 = ({<y = z>} : @ mode)
+    ; letmodule1 =
+        (let module M = ME in
+         x
+         :
+         @ mode)
+    ; letexception1 =
+        (let exception E in
+         x
+         :
+         @ mode)
+    ; assert1 = (assert x : @ mode)
+    ; lazy1 = (lazy x : @ mode)
+    ; object1 = (object end : @ mode)
+    ; newtype1 = (fun (type t) @ mode -> x : @ mode)
+    ; pack1 = ((module M) : @ mode)
+    ; pack2 = ((module M : S) : @ mode)
+    ; open1 = (M.(x y) : @ mode)
+    ; letopen1 =
+        (let open M in
+         x
+         :
+         @ mode)
+    ; letop1 =
+        (let* x = y in
+         z
+         :
+         @ mode)
+    ; extension1 = ([%ext] : @ mode)
+    ; hole1 = (_ : @ mode)
+    ; cons1 = (x :: y :: z : @ mode)
+    ; prefix1 = (!x : @ mode)
+    ; infix1 = (x + y : @ mode)
     }
   ;;
 end

--- a/test/passing/tests/modes.ml.ref
+++ b/test/passing/tests/modes.ml.ref
@@ -62,6 +62,15 @@ module Expressions = struct
 
   let x = (expr : (typ1 * typ2) @ mode1 mode2)
 
+  (* mode-only constraints without a type *)
+  let x = (expr : @ mode1)
+
+  let x = (expr : @ mode1 mode2)
+
+  let x = f (expr : @ mode1)
+
+  let x = (expr : @ mode1).field
+
   (* mode constraints in expressions *)
   let x =
     { let1=
@@ -214,6 +223,147 @@ module Expressions = struct
     ; cons1= (x :: y :: z : _ @ mode)
     ; prefix1= (!x : _ @ mode)
     ; infix1= (x + y : _ @ mode) }
+
+  (* mode-only constraints in expressions *)
+  let x =
+    { let1=
+        (let x = (x : @ mode) and y = (y : @ mode) in
+         (z : @ mode) )
+    ; function1= (function x -> (x : @ mode) | y -> (y : @ mode))
+    ; fun1= (fun ?(x = (x : @ mode)) () @ mode -> (y : @ mode))
+    ; fun2= (fun ?(x = (x : @ mode)) () @ mode1 -> (y : @ mode2))
+    ; fun3= (fun ?(x = (x : @ mode)) () @ mode -> y)
+    ; apply1= (x : @ mode) (y : @ mode)
+    ; apply2= f ~lbl:(x : @ mode)
+    ; apply3= f ~x:(x : @ mode)
+    ; apply4= f ?lbl:(x : @ mode)
+    ; apply5= f ?x:(x : @ mode)
+    ; match1=
+        (match (x : @ mode) with y -> (y : @ mode) | z -> (z : @ mode))
+    ; try1= (try (x : @ mode) with y -> (y : @ mode))
+    ; tuple1= ((x : @ mode), (y : @ mode))
+    ; tuple2= (~x:(x : @ mode), ~y:(z : @ mode))
+    ; construct1= A (x : @ mode)
+    ; construct2= A ((x : @ mode), (y : @ mode))
+    ; variant1= `A (x : @ mode)
+    ; variant2= `A ((x : @ mode), (y : @ mode))
+    ; field1= (x : @ mode).x
+    ; setfield1= (x : @ mode).x <- (y : @ mode)
+    ; array1= [|(x : @ mode); (y : @ mode)|]
+    ; array2= [:(x : @ mode); (y : @ mode):]
+    ; list1= [(x : @ mode); (y : @ mode)]
+    ; ite1= (if (x : @ mode) then (y : @ mode) else (z : @ mode))
+    ; sequence1=
+        ( (x : @ mode) ;
+          (y : @ mode) )
+    ; while1=
+        while (x : @ mode) do
+          (y : @ mode)
+        done
+    ; for1=
+        for i = (x : @ mode) to (y : @ mode) do
+          (z : @ mode)
+        done
+    ; constraint1= ((x : @ mode) : @ mode)
+    ; constraint2= ((x : @ mode) : _ @ mode)
+    ; constraint3= ((x : _ @ mode) : @ mode)
+    ; coerce1= ((x : @ mode) :> _)
+    ; send1= (x : @ mode)#y
+    ; setinstvar1= x <- (x : @ mode)
+    ; override1= {<x = (x : @ mode); y = (y : @ mode)>}
+    ; letmodule1=
+        (let module M = ME in
+        (x : @ mode) )
+    ; letexception1=
+        (let exception E in
+        (x : @ mode) )
+    ; assert1= assert (x : @ mode)
+    ; lazy1= lazy (x : @ mode)
+    ; newtype1= (fun (type t) @ mode -> (x : @ mode))
+    ; open1= M.((x : @ mode))
+    ; letopen1=
+        (let open M in
+         (x : @ mode) )
+    ; letop1=
+        (let* x = (x : @ mode) in
+         (y : @ mode) )
+    ; extension1= [%ext (x : @ mode)]
+    ; cons1= (x : @ mode) :: (y : @ mode) :: (z : @ mode)
+    ; prefix1= !(x : @ mode)
+    ; infix1= (x : @ mode) + (y : @ mode) }
+
+  (* expressions in mode-only constraints *)
+  let x =
+    { ident1= (x : @ mode)
+    ; constant1= ("" : @ mode)
+    ; let1=
+        ( let x = y in
+          z
+          :
+          @ mode )
+    ; function1= (function x -> x | y -> y : @ mode)
+    ; fun1= (fun x @ mode -> y : @ mode)
+    ; fun2= (fun x @ mode1 -> y : @ mode2)
+    ; fun3= (fun x -> y : @ mode)
+    ; apply1= (f x : @ mode)
+    ; match1= (match x with y -> y | z -> z : @ mode)
+    ; try1= (try x with y -> y | z -> z : @ mode)
+    ; tuple1= ((x, y) : @ mode)
+    ; tuple2= ((~x, ~y) : @ mode)
+    ; construct1= (A : @ mode)
+    ; construct2= (A x : @ mode)
+    ; construct3= (A (x, y) : @ mode)
+    ; construct4= (A {x} : @ mode)
+    ; variant1= (`A : @ mode)
+    ; variant2= (`A x : @ mode)
+    ; record1= ({x} : @ mode)
+    ; field1= (x.y : @ mode)
+    ; setfield1= (x.y <- z : @ mode)
+    ; array1= ([|x|] : @ mode)
+    ; array2= ([:x:] : @ mode)
+    ; list1= ([x] : @ mode)
+    ; ite1= (if x then y else z : @ mode)
+    ; sequence1= (x ; y : @ mode)
+    ; constraint1= ((x : @ mode) : @ mode)
+    ; constraint2= ((x : _ @ mode) : @ mode)
+    ; constraint3= ((x : @ mode) : _ @ mode)
+    ; coerce1= ((x :> _) : @ mode)
+    ; send1= (x#y : @ mode)
+    ; new1= (new x : @ mode)
+    ; setinstvar1= (x <- 2 : @ mode)
+    ; override1= ({<y = z>} : @ mode)
+    ; letmodule1=
+        ( let module M = ME in
+          x
+          :
+          @ mode )
+    ; letexception1=
+        ( let exception E in
+          x
+          :
+          @ mode )
+    ; assert1= (assert x : @ mode)
+    ; lazy1= (lazy x : @ mode)
+    ; object1= (object end : @ mode)
+    ; newtype1= (fun (type t) @ mode -> x : @ mode)
+    ; pack1= ((module M) : @ mode)
+    ; pack2= ((module M : S) : @ mode)
+    ; open1= (M.(x y) : @ mode)
+    ; letopen1=
+        ( let open M in
+          x
+          :
+          @ mode )
+    ; letop1=
+        ( let* x = y in
+          z
+          :
+          @ mode )
+    ; extension1= ([%ext] : @ mode)
+    ; hole1= (_ : @ mode)
+    ; cons1= (x :: y :: z : @ mode)
+    ; prefix1= (!x : @ mode)
+    ; infix1= (x + y : @ mode) }
 end
 
 module Arrow_params = struct

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -2802,6 +2802,8 @@ spliceable_expr:
       { let (t, m) = $3 in
         mkexp_type_constraint_with_modes
           ~ghost:true ~loc:$sloc ~modes:m $2 ~ty:t }
+  | LPAREN seq_expr COLON at_mode_expr RPAREN
+      { ghexp_constraint ~loc:$sloc ~modes:$4 $2 None }
   | mkrhs(val_longident)
       { mkexp ~loc:$sloc (Pexp_ident ($1)) }
   | error
@@ -2819,6 +2821,8 @@ simple_expr:
   | LPAREN seq_expr type_constraint_with_modes RPAREN
       { let ty, modes = $3 in
         mkexp_type_constraint_with_modes ~ghost:true ~loc:$sloc ~modes $2 ~ty }
+  | LPAREN seq_expr COLON at_mode_expr RPAREN
+      { ghexp_constraint ~loc:$sloc ~modes:$4 $2 None }
   | indexop_expr(DOT, seq_expr, { None })
       { mk_builtin_indexop_expr ~loc:$sloc $1 }
   (* Immutable array indexing is a regular operator, so it doesn't need its own

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -406,9 +406,13 @@ let mkexp_type_constraint_with_modes ?(ghost=false) ~loc ~modes e t =
       mk ~loc (Pexp_coerce(e, t1, t2))
      | _ :: _ -> not_expecting loc "mode annotations"
 
-let mkexp_opt_type_constraint_with_modes ?ghost ~loc ~modes e = function
-  | None -> e
-  | Some c -> mkexp_type_constraint_with_modes ?ghost ~loc ~modes e c
+let mkexp_opt_type_constraint_with_modes ?(ghost=false) ~loc ~modes e t =
+  match t, modes with
+  | None, [] -> e
+  | None, _ :: _ ->
+     let mk = if ghost then ghexp_constraint else mkexp_constraint in
+     mk ~loc ~exp:e ~cty:None ~modes
+  | Some c, _ -> mkexp_type_constraint_with_modes ~ghost ~loc ~modes e c
 
 (* Helper functions for desugaring array indexing operators *)
 type paren_kind = Paren | Brace | Bracket
@@ -2974,9 +2978,10 @@ spliceable_expr:
       { reloc_exp ~loc:$sloc $2 }
   | LPAREN seq_expr error
       { unclosed "(" $loc($1) ")" $loc($3) }
-  | LPAREN seq_expr type_constraint_with_modes RPAREN
+  | LPAREN seq_expr opt_type_constraint_with_modes RPAREN
       { let (t, m) = $3 in
-        mkexp_type_constraint_with_modes ~ghost:true ~loc:$sloc ~modes:m $2 t }
+        mkexp_opt_type_constraint_with_modes ~ghost:true ~loc:$sloc ~modes:m $2
+          t }
   | mkrhs(val_longident)
       { mkexp ~loc:$sloc (Pexp_ident ($1)) }
   | error
@@ -2988,9 +2993,10 @@ simple_expr:
       { reloc_exp ~loc:$sloc $2 }
   | LPAREN seq_expr error
       { unclosed "(" $loc($1) ")" $loc($3) }
-  | LPAREN seq_expr type_constraint_with_modes RPAREN
+  | LPAREN seq_expr opt_type_constraint_with_modes RPAREN
       { let (t, m) = $3 in
-        mkexp_type_constraint_with_modes ~ghost:true ~loc:$sloc ~modes:m $2 t }
+        mkexp_opt_type_constraint_with_modes ~ghost:true ~loc:$sloc ~modes:m $2
+          t }
   | indexop_expr(DOT, seq_expr, { None })
       { mk_indexop_expr builtin_indexing_operators ~loc:$sloc $1 }
   (* Immutable array indexing is a regular operator, so it doesn't need its own
@@ -3658,6 +3664,13 @@ type_constraint:
   | COLON error                                 { syntax_error() }
   | COLONGREATER error                          { syntax_error() }
 ;
+
+%inline opt_type_constraint_with_modes:
+  | type_constraint_with_modes
+    { let ty, modes = $1 in
+      Some ty, modes }
+  | COLON at_mode_expr
+    { None, $2 }
 
 %inline constraint_:
   | type_constraint_with_modes


### PR DESCRIPTION
See [OxCaml #5602](https://github.com/oxcaml/oxcaml/pull/5602).

This was partially written with the help of Opus v4.6.

The parser-standard diff is the same as the one in in the original OxCaml PR, but the parser-extended diff is bespoke since `mkexp_type_constraint_with_modes` had already diverged between the two parsers.