### PR TITLE
Add an option for supporting runtime metaprogramming syntax

### DIFF
--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -616,11 +616,11 @@ OPTIONS
        --no-margin-check
            Unset margin-check.
 
-       --no-syntax-quotations
-           Unsey syntax-quotations.
-
        --no-quiet
            Unset quiet.
+
+       --no-syntax-quotations
+           Unset syntax-quotations.
 
        --no-version-check
            Unset version-check.

--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -616,6 +616,9 @@ OPTIONS
        --no-margin-check
            Unset margin-check.
 
+       --no-syntax-quotations
+           Unsey syntax-quotations.
+
        --no-quiet
            Unset quiet.
 
@@ -658,8 +661,10 @@ OPTIONS
            .ocamlformat configuration files inside DIR and its
            subdirectories.
 
-       --syntax-metaprogramming
-           Turn on support for runtime metaprogramming syntax.
+       --syntax-quotations
+           Enable runtime metaprogramming syntax (quoting and splicing). This
+           can be overriden with "#syntax quotations (on|off)" directives.
+           The flag is unset by default.
 
        --use-file
            Deprecated. Same as impl.

--- a/doc/manpage_ocamlformat.mld
+++ b/doc/manpage_ocamlformat.mld
@@ -658,6 +658,9 @@ OPTIONS
            .ocamlformat configuration files inside DIR and its
            subdirectories.
 
+       --syntax-metaprogramming
+           Turn on support for runtime metaprogramming syntax.
+
        --use-file
            Deprecated. Same as impl.
 

--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -545,7 +545,8 @@ module Signature_item = struct
      |Psig_kind_abbrev (_, _)
      |Psig_recmodule []
      |Psig_class_type []
-     |Psig_class [] ->
+     |Psig_class []
+     |Psig_hashsyntax _ ->
         false
 
   let is_simple (itm, (c : Conf.t)) =

--- a/lib/Conf.ml
+++ b/lib/Conf.ml
@@ -272,6 +272,7 @@ let default =
       ; max_iters= elt 10
       ; ocaml_version= elt Ocaml_version.Releases.v4_04_0
       ; quiet= elt false
+      ; syntax_quotations= elt false
       ; disable_conf_attrs= elt false
       ; version_check= elt true } }
 
@@ -1475,6 +1476,16 @@ module Operational = struct
       (fun conf elt -> update conf ~f:(fun f -> {f with quiet= elt}))
       (fun conf -> conf.opr_opts.quiet)
 
+  let syntax_quotations =
+    let doc =
+      "Enable runtime metaprogramming syntax (quoting and splicing). This \
+       can be overriden with \"#syntax quotations (on|off)\" directives."
+    in
+    Decl.flag ~names:["syntax-quotations"] ~default ~doc ~kind
+      (fun conf elt ->
+        update conf ~f:(fun f -> {f with syntax_quotations= elt}) )
+      (fun conf -> conf.opr_opts.syntax_quotations)
+
   let disable_conf_attrs =
     let doc = "Disable configuration in attributes." in
     Decl.flag ~default ~names:["disable-conf-attrs"] ~doc ~kind
@@ -1500,6 +1511,7 @@ module Operational = struct
       ; elt max_iters
       ; elt ocaml_version
       ; elt quiet
+      ; elt syntax_quotations
       ; elt disable_conf_attrs
       ; elt version_check ]
 end

--- a/lib/Conf_t.ml
+++ b/lib/Conf_t.ml
@@ -133,6 +133,7 @@ type opr_opts =
   ; max_iters: int elt
   ; ocaml_version: Ocaml_version.t elt
   ; quiet: bool elt
+  ; syntax_quotations: bool elt
   ; disable_conf_attrs: bool elt
   ; version_check: bool elt }
 

--- a/lib/Conf_t.mli
+++ b/lib/Conf_t.mli
@@ -138,6 +138,9 @@ type opr_opts =
   ; ocaml_version: Ocaml_version.t elt
         (** Version of OCaml syntax of the output. *)
   ; quiet: bool elt
+  ; syntax_quotations: bool elt
+        (** The default behaviour of the lexer is to emit runtime
+            metaprogramming tokens. *)
   ; disable_conf_attrs: bool elt
   ; version_check: bool elt }
 

