### PR TITLE
Support scannable axes

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -906,7 +906,16 @@ and fmt_jkind c ~ctx {txt= jkd; loc} =
   let parens, fmt =
     match jkd with
     | Default -> (false, fmt "_")
-    | Abbreviation abbrev -> (false, fmt_str_loc c abbrev)
+    | Abbreviation (abbrev, modifiers) ->
+        let fmt =
+          fmt_longident_loc c abbrev
+          $ fmt_if_k
+              (not (List.is_empty modifiers))
+              ( fmt "@ "
+              $ list modifiers "@ " (fun modifier -> fmt_str_loc c modifier)
+              )
+        in
+        (false, fmt)
     | Mod (jkind, modes) ->
         let parens =
           match ctx with

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -15,9 +15,12 @@ let rewrite_type_declaration_imm_attr_to_jkind_annot decl =
   let get_jkind_of_legacy_attr attr =
     match (attr.attr_name.txt, attr.attr_payload) with
     | ("ocaml.immediate64" | "immediate64"), PStr [] ->
-        Some (Abbreviation (Location.mknoloc "immediate64"))
+        Some
+          (Abbreviation
+             (Location.mknoloc (Longident.Lident "immediate64"), []) )
     | ("ocaml.immediate" | "immediate"), PStr [] ->
-        Some (Abbreviation (Location.mknoloc "immediate"))
+        Some
+          (Abbreviation (Location.mknoloc (Longident.Lident "immediate"), []))
     | _ -> None
   in
   let immediate_attrs, remaining_attrs =

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -445,12 +445,18 @@ let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
   let type_declaration (m : Ast_mapper.mapper) decl =
     let ptype_jkind_annotation, extra_attributes =
       match decl.ptype_jkind_annotation with
-      | Some {pjkind_desc= Abbreviation "immediate"; _} ->
+      | Some
+          { pjkind_desc=
+              Abbreviation ({txt= Longident.Lident "immediate"; _}, [])
+          ; _ } ->
           ( None
           , [ Ast_helper.Attr.mk
                 {txt= "immediate"; loc= Location.none}
                 (PStr []) ] )
