### PR TITLE
Expression quotes add spaces

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -3443,7 +3443,7 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
       pro
       $ hvbox 0
           (Params.Exp.wrap c.conf ~parens
-             ( wrap_fits_breaks ~space:true c.conf "<[" "]>"
+             ( wrap_fits_breaks ~space:false c.conf "<[ " " ]>"
                  (fmt_expression c ~box ?eol ~parens:false ~indent_wrap ?ext
                     (sub_exp ~ctx expr) )
              $ fmt_atrs ) )

--- a/test/cli/syntax_quotations.t
+++ b/test/cli/syntax_quotations.t
@@ -10,8 +10,8 @@
   $ echo '#syntax quotations off
   > let c = $xyz' > soff.ml
   $ ocamlformat --syntax-quotations a.ml
-  let c = <[123]> in
-  <[42 + $c]>
+  let c = <[ 123 ]> in
+  <[ 42 + $c ]>
 
   $ ocamlformat a.ml
   ocamlformat: ignoring "a.ml" (syntax error)
@@ -21,8 +21,8 @@
   Error: Syntax error
   [1]
   $ ocamlformat --syntax-quotations a.ml
-  let c = <[123]> in
-  <[42 + $c]>
+  let c = <[ 123 ]> in
+  <[ 42 + $c ]>
   $ ocamlformat qoff.ml
   ocamlformat: ignoring "qoff.ml" (syntax error)
   File "qoff.ml", line 2, characters 8-9:
@@ -42,14 +42,14 @@
   $ ocamlformat qon.ml
   #syntax quotations on;;
   
-  let c = <[123]> in
-  <[42 + $c]>
+  let c = <[ 123 ]> in
+  <[ 42 + $c ]>
 
   $ ocamlformat --syntax-quotations qon.ml
   #syntax quotations on;;
   
-  let c = <[123]> in
-  <[42 + $c]>
+  let c = <[ 123 ]> in
+  <[ 42 + $c ]>
   $ ocamlformat soff.ml
   ocamlformat: ignoring "soff.ml" (syntax error)
   File "soff.ml", line 2, characters 8-9:

--- a/test/passing/tests/quotations.ml
+++ b/test/passing/tests/quotations.ml
@@ -1,37 +1,37 @@
 #syntax quotations on
 
-let simple_number = <[123]>
+let simple_number = <[ 123 ]>
 
 let npower x_quoted n =
-  let rec loop m = if m = 0 then <[1]> else <[$x_quoted * $(loop (m - 1))]> in
+  let rec loop m = if m = 0 then <[ 1 ]> else <[ $x_quoted * $(loop (m - 1)) ]> in
   loop n
 ;;
 
-let example_function n = <[fun x -> $(npower <[x]> n)]>
+let example_function n = <[ fun x -> $(npower <[ x ]> n) ]>
 
 let longer_example m n =
-  let first_quote = <[fun x -> $(npower <[x]> m)]> in
-  let second_quote = <[fun y -> $(npower <[y]> n)]> in
-  let combined_quote = <[fun x -> $second_quote ($first_quote x)]> in
-  <[$combined_quote, $combined_quote]>
+  let first_quote = <[ fun x -> $(npower <[ x ]> m) ]> in
+  let second_quote = <[ fun y -> $(npower <[ y ]> n) ]> in
+  let combined_quote = <[ fun x -> $second_quote ($first_quote x) ]> in
+  <[ $combined_quote, $combined_quote ]>
 ;;
 
 let even_longer m n =
   <[ fun x y ->
-     let xm = $(npower <[x]> m) in
-     let yn = $(npower <[y]> n) in
+     let xm = $(npower <[ x ]> m) in
+     let yn = $(npower <[ y ]> n) in
      let z = xm + yn in
-     $(npower <[z]> (m + n)) ]>
+     $(npower <[ z ]> (m + n)) ]>
 ;;
 
 type s = <[int]>
 type t = s expr
 
-let f (x : t) : <[$s * $s]> expr = <[$x, $x + 1]>
+let f (x : t) : <[$s * $s]> expr = <[ $x, $x + 1 ]>
 
 let double =