--- a/lib/Exposed.ml
+++ b/lib/Exposed.ml
@@ -144,7 +144,8 @@ module Right_angle = struct
     | Psig_kind_abbrev (_, jk) -> jkind jk
     | Psig_module _ | Psig_modsubst _ | Psig_recmodule _ | Psig_modtype _
      |Psig_modtypesubst _ | Psig_open _ | Psig_include _ | Psig_class _
-     |Psig_class_type _ | Psig_attribute _ | Psig_extension _ ->
+     |Psig_class_type _ | Psig_attribute _ | Psig_extension _
+     |Psig_hashsyntax _ ->
         false
 
   let payload = function

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1287,7 +1287,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_splice t ->
       let needs_parens =
         match t.ptyp_desc with
-        | Ptyp_var _ | Ptyp_any | Ptyp_constr (_, []) -> false
+        | Ptyp_var _ | Ptyp_constr (_, []) -> false
         | _ -> true
       in
       fmt "$"
@@ -4622,6 +4622,9 @@ and fmt_signature_item c ?ext {ast= si; _} =
   | Psig_class_type cl ->
       fmt_class_types ?ext c ctx ~pre:"class type" ~sep:"=" cl
   | Psig_typesubst decls -> fmt_type c ?ext ~eq:":=" Recursive decls ctx