-      | Some {pjkind_desc= Abbreviation "immediate64"; _} ->
+      | Some
+          { pjkind_desc=
+              Abbreviation ({txt= Longident.Lident "immediate64"; _}, [])
+          ; _ } ->
           ( None
           , [ Ast_helper.Attr.mk
                 {txt= "immediate64"; loc= Location.none}

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -30,11 +30,34 @@ type t_imm =
 
 type t_imm64 [@@immediate64]
 
+type t_qualified_immediate
+
+type t_modified_immediate
+
+type t_modified_immediate64
+
 type t_float64
 
 type t_any
 
 type t_void
+
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_any_non_pointer
+
+type t_value_non_pointer
+
+type t_value_maybe_pointer
+
+type t_value_maybe_pointer_non_pointer
+
+type t_product_non_pointer
+
+type t_qualified_non_pointer
+
+let scannable_id : 'a -> 'a = fun x -> x
 
 (***************************************)
 (* Test 1: annotation on type variable *)

--- a/test/passing/tests/layout_annotation-erased.ml.ref
+++ b/test/passing/tests/layout_annotation-erased.ml.ref
@@ -49,6 +49,8 @@ type t_any_non_pointer
 
 type t_value_non_pointer
 
+type t_value_non_pointer_comment (* hi *)
+
 type t_value_maybe_pointer
 
 type t_value_maybe_pointer_non_pointer

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -40,11 +40,41 @@ type t_imm
 type t_imm64 :
        immediate64
 
+type t_qualified_immediate
+     : Foo.immediate
+
+type t_modified_immediate
+     : immediate non_pointer
+
+type t_modified_immediate64
+     : immediate64 maybe_pointer
+
 type t_float64 : float64
 
 type t_any : any
 
 type t_void : void
+
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_any_non_pointer : any non_pointer
+
+type t_value_non_pointer
+     : value non_pointer
+
+type t_value_maybe_pointer : value maybe_pointer
+
+type t_value_maybe_pointer_non_pointer
+     : value maybe_pointer non_pointer
+
+type t_product_non_pointer
+     : value & value non_pointer
+
+type t_qualified_non_pointer
+     : Foo.bar non_pointer
+
+let scannable_id : ('a : value non_pointer) -> 'a = fun x -> x
 
 (***************************************)
 (* Test 1: annotation on type variable *)
@@ -376,4 +406,3 @@ type t =
 
 type t =
   | T : (* 1 *) ('a : value) 'b (* 2 *) ('c : (* 3 *) float64) 'd . (* 4 *) { x : 'a * 'b * 'c * 'd } -> t
-

--- a/test/passing/tests/layout_annotation.ml
+++ b/test/passing/tests/layout_annotation.ml
@@ -63,6 +63,9 @@ type t_any_non_pointer : any non_pointer
 type t_value_non_pointer
      : value non_pointer
 
+type t_value_non_pointer_comment
+     : value (* hi *) non_pointer
+
 type t_value_maybe_pointer : value maybe_pointer
 
 type t_value_maybe_pointer_non_pointer

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -26,9 +26,24 @@ type t_imm : immediate =
   }
 
 type t_imm64 : immediate64
+type t_qualified_immediate : Foo.immediate
+type t_modified_immediate : immediate non_pointer
+type t_modified_immediate64 : immediate64 maybe_pointer
 type t_float64 : float64
 type t_any : any
 type t_void : void
+
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_any_non_pointer : any non_pointer
+type t_value_non_pointer : value non_pointer
+type t_value_maybe_pointer : value maybe_pointer
+type t_value_maybe_pointer_non_pointer : value maybe_pointer non_pointer
+type t_product_non_pointer : value & value non_pointer
+type t_qualified_non_pointer : Foo.bar non_pointer
+
+let scannable_id : ('a : value non_pointer) -> 'a = fun x -> x
 
 (***************************************)
 (* Test 1: annotation on type variable *)

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -38,6 +38,7 @@ type t_void : void
 
 type t_any_non_pointer : any non_pointer
 type t_value_non_pointer : value non_pointer
+type t_value_non_pointer_comment : value (* hi *) non_pointer
 type t_value_maybe_pointer : value maybe_pointer
 type t_value_maybe_pointer_non_pointer : value maybe_pointer non_pointer
 type t_product_non_pointer : value & value non_pointer

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -28,11 +28,34 @@ type t_imm : immediate =
 
 type t_imm64 : immediate64
 
+type t_qualified_immediate : Foo.immediate
+
+type t_modified_immediate : immediate non_pointer
+
+type t_modified_immediate64 : immediate64 maybe_pointer
+
 type t_float64 : float64
 
 type t_any : any
 
 type t_void : void
+
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_any_non_pointer : any non_pointer
+
+type t_value_non_pointer : value non_pointer
+
+type t_value_maybe_pointer : value maybe_pointer
+
+type t_value_maybe_pointer_non_pointer : value maybe_pointer non_pointer
+
+type t_product_non_pointer : value & value non_pointer
+
+type t_qualified_non_pointer : Foo.bar non_pointer
+
+let scannable_id : ('a : value non_pointer) -> 'a = fun x -> x
 
 (***************************************)
 (* Test 1: annotation on type variable *)

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -47,6 +47,8 @@ type t_any_non_pointer : any non_pointer
 
 type t_value_non_pointer : value non_pointer
 
+type t_value_non_pointer_comment : value (* hi *) non_pointer
+
 type t_value_maybe_pointer : value maybe_pointer
 
 type t_value_maybe_pointer_non_pointer : value maybe_pointer non_pointer

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml
@@ -33,9 +33,13 @@ type old_imm64 [@@immediate64] [@@immediate]
 
 type old_imm: immediate [@@immediate]
 type old_imm: immediate64 [@@immediate]
+type old_imm: Foo.immediate [@@immediate]
+type old_imm: immediate non_pointer [@@immediate]
 
 type old_imm64: immediate64 [@@immediate64]
 type old_imm64: immediate [@@immediate64]
+type old_imm64: Foo.immediate64 [@@immediate64]
+type old_imm64: immediate64 maybe_pointer [@@immediate64]
 
 (* Do nothing if there's unexpected payload *)
 

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml.js-ref
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml.js-ref
@@ -32,8 +32,12 @@ type old_imm64 [@@immediate64] [@@immediate]
 
 type old_imm : immediate [@@immediate]
 type old_imm : immediate64 [@@immediate]
+type old_imm : Foo.immediate [@@immediate]
+type old_imm : immediate non_pointer [@@immediate]
 type old_imm64 : immediate64 [@@immediate64]
 type old_imm64 : immediate [@@immediate64]
+type old_imm64 : Foo.immediate64 [@@immediate64]
+type old_imm64 : immediate64 maybe_pointer [@@immediate64]
 
 (* Do nothing if there's unexpected payload *)
 

--- a/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
+++ b/test/passing/tests/layout_annotation_immediate_rewrite.ml.ref
@@ -44,9 +44,17 @@ type old_imm : immediate [@@immediate]
 
 type old_imm : immediate64 [@@immediate]
 
+type old_imm : Foo.immediate [@@immediate]
+
+type old_imm : immediate non_pointer [@@immediate]
+
 type old_imm64 : immediate64 [@@immediate64]
 
 type old_imm64 : immediate [@@immediate64]
+
+type old_imm64 : Foo.immediate64 [@@immediate64]
+
+type old_imm64 : immediate64 maybe_pointer [@@immediate64]
 
 (* Do nothing if there's unexpected payload *)
 

--- a/test/passing/tests/layout_annotation_mod.ml
+++ b/test/passing/tests/layout_annotation_mod.ml
@@ -23,6 +23,12 @@ type t_any : any mod mode
 
 type t_void : void mod mode 
 
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_value_non_pointer_mod
+     : value non_pointer mod mode
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 
@@ -358,4 +364,3 @@ type t =
 
 type t =
   | T : (* 1 *) ('a : value mod mode) 'b (* 2 *) ('c : (* 3 *) float64 (* 4 *) mod mode) 'd . (* 5 *) { x : 'a * 'b * 'c * 'd } -> t
-

--- a/test/passing/tests/layout_annotation_mod.ml.js-ref
+++ b/test/passing/tests/layout_annotation_mod.ml.js-ref
@@ -14,6 +14,11 @@ type t_float64 : float64 mod mode
 type t_any : any mod mode
 type t_void : void mod mode
 
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_value_non_pointer_mod : value non_pointer mod mode
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/test/passing/tests/layout_annotation_mod.ml.ref
+++ b/test/passing/tests/layout_annotation_mod.ml.ref
@@ -21,6 +21,11 @@ type t_any : any mod mode
 
 type t_void : void mod mode
 
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_value_non_pointer_mod : value non_pointer mod mode
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/test/passing/tests/layout_annotation_with.ml
+++ b/test/passing/tests/layout_annotation_with.ml
@@ -23,6 +23,13 @@ type t_any : any with type_
 
 type t_void : void with type_
 
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_value_non_pointer : value non_pointer with type_
+
+let scannable_id : ('a : value non_pointer with type_) -> 'a = fun x -> x
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/test/passing/tests/layout_annotation_with.ml.err
+++ b/test/passing/tests/layout_annotation_with.ml.err
@@ -1,3 +1,3 @@
 Warning: tests/layout_annotation_with.ml:8 exceeds the margin
-Warning: tests/layout_annotation_with.ml:430 exceeds the margin
-Warning: tests/layout_annotation_with.ml:486 exceeds the margin
+Warning: tests/layout_annotation_with.ml:437 exceeds the margin
+Warning: tests/layout_annotation_with.ml:493 exceeds the margin

--- a/test/passing/tests/layout_annotation_with.ml.js-ref
+++ b/test/passing/tests/layout_annotation_with.ml.js-ref
@@ -14,6 +14,13 @@ type t_float64 : float64 with type_
 type t_any : any with type_
 type t_void : void with type_
 
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_value_non_pointer : value non_pointer with type_
+
+let scannable_id : ('a : value non_pointer with type_) -> 'a = fun x -> x
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/test/passing/tests/layout_annotation_with.ml.ref
+++ b/test/passing/tests/layout_annotation_with.ml.ref
@@ -21,6 +21,13 @@ type t_any : any with type_
 
 type t_void : void with type_
 
+(***********************************************************)
+(* Test 0: scannable axes on layout abbreviations *)
+
+type t_value_non_pointer : value non_pointer with type_
+
+let scannable_id : ('a : value non_pointer with type_) -> 'a = fun x -> x
+
 (***************************************)
 (* Test 1: annotation on type variable *)
 

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -1110,11 +1110,8 @@ let default_mapper =
     jkind_annotation = (fun this ->
       function
       | Default -> Default
-      | Abbreviation s ->
-        let {txt; loc} =
-          map_loc this s
-        in
-        Abbreviation ({ txt; loc })
+      | Abbreviation (s, modifiers) ->
+        Abbreviation (map_loc this s, List.map (map_loc this) modifiers)
       | Mod (t, mode_list) ->
         Mod (map_loc_txt this this.jkind_annotation t, this.modes this mode_list)
       | With (t, ty, ms) ->

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -800,8 +800,10 @@ let mk_directive ~loc name arg =
 let convert_jkind_to_legacy_attr =
   let mk ~loc name = [Attr.mk ~loc (mkloc name loc) (PStr [])] in
   function
-  | {txt = Abbreviation {txt = "immediate"; loc}; loc = _} -> mk ~loc "immediate"
-  | {txt = Abbreviation {txt = "immediate64"; loc}; loc = _} -> mk ~loc "immediate64"
+  | {txt = Abbreviation ({txt = Longident.Lident "immediate"; loc}, []); loc = _} ->
+      mk ~loc "immediate"
+  | {txt = Abbreviation ({txt = Longident.Lident "immediate64"; loc}, []); loc = _} ->
+      mk ~loc "immediate64"
   | _ -> []
 
 (* NOTE: An alternate approach for performing the erasure of %call_pos and %src_pos
@@ -3935,9 +3937,8 @@ jkind:
       { Mod ($1, $3) }
   | mkrhs(jkind) WITH core_type optional_atat_modalities_expr
       { With ($1, $3, $4) }
-  | mkrhs(ident)
-      { let {txt; loc} = $1 in
-        Abbreviation ({ txt; loc }) }
+  | abbrev=mkrhs(type_longident) modifiers=mkrhs(LIDENT)*
+      { Abbreviation (abbrev, modifiers) }
   | KIND_OF ty=core_type
       { Kind_of ty }
   | UNDERSCORE

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -1328,11 +1328,11 @@ and module_binding =
     }
 (** Values of type [module_binding] represents [module X = ME] *)
 
-and jkind_const_annotation  = string Location.loc
+and jkind_const_annotation  = Longident.t Location.loc
 
 and jkind_annotation =
   | Default
-  | Abbreviation of jkind_const_annotation
+  | Abbreviation of jkind_const_annotation * string Location.loc list
   | Mod of jkind_annotation loc * modes
   | With of jkind_annotation loc * core_type * modalities
   | Kind_of of core_type

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -698,8 +698,12 @@ and jkind_annotation ?loc i ppf jkind =
   in
   match jkind with
   | Default -> line i ppf "Default %a\n" fmt_loc_opt loc
-  | Abbreviation jkind ->
-      line i ppf "Abbreviation \"%s\" %a\n" jkind.txt fmt_loc_opt loc
+  | Abbreviation (jkind, modifiers) ->
+      line i ppf "Abbreviation %a %a\n" fmt_longident_loc jkind fmt_loc_opt loc;
+      List.iter
+        (fun modifier ->
+          line (i+1) ppf "scannable_axis %a\n" fmt_string_loc modifier )
+        modifiers
   | Mod (jkind, m) ->
       line i ppf "Mod %a\n"  fmt_loc_opt loc;
       jkind_annotation_loc (i+1) ppf jkind;

--- a/vendor/parser-jane/for-parser-standard/ast_mapper.ml
+++ b/vendor/parser-jane/for-parser-standard/ast_mapper.ml
@@ -961,7 +961,8 @@ let default_mapper =
       let pjkind_desc =
         match pjkind_desc with
         | Default -> Default
-        | Abbreviation (s : string) -> Abbreviation s
+        | Abbreviation (s, modifiers) ->
+          Abbreviation (map_loc this s, List.map (map_loc this) modifiers)
         | Mod (t, mode_list) ->
           Mod (this.jkind_annotation this t, this.modes this mode_list)
         | With (t, ty, modalities) ->

--- a/vendor/parser-jane/for-parser-standard/parser.mly
+++ b/vendor/parser-jane/for-parser-standard/parser.mly
@@ -4050,8 +4050,8 @@ jkind_desc:
   | jkind_annotation WITH core_type optional_atat_modalities_expr {
       With ($1, $3, $4)
     }
-  | ident {
-      Abbreviation $1
+  | mkrhs(type_longident) modifiers=mkrhs(LIDENT)* {
+      Abbreviation ($1, modifiers)
     }
   | KIND_OF ty=core_type {
       Kind_of ty

--- a/vendor/parser-jane/for-parser-standard/parsetree.mli
+++ b/vendor/parser-jane/for-parser-standard/parsetree.mli
@@ -1330,7 +1330,15 @@ and module_binding =
 
 and jkind_annotation_desc =
   | Default
-  | Abbreviation of string
+  (* CR layouts-scannable: Scannable axes annotations only currently parse on
+     abbreviations, not on products/etc. It could be desirable for these
+     annotations to parse in more places with a warning (ex: for generated
+     code). This change should only be made if necessary (and after the
+     ignored-kind-modifier warning is enabled), since it adds confusion. *)
+  | Abbreviation of Longident.t loc * string loc list
+  (** [Abbreviation(A, [SA1; ...; SAn])] represents the layout
+      [A SA1 ... SAn] where [A] is some abbreviation (like [value])
+      and each [SAi] is a scannable axis annotation (like [non_pointer]) *)
   (* CR layouts v2.8: [mod] can have only layouts on the left, not
      full kind annotations. We may want to narrow this type some. *)
   | Mod of jkind_annotation * modes

--- a/vendor/parser-jane/for-parser-standard/printast.ml
+++ b/vendor/parser-jane/for-parser-standard/printast.ml
@@ -532,8 +532,12 @@ and jkind_annotation i ppf (jkind : jkind_annotation) =
   line i ppf "jkind %a\n" fmt_location jkind.pjkind_loc;
   match jkind.pjkind_desc with
   | Default -> line i ppf "Default\n"
-  | Abbreviation jkind ->
-      line i ppf "Abbreviation \"%s\"\n" jkind
+  | Abbreviation (jkind, modifiers) ->
+      line i ppf "Abbreviation %a\n" fmt_longident_loc jkind;
+      List.iter
+        (fun modifier ->
+          line (i+1) ppf "scannable_axis %a\n" fmt_string_loc modifier )
+        modifiers
   | Mod (jkind, m) ->
       line i ppf "Mod\n";
       jkind_annotation (i+1) ppf jkind;

--- a/vendor/parser-standard/ast_mapper.ml
+++ b/vendor/parser-standard/ast_mapper.ml
@@ -975,7 +975,8 @@ let default_mapper =
       let pjkind_desc =
         match pjkind_desc with
         | Default -> Default
-        | Abbreviation (s : string) -> Abbreviation s
+        | Abbreviation (s, modifiers) ->
+          Abbreviation (map_loc this s, List.map (map_loc this) modifiers)
         | Mod (t, mode_list) ->
           Mod (this.jkind_annotation this t, this.modes this mode_list)
         | With (t, ty, modalities) ->

--- a/vendor/parser-standard/parser.mly
+++ b/vendor/parser-standard/parser.mly
@@ -4137,8 +4137,8 @@ jkind_desc:
   | jkind_annotation WITH core_type optional_atat_modalities_expr {
       With ($1, $3, $4)
     }
-  | ident {
-      Abbreviation $1
+  | mkrhs(type_longident) modifiers=mkrhs(LIDENT)* {
+      Abbreviation ($1, modifiers)
     }
   | KIND_OF ty=core_type {
       Kind_of ty

--- a/vendor/parser-standard/parsetree.mli
+++ b/vendor/parser-standard/parsetree.mli
@@ -1339,7 +1339,7 @@ and module_binding =
 
 and jkind_annotation_desc =
   | Default
-  | Abbreviation of string
+  | Abbreviation of Longident.t loc * string loc list
   (* CR layouts v2.8: [mod] can have only layouts on the left, not
      full kind annotations. We may want to narrow this type some. *)
   | Mod of jkind_annotation * modes

--- a/vendor/parser-standard/printast.ml
+++ b/vendor/parser-standard/printast.ml
@@ -552,8 +552,12 @@ and jkind_annotation i ppf (jkind : jkind_annotation) =
   line i ppf "jkind %a\n" fmt_location jkind.pjkind_loc;
   match jkind.pjkind_desc with
   | Default -> line i ppf "Default\n"
-  | Abbreviation jkind ->
-      line i ppf "Abbreviation \"%s\"\n" jkind
+  | Abbreviation (jkind, modifiers) ->
+      line i ppf "Abbreviation %a\n" fmt_longident_loc jkind;
+      List.iter
+        (fun modifier ->
+          line (i+1) ppf "scannable_axis %a\n" fmt_string_loc modifier )
+        modifiers
   | Mod (jkind, m) ->
       line i ppf "Mod\n";
       jkind_annotation (i+1) ppf jkind;


### PR DESCRIPTION
These now parse and format correctly:

```
type t : any non_pointer
type t : value non_pointer
type t : value maybe_pointer
type t : value maybe_pointer non_pointer
```

Qualified abbreviations are supported too:

```
type t : Foo.bar non_pointer
```

And scannable modifiers compose correctly with existing kind syntax:

```
type t : value non_pointer with type_
type t : value non_pointer mod mode
```

These are preserved rather than rewritten:

```
type t : Foo.immediate
type t : immediate non_pointer
type t : Foo.immediate64
type t : immediate64 maybe_pointer
```

Note:

* The parser now matches OxCaml directly by accepting type_longident as the abbreviation head, rather than narrower
* The formatter preserves scannable modifiers in source order instead of normalizing them (do we want to normalize?)
* The immediate / immediate64 rewrite path now only rewrites unqualified & modifier-free abbreviations, to avoid removing scannable-axis components