-  <[ let x = <[42]> in
-     <[123 + $x]> ]>
+  <[ let x = <[ 42 ]> in
+     <[ 123 + $x ]> ]>
 ;;
 
 (* Long lines and breaks *)
@@ -50,12 +50,12 @@ let _ =
        zzzzzzzzzzzzzzzzzzzzzzz ->
      $( <[ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
            + yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ]>
-      , <[zzzzzzzzzzzzzzzzzzzzzzz]> ) ]>
+      , <[ zzzzzzzzzzzzzzzzzzzzzzz ]> ) ]>
 ;;
 
 let _ =
   let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx =
-    <[fun aaaaaaaaaaaaaaaaaaaaa -> aaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaa]>
+    <[ fun aaaaaaaaaaaaaaaaaaaaa -> aaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaa ]>
   in
   <[ ( $xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      , $xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -65,7 +65,7 @@ let _ =
 let _ =
   fun xxxxxxxxxxxxxxxxxxxx ->
   <[ fun zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ->
-     $((fun yyyyyyyyyyyyyyyyyyyy -> <[zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz + 42]>)
+     $((fun yyyyyyyyyyyyyyyyyyyy -> <[ zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz + 42 ]>)
          xxxxxxxxxxxxxxxxxxxx) ]>
 ;;
 
@@ -106,7 +106,7 @@ let _ =
      $((* 6 *)
          (fun (* 7 *)
               (* 8 *) y (* 9 *) -> (* 10 *) y (* 11 *))
-         (* 12 *) <[(* 13 *) x (* 14 *)]> (* 15 *))
+         (* 12 *) <[ (* 13 *) x (* 14 *) ]> (* 15 *))
      (* 16 *) ]>
 ;;
 
@@ -118,8 +118,8 @@ type 'a t = <[int (* 1 *) -> $('a (* 2 *) -> 'a (* 3 *) -> <[int]> (* 4 *)) (* 5
 (* Attributes *)
 
 let _ =
-  <[ (fun xxxxxxxxxxxxx -> (555555 + xxxxxxxxxxxxx) [@nontail]) 1111333333777777 [@inlined]
-  ]>
+  <[ (fun xxxxxxxxxxxxx -> (555555 + xxxxxxxxxxxxx) [@nontail])
+       1111333333777777 [@inlined] ]>
 ;;
 
-let _ = <[fun x -> $((fun y -> y) (<[x]> [@nontail])) [@inlined]]> [@boxed]
+let _ = <[ fun x -> $((fun y -> y) (<[ x ]> [@nontail])) [@inlined] ]> [@boxed]

--- a/test/passing/tests/quotations.ml.err
+++ b/test/passing/tests/quotations.ml.err
@@ -1,1 +1,0 @@
-Warning: tests/quotations.ml:120 exceeds the margin

--- a/test/passing/tests/quotations.ml.js-ref
+++ b/test/passing/tests/quotations.ml.js-ref
@@ -1,37 +1,37 @@
 #syntax quotations on
 
-let simple_number = <[123]>
+let simple_number = <[ 123 ]>
 
 let npower x_quoted n =
-  let rec loop m = if m = 0 then <[1]> else <[$x_quoted * $(loop (m - 1))]> in
+  let rec loop m = if m = 0 then <[ 1 ]> else <[ $x_quoted * $(loop (m - 1)) ]> in
   loop n
 ;;
 
-let example_function n = <[fun x -> $(npower <[x]> n)]>
+let example_function n = <[ fun x -> $(npower <[ x ]> n) ]>
 
 let longer_example m n =
-  let first_quote = <[fun x -> $(npower <[x]> m)]> in
-  let second_quote = <[fun y -> $(npower <[y]> n)]> in
-  let combined_quote = <[fun x -> $second_quote ($first_quote x)]> in
-  <[$combined_quote, $combined_quote]>
+  let first_quote = <[ fun x -> $(npower <[ x ]> m) ]> in
+  let second_quote = <[ fun y -> $(npower <[ y ]> n) ]> in
+  let combined_quote = <[ fun x -> $second_quote ($first_quote x) ]> in
+  <[ $combined_quote, $combined_quote ]>
 ;;
 
 let even_longer m n =
   <[ fun x y ->
-     let xm = $(npower <[x]> m) in
-     let yn = $(npower <[y]> n) in
+     let xm = $(npower <[ x ]> m) in
+     let yn = $(npower <[ y ]> n) in
      let z = xm + yn in
-     $(npower <[z]> (m + n)) ]>
+     $(npower <[ z ]> (m + n)) ]>
 ;;
 
 type s = <[int]>
 type t = s expr
 