+  | Psig_hashsyntax (mode, toggle) ->
+      let toggle_str = if toggle then "on" else "off" in
+      str (Printf.sprintf "#syntax %s %s" mode.txt toggle_str)
 
 and fmt_class_types ?ext c ctx ~pre ~sep cls =
   list_fl cls (fun ~first ~last:_ cl ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1285,8 +1285,14 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_quote t ->
       wrap_fits_breaks c.conf "<[" "]>" (fmt_core_type c (sub_typ ~ctx t))
   | Ptyp_splice t ->
+      let needs_parens =
+        match t.ptyp_desc with
+        | Ptyp_var _ | Ptyp_any | Ptyp_constr (_, []) -> false
+        | _ -> true
+      in
       fmt "$"
-      $ wrap_fits_breaks c.conf "(" ")" (fmt_core_type c (sub_typ ~ctx t))
+      $ Params.parens_if needs_parens c.conf
+          (fmt_core_type c (sub_typ ~ctx:(Typ typ) t))
 
 and fmt_labeled_tuple_type c lbl xtyp =
   match lbl with

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -63,8 +63,16 @@ let split_hash_bang source =
 
 let parse ?(disable_w50 = false) ?(disable_deprecated = false) parse fragment
     (conf : Conf.t) ~input_name ~source =
-  Parser_standard.Lexer.set_syntax_mode conf.opr_opts.syntax_quotations.v ;
-  Parser_extended.Lexer.set_syntax_mode conf.opr_opts.syntax_quotations.v ;
+  let config_syntax_sta =
+    Parser_standard.Lexer.Syntax_mode.
+      {quotations= conf.opr_opts.syntax_quotations.v}
+  in
+  let config_syntax_ext =
+    Parser_extended.Lexer.Syntax_mode.
+      {quotations= conf.opr_opts.syntax_quotations.v}
+  in
+  Parser_standard.Lexer.set_syntax_mode config_syntax_sta ;
+  Parser_extended.Lexer.set_syntax_mode config_syntax_ext ;
   let warnings =
     if conf.opr_opts.quiet.v then List.map ~f:W.disable W.in_lexer else []
   in

--- a/lib/Parse_with_comments.ml
+++ b/lib/Parse_with_comments.ml
@@ -63,6 +63,8 @@ let split_hash_bang source =
 
 let parse ?(disable_w50 = false) ?(disable_deprecated = false) parse fragment
     (conf : Conf.t) ~input_name ~source =
+  Parser_standard.Lexer.set_syntax_mode conf.opr_opts.syntax_quotations.v ;
+  Parser_extended.Lexer.set_syntax_mode conf.opr_opts.syntax_quotations.v ;
   let warnings =
     if conf.opr_opts.quiet.v then List.map ~f:W.disable W.in_lexer else []
   in

--- a/test/cli/print_config.t
+++ b/test/cli/print_config.t
@@ -13,6 +13,7 @@ No redundant values:
   max-iters=10
   ocaml-version=4.04.0
   quiet=false
+  syntax-quotations=false
   disable-conf-attrs=false
   version-check=true
   assignment-operator=end-line (profile conventional (file .ocamlformat:1))
@@ -93,6 +94,7 @@ Redundant values from the conventional profile:
   max-iters=10
   ocaml-version=4.04.0
   quiet=false
+  syntax-quotations=false
   disable-conf-attrs=false
   version-check=true
   assignment-operator=end-line (profile conventional (file .ocamlformat:1))
@@ -173,6 +175,7 @@ Redundant values from the ocamlformat profile:
   max-iters=10
   ocaml-version=4.04.0
   quiet=false
+  syntax-quotations=false
   disable-conf-attrs=false
   version-check=true
   assignment-operator=end-line (profile ocamlformat (file .ocamlformat:1))

--- a/test/cli/syntax_quotations.t
+++ b/test/cli/syntax_quotations.t
@@ -1,0 +1,48 @@
+  $ echo profile=default > .ocamlformat
+
+  $ echo 'let c = <[123]> in <[42 + $c]>' > a.ml
+  $ echo '#syntax quotations on
+  > let c = <[123]> in <[42 + $c]>' > bon.ml
+  $ echo '#syntax quotations off
+  > let c = <[123]> in <[42 + $c]>' > boff.ml
+  $ ocamlformat --syntax-quotations a.ml
+  let c = <[123]> in
+  <[42 + $c]>
+
+  $ ocamlformat a.ml
+  ocamlformat: ignoring "a.ml" (syntax error)
+  File "a.ml", line 1, characters 8-9:
+  1 | let c = <[123]> in <[42 + $c]>
+              ^
+  Error: Syntax error
+  [1]
+  $ ocamlformat --syntax-quotations a.ml
+  let c = <[123]> in
+  <[42 + $c]>
+  $ ocamlformat boff.ml
+  ocamlformat: ignoring "boff.ml" (syntax error)
+  File "boff.ml", line 2, characters 8-9:
+  2 | let c = <[123]> in <[42 + $c]>
+              ^
+  Error: Syntax error
+  [1]
+
+  $ ocamlformat --syntax-quotations boff.ml
+  ocamlformat: ignoring "boff.ml" (syntax error)
+  File "boff.ml", line 2, characters 8-9:
+  2 | let c = <[123]> in <[42 + $c]>
+              ^
+  Error: Syntax error
+  [1]
+
+  $ ocamlformat bon.ml
+  #syntax quotations on;;
+  
+  let c = <[123]> in
+  <[42 + $c]>
+
+  $ ocamlformat --syntax-quotations bon.ml
+  #syntax quotations on;;
+  
+  let c = <[123]> in
+  <[42 + $c]>

--- a/test/cli/syntax_quotations.t
+++ b/test/cli/syntax_quotations.t
@@ -2,9 +2,13 @@
 
   $ echo 'let c = <[123]> in <[42 + $c]>' > a.ml
   $ echo '#syntax quotations on
-  > let c = <[123]> in <[42 + $c]>' > bon.ml
+  > let c = <[123]> in <[42 + $c]>' > qon.ml
   $ echo '#syntax quotations off
-  > let c = <[123]> in <[42 + $c]>' > boff.ml
+  > let c = <[123]> in <[42 + $c]>' > qoff.ml
+  $ echo '#syntax quotations on
+  > let c = $xyz' > son.ml
+  $ echo '#syntax quotations off
+  > let c = $xyz' > soff.ml
   $ ocamlformat --syntax-quotations a.ml
   let c = <[123]> in
   <[42 + $c]>
@@ -19,30 +23,55 @@
   $ ocamlformat --syntax-quotations a.ml
   let c = <[123]> in
   <[42 + $c]>
-  $ ocamlformat boff.ml
-  ocamlformat: ignoring "boff.ml" (syntax error)
-  File "boff.ml", line 2, characters 8-9:
+  $ ocamlformat qoff.ml
+  ocamlformat: ignoring "qoff.ml" (syntax error)
+  File "qoff.ml", line 2, characters 8-9:
   2 | let c = <[123]> in <[42 + $c]>
               ^
   Error: Syntax error
   [1]
 
-  $ ocamlformat --syntax-quotations boff.ml
-  ocamlformat: ignoring "boff.ml" (syntax error)
-  File "boff.ml", line 2, characters 8-9:
+  $ ocamlformat --syntax-quotations qoff.ml
+  ocamlformat: ignoring "qoff.ml" (syntax error)
+  File "qoff.ml", line 2, characters 8-9:
   2 | let c = <[123]> in <[42 + $c]>
               ^
   Error: Syntax error
   [1]
 
-  $ ocamlformat bon.ml
+  $ ocamlformat qon.ml
   #syntax quotations on;;
   
   let c = <[123]> in
   <[42 + $c]>
 
-  $ ocamlformat --syntax-quotations bon.ml
+  $ ocamlformat --syntax-quotations qon.ml
   #syntax quotations on;;
   
   let c = <[123]> in
   <[42 + $c]>
+  $ ocamlformat soff.ml
+  ocamlformat: ignoring "soff.ml" (syntax error)
+  File "soff.ml", line 2, characters 8-9:
+  2 | let c = $xyz
+              ^
+  Error: Syntax error
+  [1]
+
+  $ ocamlformat --syntax-quotations soff.ml
+  ocamlformat: ignoring "soff.ml" (syntax error)
+  File "soff.ml", line 2, characters 8-9:
+  2 | let c = $xyz
+              ^
+  Error: Syntax error
+  [1]
+
+  $ ocamlformat son.ml
+  #syntax quotations on
+  
+  let c = $xyz
+
+  $ ocamlformat --syntax-quotations son.ml
+  #syntax quotations on
+  
+  let c = $xyz

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -10736,6 +10736,42 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to quotations.mli.stdout
+   (with-stderr-to quotations.mli.stderr
+     (setenv TERM dumb (run %{bin:ocamlformat} --margin-check %{dep:tests/quotations.mli}))))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/quotations.mli quotations.mli.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/quotations.mli.err quotations.mli.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
+  (with-stdout-to quotations.mli.js-stdout
+   (with-stderr-to quotations.mli.js-stderr
+     (setenv TERM dumb (run %{bin:ocamlformat} --profile=janestreet --enable-outside-detected-project --disable-conf-files %{dep:tests/quotations.mli}))))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/quotations.mli.js-ref quotations.mli.js-stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/quotations.mli.js-err quotations.mli.js-stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to quoted_strings.ml.stdout
    (with-stderr-to quoted_strings.ml.stderr
      (setenv TERM dumb (run %{bin:ocamlformat} --margin-check %{dep:tests/quoted_strings.ml}))))))

--- a/test/passing/tests/print_config.ml.err
+++ b/test/passing/tests/print_config.ml.err
@@ -6,6 +6,7 @@ margin-check=true (command line)
 max-iters=2 (environment variable)
 ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 quiet=false
+syntax-quotations=false
 disable-conf-attrs=false
 version-check=true
 assignment-operator=end-line (profile ocamlformat (file tests/.ocamlformat:1))

--- a/test/passing/tests/quotations.ml
+++ b/test/passing/tests/quotations.ml
@@ -27,7 +27,7 @@ let even_longer m n =
 type s = <[int]>
 type t = s expr
 
-let f (x : t) : <[$(s) * $(s)]> expr = <[$x, $x + 1]>
+let f (x : t) : <[$s * $s]> expr = <[$x, $x + 1]>
 
 let double =
   <[ let x = <[42]> in

--- a/test/passing/tests/quotations.ml.js-ref
+++ b/test/passing/tests/quotations.ml.js-ref
@@ -27,7 +27,7 @@ let even_longer m n =
 type s = <[int]>
 type t = s expr
 
-let f (x : t) : <[$(s) * $(s)]> expr = <[$x, $x + 1]>
+let f (x : t) : <[$s * $s]> expr = <[$x, $x + 1]>
 
 let double =
   <[ let x = <[42]> in

--- a/test/passing/tests/quotations.mli
+++ b/test/passing/tests/quotations.mli
@@ -1,0 +1,7 @@
+#syntax quotations on
+
+type t = <[int]>
+
+type 'a t = <[$'a list -> $'a option]>
+
+val foo : <[int]> expr

--- a/test/passing/tests/quotations.mli.js-ref
+++ b/test/passing/tests/quotations.mli.js-ref
@@ -1,0 +1,6 @@
+#syntax quotations on
+
+type t = <[int]>
+type 'a t = <[$'a list -> $'a option]>
+
+val foo : <[int]> expr

--- a/test/passing/tests/verbose1.ml.err
+++ b/test/passing/tests/verbose1.ml.err
@@ -6,6 +6,7 @@ margin-check=true (command line)
 max-iters=2 (file tests/.ocamlformat:6)
 ocaml-version=4.13.0 (file tests/.ocamlformat:7)
 quiet=false
+syntax-quotations=false
 disable-conf-attrs=false
 version-check=true
 assignment-operator=end-line (profile ocamlformat (file tests/.ocamlformat:1))

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,4 +1,4 @@
 (test
  (name test_unit)
  (package ocamlformat-lib)
- (libraries alcotest base ocamlformat-lib))
+ (libraries alcotest base ocamlformat-lib ocamlformat_config))

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -1,4 +1,4 @@
 (test
  (name test_unit)
  (package ocamlformat-lib)
- (libraries alcotest base ocamlformat-lib ocamlformat_config))
+ (libraries alcotest base ocamlformat-lib))