-let f (x : t) : <[$s * $s]> expr = <[$x, $x + 1]>
+let f (x : t) : <[$s * $s]> expr = <[ $x, $x + 1 ]>
 
 let double =
-  <[ let x = <[42]> in
-     <[123 + $x]> ]>
+  <[ let x = <[ 42 ]> in
+     <[ 123 + $x ]> ]>
 ;;
 
 (* Long lines and breaks *)
@@ -50,12 +50,12 @@ let _ =
        zzzzzzzzzzzzzzzzzzzzzzz ->
      $( <[ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
            + yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ]>
-      , <[zzzzzzzzzzzzzzzzzzzzzzz]> ) ]>
+      , <[ zzzzzzzzzzzzzzzzzzzzzzz ]> ) ]>
 ;;
 
 let _ =
   let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx =
-    <[fun aaaaaaaaaaaaaaaaaaaaa -> aaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaa]>
+    <[ fun aaaaaaaaaaaaaaaaaaaaa -> aaaaaaaaaaaaaaaaaaaaa, aaaaaaaaaaaaaaaaaaaaa ]>
   in
   <[ ( $xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
      , $xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -65,7 +65,7 @@ let _ =
 let _ =
   fun xxxxxxxxxxxxxxxxxxxx ->
   <[ fun zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz ->
-     $((fun yyyyyyyyyyyyyyyyyyyy -> <[zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz + 42]>)
+     $((fun yyyyyyyyyyyyyyyyyyyy -> <[ zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz + 42 ]>)
          xxxxxxxxxxxxxxxxxxxx) ]>
 ;;
 
@@ -106,7 +106,7 @@ let _ =
      $((* 6 *)
          (fun (* 7 *)
               (* 8 *) y (* 9 *) -> (* 10 *) y (* 11 *))
-         (* 12 *) <[(* 13 *) x (* 14 *)]> (* 15 *))
+         (* 12 *) <[ (* 13 *) x (* 14 *) ]> (* 15 *))
      (* 16 *) ]>
 ;;
 
@@ -118,8 +118,8 @@ type 'a t = <[int (* 1 *) -> $('a (* 2 *) -> 'a (* 3 *) -> <[int]> (* 4 *)) (* 5
 (* Attributes *)
 
 let _ =
-  <[ (fun xxxxxxxxxxxxx -> (555555 + xxxxxxxxxxxxx) [@nontail]) 1111333333777777 [@inlined]
-  ]>
+  <[ (fun xxxxxxxxxxxxx -> (555555 + xxxxxxxxxxxxx) [@nontail])
+       1111333333777777 [@inlined] ]>
 ;;
 
-let _ = <[fun x -> $((fun y -> y) (<[x]> [@nontail])) [@inlined]]> [@boxed]
+let _ = <[ fun x -> $((fun y -> y) (<[ x ]> [@nontail])) [@inlined] ]> [@boxed]


### PR DESCRIPTION
We were previously only adding spaces for multiline quotes, e.g.
```
<[ let x = ... in
     ... ]>
```

This PR always adds spaces for quotes of expressions. Instead of:
```
<[let x = ... in ...]>
```
we get:
```
<[ let x = ... in ... ]>
```
Similarly, `<[x]>` is now `<[ x ]>`.
See the diff for more examples.

Existing tests should be sufficient. I'd only be worried about weird wrapping behaviour, but I'm not sure what tests to add for that.

Quotes of types do not add spaces like before.