--- a/vendor/parser-extended/ast_helper.ml
+++ b/vendor/parser-extended/ast_helper.ml
@@ -267,6 +267,7 @@ module Sig = struct
   let class_type ?loc a = mk ?loc (Psig_class_type a)
   let extension ?loc ?(attrs = []) a = mk ?loc (Psig_extension (a, attrs))
   let attribute ?loc a = mk ?loc (Psig_attribute a)
+  let hashsyntax ?loc mode toggle = mk ?loc (Psig_hashsyntax (mode, toggle))
   let text txt =
     let f_txt = List.filter (fun ds -> docstring_body ds <> "") txt in
     List.map

--- a/vendor/parser-extended/ast_mapper.ml
+++ b/vendor/parser-extended/ast_mapper.ml
@@ -468,6 +468,7 @@ module MT = struct
         let attrs = sub.attributes sub attrs in
         extension ~loc ~attrs (sub.extension sub x)
     | Psig_attribute x -> attribute ~loc (sub.attribute sub x)
+    | Psig_hashsyntax (mode, toggle) -> hashsyntax ~loc mode toggle
 end
 
 

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -132,8 +132,8 @@ module Syntax_mode = struct
   let quotations = ref false
 end
 
-let reset_syntax_mode () =
-  Syntax_mode.quotations := false
+let set_syntax_mode syntax_mode =
+  Syntax_mode.quotations := syntax_mode
 
 (* See the comment on the [directive] lexer. *)
 type directive_lexing_already_consumed =
@@ -912,7 +912,8 @@ and directive already_consumed = parse
         in (
           match mode with
             | "quotations" ->
-                Syntax_mode.quotations := toggle;
+                enqueue_token_from_end_of_lexbuf_window lexbuf SEMISEMI ~len:0;
+                Syntax_mode.quotations := toggle
             | _ ->
                 directive_error lexbuf ("unknown syntax mode " ^ mode)
                   ~already_consumed ~directive:"syntax"

--- a/vendor/parser-extended/lexer.mll
+++ b/vendor/parser-extended/lexer.mll
@@ -129,11 +129,12 @@ let at_beginning_of_line pos = (pos.pos_cnum = pos.pos_bol)
 
 (* Syntax mode configuration for the #syntax directive *)
 module Syntax_mode = struct
+  type config = { quotations : bool }
   let quotations = ref false
 end
 
-let set_syntax_mode syntax_mode =
-  Syntax_mode.quotations := syntax_mode
+let set_syntax_mode ({ quotations } : Syntax_mode.config) =
+  Syntax_mode.quotations := quotations
 
 (* See the comment on the [directive] lexer. *)
 type directive_lexing_already_consumed =

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -2014,6 +2014,9 @@ signature_item:
   | kind_abbreviation_decl
       { let name, jkind = $1 in
         mksig ~loc:$sloc (Psig_kind_abbrev (name, jkind)) }
+  | HASH_SYNTAX
+      { let mode, toggle = $1 in
+        mksig ~loc:$sloc (Psig_hashsyntax (mkloc mode (make_loc $sloc), toggle)) }
 
 (* A module declaration. *)
 %inline module_declaration:

--- a/vendor/parser-extended/parsetree.mli
+++ b/vendor/parser-extended/parsetree.mli
@@ -1120,6 +1120,7 @@ and signature_item_desc =
       (** [class type ct1 = ... and ... and ctn = ...] *)
   | Psig_attribute of attribute  (** [[\@\@\@id]] *)
   | Psig_extension of extension * attributes  (** [[%%id]] *)
+  | Psig_hashsyntax of string loc * bool  (** [#syntax quotations on]: mode * toggle *)
 
 and module_declaration =
     {

--- a/vendor/parser-extended/printast.ml
+++ b/vendor/parser-extended/printast.ml
@@ -1126,6 +1126,9 @@ and signature_item i ppf x =
       payload i ppf arg
   | Psig_attribute a ->
       attribute i ppf "Psig_attribute" a
+  | Psig_hashsyntax (mode, toggle) ->
+      line i ppf "Psig_hashsyntax %a %s\n" fmt_string_loc mode
+        (if toggle then "on" else "off")
 
 and modtype_declaration i ppf = function
   | None -> line i ppf "#abstract"

--- a/vendor/parser-standard/lexer.mll
+++ b/vendor/parser-standard/lexer.mll
@@ -165,8 +165,8 @@ module Syntax_mode = struct
   let quotations = ref false
 end
 
-let reset_syntax_mode () =
-  Syntax_mode.quotations := false
+let set_syntax_mode syntax_mode =
+  Syntax_mode.quotations := syntax_mode
 
 (* See the comment on the [directive] lexer. *)
 type directive_lexing_already_consumed =
@@ -917,8 +917,10 @@ and directive already_consumed = parse
         in (
           match mode with
             | "quotations" ->
+                let tok = token lexbuf in
+                enqueue_token_from_end_of_lexbuf_window lexbuf SEMISEMI ~len:0;
                 Syntax_mode.quotations := toggle;
-                token lexbuf
+                tok
             | _ ->
                 directive_error lexbuf ("unknown syntax mode " ^ mode)
                   ~already_consumed ~directive:"syntax"

--- a/vendor/parser-standard/lexer.mll
+++ b/vendor/parser-standard/lexer.mll
@@ -162,11 +162,12 @@ let at_beginning_of_line pos = (pos.pos_cnum = pos.pos_bol)
 
 (* Syntax mode configuration for the #syntax directive *)
 module Syntax_mode = struct
+  type config = { quotations : bool }
   let quotations = ref false
 end
 
-let set_syntax_mode syntax_mode =
-  Syntax_mode.quotations := syntax_mode
+let set_syntax_mode ({ quotations } : Syntax_mode.config) =
+  Syntax_mode.quotations := quotations
 
 (* See the comment on the [directive] lexer. *)
 type directive_lexing_already_consumed =


### PR DESCRIPTION
Currently, the only way to toggle runtime metaprogramming support in ocamlformat is through the `#syntax` directive. This contrasts with the fact that OxCaml can be configured to support quotations syntax and that the `#syntax` directive is not mandatory. A `syntax-quotations` configuration option is added to ocamlformat to enable/disable runtime metaprogramming.

This mainly affects lexer semantics. The option is read immediately prior to the invocation of the lexer and the syntax mode is adjusted.

Two drive-by fixes are made: how `#syntax` is processed and when parentheses are placed around splice type expressions.

A change is made to the lexers so that `SEMISEMI` tokens are inserted after the `syntax` directive. This tracks with a concurrent OxCaml PR, which fixes toplevel behaviour and allows certain expressions immediately after the directive to be correctly parsed (for example, the ones in `syntax_quotations.t`). This is done concurrently to ensure the tests of the `syntax-quotations` option are exhaustive and not buggy.

Parentheses are no longer placed around type variables being spliced e.g. `$'a` is preferred to `$('a)`.

