### PR TITLE
Always use `@ local` rather than `local_` syntax in types

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1137,8 +1137,11 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
   | Ptyp_arrow (args, ret_typ, modes) ->
       Cmts.relocate c.cmts ~src:ptyp_loc
         ~before:(List.hd_exn args).pap_type.ptyp_loc ~after:ret_typ.ptyp_loc ;
-      let args, ret_typ, ctx =
-        Sugar.decompose_arrow ctx args (ret_typ, modes)
+      let ret_typ =
+        { pap_label= Nolabel
+        ; pap_loc= ret_typ.ptyp_loc
+        ; pap_type= ret_typ
+        ; pap_modes= modes }
       in
       let indent =
         match pro with

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -989,19 +989,7 @@ and fmt_jkind_constr c ~ctx jkind =
 (* Jane street: This is used to print both arrow param types and arrow return
    types. The ~return parameter distinguishes. *)
 and fmt_arrow_param ~return c ctx
-    ({pap_label= lI; pap_loc= locI; pap_type= tI; pap_modes= mI}, localI) =
-  (* Jane Street: legacy [local_ T] in type position is rewritten to the
-     modal form [T @ local] by folding the [local] mode into [pap_modes]. The
-     parser sorts modes alphabetically (parser.mly:mode_expr), so we insert
-     [local] in sorted position. *)
-  let mI =
-    if localI then
-      let local_mode = {txt= Mode "local"; loc= locI} in
-      List.sort (local_mode :: mI) ~compare:(fun ma mb ->
-          let (Mode a) = ma.txt and (Mode b) = mb.txt in
-          String.compare a b )
-    else mI
-  in
+    {pap_label= lI; pap_loc= locI; pap_type= tI; pap_modes= mI} =
   let arg_label lbl =
     match lbl with
     | Nolabel -> None
@@ -1010,10 +998,8 @@ and fmt_arrow_param ~return c ctx
   in
   let xtI = sub_typ ~ctx tI in
   (* Jane Street: as a special case, labeled tuple types in function returns
-     need parens if the return has modes AND the first element has a label.
-     We _should_ put this logic in [parenze_typ] or a similar place, but we
-     can't because of the horrible hack where the attribute encoding [local_]
-     is actually removed from the type before printing it. *)
+     need parens if the return has modes AND the first element has a
+     label. *)
   let labeled_tuple_ret_parens =
     return
     && (not (List.is_empty mI))
@@ -1152,7 +1138,7 @@ and fmt_core_type c ?(box = true) ?pro ?(pro_space = true) ?constraint_ctx
       Cmts.relocate c.cmts ~src:ptyp_loc
         ~before:(List.hd_exn args).pap_type.ptyp_loc ~after:ret_typ.ptyp_loc ;
       let args, ret_typ, ctx =
-        Sugar.decompose_arrow c.cmts ctx args (ret_typ, modes)
+        Sugar.decompose_arrow ctx args (ret_typ, modes)
       in
       let indent =
         match pro with
@@ -3633,7 +3619,6 @@ and fmt_class_type ?(pro = noop) c ({ast= typ; _} as xtyp) =
   | Pcty_arrow (args, rhs) ->
       Cmts.relocate c.cmts ~src:pcty_loc
         ~before:(List.hd_exn args).pap_type.ptyp_loc ~after:rhs.pcty_loc ;
-      let args = List.map ~f:(fun arg -> (arg, false)) args in
       let pro =
         pro ~cmt:true
         $ fmt_arrow_type c ~ctx ~parens:false ~parent_has_parens:parens args

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -990,23 +990,33 @@ and fmt_jkind_constr c ~ctx jkind =
    types. The ~return parameter distinguishes. *)
 and fmt_arrow_param ~return c ctx
     ({pap_label= lI; pap_loc= locI; pap_type= tI; pap_modes= mI}, localI) =
+  (* Jane Street: legacy [local_ T] in type position is rewritten to the
+     modal form [T @ local] by folding the [local] mode into [pap_modes]. The
+     parser sorts modes alphabetically (parser.mly:mode_expr), so we insert
+     [local] in sorted position. *)
+  let mI =
+    if localI then
+      let local_mode = {txt= Mode "local"; loc= locI} in
+      List.sort (local_mode :: mI) ~compare:(fun ma mb ->
+          let (Mode a) = ma.txt and (Mode b) = mb.txt in
+          String.compare a b )
+    else mI
+  in
   let arg_label lbl =
     match lbl with
-    | Nolabel -> if localI then Some (str "local_ ") else None
-    | Labelled l -> Some (str l.txt $ fmt ":@," $ fmt_if localI "local_ ")
-    | Optional l ->
-        Some (str "?" $ str l.txt $ fmt ":@," $ fmt_if localI "local_ ")
+    | Nolabel -> None
+    | Labelled l -> Some (str l.txt $ fmt ":@,")
+    | Optional l -> Some (str "?" $ str l.txt $ fmt ":@,")
   in
   let xtI = sub_typ ~ctx tI in
   (* Jane Street: as a special case, labeled tuple types in function returns
-     need parens if the return is [local_] or has modes AND the first element
-     has a label. We _should_ put this logic in [parenze_typ] or a similar
-     place, but we can't because of the horrible hack where the attribute
-     encoding [local_] is actually removed from the type before printing
-     it. *)
+     need parens if the return has modes AND the first element has a label.
+     We _should_ put this logic in [parenze_typ] or a similar place, but we
+     can't because of the horrible hack where the attribute encoding [local_]
+     is actually removed from the type before printing it. *)
   let labeled_tuple_ret_parens =
     return
-    && (localI || not (List.is_empty mI))
+    && (not (List.is_empty mI))
     &&
     match tI.ptyp_desc with
     | Ptyp_tuple ((Some _, _) :: _) -> true

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -208,6 +208,52 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
      declarations, types, and patterns; checking there explicitly ensures we
      don't confuse them with the existing [let[@local always] f x = x]
      attribute, which occurs at a different level. *)
+  let extract_local_attr attrs =
+    let local_attrs, rest =
+      List.partition_tf attrs ~f:(fun attr ->
+          Conf.is_jane_street_local_annotation "local"
+            ~test:attr.attr_name.txt )
+    in
+    (rest, not (List.is_empty local_attrs))
+  in
+  let sort_modes =
+    List.sort
+      ~compare:(fun (ma : mode Asttypes.loc) (mb : mode Asttypes.loc) ->
+        let (Mode a) = ma.txt and (Mode b) = mb.txt in
+        String.compare a b )
+  in
+  let inject_local_into_modes modes =
+    let local_mode : mode Asttypes.loc =
+      {txt= Mode "local"; loc= Location.none}
+    in
+    sort_modes (local_mode :: modes)
+  in
+  let canonicalize_arrow_param ap =
+    let ptyp_attributes, has_local =
+      extract_local_attr ap.pap_type.ptyp_attributes
+    in
+    if has_local then
+      { ap with
+        pap_type= {ap.pap_type with ptyp_attributes}
+      ; pap_modes= inject_local_into_modes ap.pap_modes }
+    else ap
+  in
+  let canonicalize_arrow typ =
+    match typ.ptyp_desc with
+    | Ptyp_arrow (params, ret, ret_modes) ->
+        let params = List.map params ~f:canonicalize_arrow_param in
+        let ret_attrs, ret_has_local =
+          extract_local_attr ret.ptyp_attributes
+        in
+        let ret, ret_modes =
+          if ret_has_local then
+            ( {ret with ptyp_attributes= ret_attrs}
+            , inject_local_into_modes ret_modes )
+          else (ret, ret_modes)
+        in
+        {typ with ptyp_desc= Ptyp_arrow (params, ret, ret_modes)}
+    | _ -> typ
+  in
   let typ (m : Ast_mapper.mapper) typ =
     (* Types also need their location stack cleared *)
     let typ = {typ with ptyp_loc_stack= []} in
@@ -216,6 +262,10 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
         ptyp_attributes=
           normalize_jane_street_local_annotations typ.ptyp_attributes }
     in
+    (* Jane Street: canonicalize legacy [local_ T] arrow params to the modal
+       form [T @ local] so that the equality check accepts both spellings as
+       equivalent. *)
+    let typ = canonicalize_arrow typ in
     Ast_mapper.default_mapper.typ m typ
   in
   let pat (m : Ast_mapper.mapper) pat =

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -208,52 +208,6 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
      declarations, types, and patterns; checking there explicitly ensures we
      don't confuse them with the existing [let[@local always] f x = x]
      attribute, which occurs at a different level. *)
-  let extract_local_attr attrs =
-    let local_attrs, rest =
-      List.partition_tf attrs ~f:(fun attr ->
-          Conf.is_jane_street_local_annotation "local"
-            ~test:attr.attr_name.txt )
-    in
-    (rest, not (List.is_empty local_attrs))
-  in
-  let sort_modes =
-    List.sort
-      ~compare:(fun (ma : mode Asttypes.loc) (mb : mode Asttypes.loc) ->
-        let (Mode a) = ma.txt and (Mode b) = mb.txt in
-        String.compare a b )
-  in
-  let inject_local_into_modes modes =
-    let local_mode : mode Asttypes.loc =
-      {txt= Mode "local"; loc= Location.none}
-    in
-    sort_modes (local_mode :: modes)
-  in
-  let canonicalize_arrow_param ap =
-    let ptyp_attributes, has_local =
-      extract_local_attr ap.pap_type.ptyp_attributes
-    in
-    if has_local then
-      { ap with
-        pap_type= {ap.pap_type with ptyp_attributes}
-      ; pap_modes= inject_local_into_modes ap.pap_modes }
-    else ap
-  in
-  let canonicalize_arrow typ =
-    match typ.ptyp_desc with
-    | Ptyp_arrow (params, ret, ret_modes) ->
-        let params = List.map params ~f:canonicalize_arrow_param in
-        let ret_attrs, ret_has_local =
-          extract_local_attr ret.ptyp_attributes
-        in
-        let ret, ret_modes =
-          if ret_has_local then
-            ( {ret with ptyp_attributes= ret_attrs}
-            , inject_local_into_modes ret_modes )
-          else (ret, ret_modes)
-        in
-        {typ with ptyp_desc= Ptyp_arrow (params, ret, ret_modes)}
-    | _ -> typ
-  in
   let typ (m : Ast_mapper.mapper) typ =
     (* Types also need their location stack cleared *)
     let typ = {typ with ptyp_loc_stack= []} in
@@ -262,10 +216,6 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
         ptyp_attributes=
           normalize_jane_street_local_annotations typ.ptyp_attributes }
     in
-    (* Jane Street: canonicalize legacy [local_ T] arrow params to the modal
-       form [T @ local] so that the equality check accepts both spellings as
-       equivalent. *)
-    let typ = canonicalize_arrow typ in
     Ast_mapper.default_mapper.typ m typ
   in
   let pat (m : Ast_mapper.mapper) pat =

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -30,10 +30,7 @@ let check_local_attr_and_reloc_cmts cmts attrs loc =
 
 let decompose_arrow ctx ctl (ct2, m2) =
   let res =
-    { pap_label= Nolabel
-    ; pap_loc= ct2.ptyp_loc
-    ; pap_type= ct2
-    ; pap_modes= m2 }
+    {pap_label= Nolabel; pap_loc= ct2.ptyp_loc; pap_type= ct2; pap_modes= m2}
   in
   (ctl, res, ctx)
 

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -28,12 +28,6 @@ let check_local_attr_and_reloc_cmts cmts attrs loc =
       (rest, true)
   | _, _ -> (attrs, false)
 
-let decompose_arrow ctx ctl (ct2, m2) =
-  let res =
-    {pap_label= Nolabel; pap_loc= ct2.ptyp_loc; pap_type= ct2; pap_modes= m2}
-  in
-  (ctl, res, ctx)
-
 let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
   let rec fun_ ?(will_keep_first_ast_node = false) ({ast= exp; _} as xexp) =
     let ctx = Exp exp in

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -28,43 +28,14 @@ let check_local_attr_and_reloc_cmts cmts attrs loc =
       (rest, true)
   | _, _ -> (attrs, false)
 
-(* This function pulls apart an arrow type, pulling out local attributes into
-   bools and producing a context without those attributes. This addresses the
-   problem that we need to remove the local attributes so that they can be
-   printed specially, and that the context needs to be updated to reflect
-   this to pass some internal ocamlformat sanity checks. It's not the
-   cleanest solution in a vacuum, but is perhaps the one that will cause the
-   fewest merge conflicts in the future. *)
-let decompose_arrow cmts ctx ctl (ct2, m2) =
-  let pull_out_local ap =
-    let ptyp_attributes, local =
-      check_local_attr_and_reloc_cmts cmts ap.pap_type.ptyp_attributes
-        ap.pap_type.ptyp_loc
-    in
-    ({ap with pap_type= {ap.pap_type with ptyp_attributes}}, local)
+let decompose_arrow ctx ctl (ct2, m2) =
+  let res =
+    { pap_label= Nolabel
+    ; pap_loc= ct2.ptyp_loc
+    ; pap_type= ct2
+    ; pap_modes= m2 }
   in
-  let args = List.map ~f:pull_out_local ctl in
-  let ((res_ap, _) as res) =
-    let ptyp_attributes, local =
-      check_local_attr_and_reloc_cmts cmts ct2.ptyp_attributes ct2.ptyp_loc
-    in
-    let ap =
-      { pap_label= Nolabel
-      ; pap_loc= ct2.ptyp_loc
-      ; pap_type= {ct2 with ptyp_attributes}
-      ; pap_modes= m2 }
-    in
-    (ap, local)
-  in
-  let ctx_typ =
-    Ptyp_arrow (List.map ~f:fst args, res_ap.pap_type, res_ap.pap_modes)
-  in
-  let ctx =
-    match ctx with
-    | Typ cty -> Typ {cty with ptyp_desc= ctx_typ}
-    | _ -> assert false
-  in
-  (args, res, ctx)
+  (ctl, res, ctx)
 
 let fun_ cmts ?(will_keep_first_ast_node = true) xexp =
   let rec fun_ ?(will_keep_first_ast_node = false) ({ast= exp; _} as xexp) =

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -13,15 +13,6 @@ open Migrate_ast
 open Asttypes
 open Extended_ast
 
-val decompose_arrow :
-     Ast.t
-  -> arrow_param list
-  -> core_type * mode loc list
-  -> arrow_param list * arrow_param * Ast.t
-(** [decompose_arrow ctx ctl (ct2, m2)] returns a list of arrow params,
-    where the last is a dummy param corresponding to ct2 (the return type)
-    with modes m2. *)
-
 val fun_ :
      Cmts.t
   -> ?will_keep_first_ast_node:bool

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -14,16 +14,13 @@ open Asttypes
 open Extended_ast
 
 val decompose_arrow :
-     Cmts.t
-  -> Ast.t
+     Ast.t
   -> arrow_param list
   -> core_type * mode loc list
-  -> (arrow_param * bool) list * (arrow_param * bool) * Ast.t
-(** [decompose_arrow ctl ct2] returns a list of arrow params, where the last
-    is a dummy param corresponding to ct2 (the return type) and a bool
-    indicating the presence of a local attribute (which has been removed).
-    The returned Ast.t is a ctx that has similarly been updated to remove the
-    attributes *)
+  -> arrow_param list * arrow_param * Ast.t
+(** [decompose_arrow ctx ctl (ct2, m2)] returns a list of arrow params,
+    where the last is a dummy param corresponding to ct2 (the return type)
+    with modes m2. *)
 
 val fun_ :
      Cmts.t

--- a/test/passing/dune.inc
+++ b/test/passing/dune.inc
@@ -8603,6 +8603,24 @@
  (deps tests/.ocamlformat )
  (package ocamlformat)
  (action
+  (with-stdout-to local_to_at_local.ml.stdout
+   (with-stderr-to local_to_at_local.ml.stderr
+     (setenv TERM dumb (run %{bin:ocamlformat} --margin-check %{dep:tests/local_to_at_local.ml}))))))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local_to_at_local.ml.ref local_to_at_local.ml.stdout)))
+
+(rule
+ (alias runtest)
+ (package ocamlformat)
+ (action (diff tests/local_to_at_local.ml.err local_to_at_local.ml.stderr)))
+
+(rule
+ (deps tests/.ocamlformat )
+ (package ocamlformat)
+ (action
   (with-stdout-to locally_abtract_types.ml.stdout
    (with-stderr-to locally_abtract_types.ml.stderr
      (setenv TERM dumb (run %{bin:ocamlformat} --margin-check %{dep:tests/locally_abtract_types.ml}))))))

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli
@@ -81,5 +81,5 @@ external f :
 val state_float :
   ('a : float64) 'e 'f.
      name:string
-  -> on_event:(local_ 'e -> 'a -> 'a)
+  -> on_event:('e @ local -> 'a -> 'a)
   -> ('e Event.t -> ('a, 'f) t) Unregistered.t

--- a/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
+++ b/test/passing/tests/explicitly_quantified_value_descriptions.mli.js-ref
@@ -78,5 +78,5 @@ external f
 val state_float
   : ('a : float64) 'e 'f.
   name:string
-  -> on_event:(local_ 'e -> 'a -> 'a)
+  -> on_event:('e @ local -> 'a -> 'a)
   -> ('e Event.t -> ('a, 'f) t) Unregistered.t

--- a/test/passing/tests/labeled_tuples_regressions.ml.js-ref
+++ b/test/passing/tests/labeled_tuples_regressions.ml.js-ref
@@ -75,7 +75,7 @@ let bar =
    labeled AND the return is `local_` *)
 module type S = sig
   val t1 : unit -> int * y:bool
-  val t2 : unit -> local_ int * y:bool
+  val t2 : unit -> int * y:bool @ local
   val t3 : unit -> x:int * y:bool
-  val t4 : unit -> local_ (x:int * y:bool)
+  val t4 : unit -> (x:int * y:bool) @ local
 end

--- a/test/passing/tests/labeled_tuples_regressions.ml.ref
+++ b/test/passing/tests/labeled_tuples_regressions.ml.ref
@@ -71,9 +71,9 @@ let bar =
 module type S = sig
   val t1 : unit -> int * y:bool
 
-  val t2 : unit -> local_ int * y:bool
+  val t2 : unit -> int * y:bool @ local
 
   val t3 : unit -> x:int * y:bool
 
-  val t4 : unit -> local_ (x:int * y:bool)
+  val t4 : unit -> (x:int * y:bool) @ local
 end

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -282,7 +282,7 @@ let f (type (a : immediate) (b : immediate)) x = x
 module type S = sig
   val init_with_immediates
     : ('a : immediate) ('b : immediate).
-    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+    int -> f:(int -> 'a @ local) @ local -> 'a t @ local
 end
 
 (**************************************)

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -355,7 +355,7 @@ let f (type (a : immediate) (b : immediate)) x = x
 module type S = sig
   val init_with_immediates :
     ('a : immediate) ('b : immediate).
-    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+    int -> f:(int -> 'a @ local) @ local -> 'a t @ local
 end
 
 (**************************************)

--- a/test/passing/tests/layout_annotation_mod.ml.js-ref
+++ b/test/passing/tests/layout_annotation_mod.ml.js-ref
@@ -260,7 +260,7 @@ let f (type (a : immediate mod mode) (b : immediate mod mode)) x = x
 module type S = sig
   val init_with_immediates
     : ('a : immediate mod mode) ('b : immediate mod mode).
-    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+    int -> f:(int -> 'a @ local) @ local -> 'a t @ local
 end
 
 (**************************************)

--- a/test/passing/tests/layout_annotation_mod.ml.ref
+++ b/test/passing/tests/layout_annotation_mod.ml.ref
@@ -335,7 +335,7 @@ let f (type (a : immediate mod mode) (b : immediate mod mode)) x = x
 module type S = sig
   val init_with_immediates :
     ('a : immediate mod mode) ('b : immediate mod mode).
-    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+    int -> f:(int -> 'a @ local) @ local -> 'a t @ local
 end
 
 (**************************************)

--- a/test/passing/tests/layout_annotation_with.ml.js-ref
+++ b/test/passing/tests/layout_annotation_with.ml.js-ref
@@ -267,7 +267,7 @@ let f (type (a : immediate with type_) (b : immediate with type_)) x = x
 module type S = sig
   val init_with_immediates
     : ('a : immediate with type_) ('b : immediate with type_).
-    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+    int -> f:(int -> 'a @ local) @ local -> 'a t @ local
 end
 
 (**************************************)

--- a/test/passing/tests/layout_annotation_with.ml.ref
+++ b/test/passing/tests/layout_annotation_with.ml.ref
@@ -341,7 +341,7 @@ let f (type (a : immediate with type_) (b : immediate with type_)) x = x
 module type S = sig
   val init_with_immediates :
     ('a : immediate with type_) ('b : immediate with type_).
-    int -> f:local_ (int -> local_ 'a) -> local_ 'a t
+    int -> f:(int -> 'a @ local) @ local -> 'a t @ local
 end
 
 (**************************************)

--- a/test/passing/tests/local.ml.js-ref
+++ b/test/passing/tests/local.ml.js-ref
@@ -33,7 +33,7 @@ type 'a r =
   | Bar of 'a * global_ 'a
   | Baz of global_ int * string * global_ 'a
 
-type ('a, 'b) cfn = a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
+type ('a, 'b) cfn = a:'a @ local -> ?b:b @ local -> 'a @ local -> (int -> 'b @ local)
 
 let _ = local_ ()
 let _ = exclave_ ()

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -32,7 +32,7 @@ type 'a r =
   | Baz of global_ int * string * global_ 'a
 
 type ('a, 'b) cfn =
-  a:local_ 'a -> ?b:local_ b -> local_ 'a -> (int -> local_ 'b)
+  a:'a @ local -> ?b:b @ local -> 'a @ local -> (int -> 'b @ local)
 
 let _ = local_ ()
 

--- a/test/passing/tests/local_to_at_local.ml
+++ b/test/passing/tests/local_to_at_local.ml
@@ -1,0 +1,40 @@
+(* This test exercises the rewrite of legacy [local_ T] in type position to
+   the modal form [T @ local]. After ocamlformat runs, no [local_] should
+   appear anywhere in a type. Value-level uses of [local_] are not exercised
+   here -- they are covered by [local.ml]. *)
+
+(* Nolabel domain *)
+type t1 = local_ string -> int
+
+(* Labelled domain *)
+type t2 = a:local_ int -> string
+
+(* Optional domain *)
+type t3 = ?a:local_ int -> string
+
+(* Local return *)
+type t4 = int -> local_ string
+
+(* Chained legacy local_ *)
+type t5 = local_ a -> local_ b -> local_ c
+
+(* Mixed with existing @ modes: [local] must be inserted in sorted position.
+   [contended] < [local], [local] < [once], [local] < [unique]. *)
+type t6 = local_ a @ once -> b @ unique
+type t7 = local_ a @ contended -> b
+type t8 = local_ a @ contended once -> b
+
+(* Inside a [val] signature *)
+module type S = sig
+  val f : local_ int -> int
+  val g : a:local_ int -> b:local_ string -> int
+end
+
+(* Inside a let-binding type constraint *)
+let h : local_ int -> int = fun x -> x
+
+(* Inside a nested arrow *)
+type t9 = (local_ int -> int) -> int
+
+(* Local return preserved through a labelled chain *)
+type t10 = a:local_ int -> b:local_ string -> local_ char list

--- a/test/passing/tests/local_to_at_local.ml.ref
+++ b/test/passing/tests/local_to_at_local.ml.ref
@@ -1,0 +1,43 @@
+(* This test exercises the rewrite of legacy [local_ T] in type position to
+   the modal form [T @ local]. After ocamlformat runs, no [local_] should
+   appear anywhere in a type. Value-level uses of [local_] are not exercised
+   here -- they are covered by [local.ml]. *)
+
+(* Nolabel domain *)
+type t1 = string @ local -> int
+
+(* Labelled domain *)
+type t2 = a:int @ local -> string
+
+(* Optional domain *)
+type t3 = ?a:int @ local -> string
+
+(* Local return *)
+type t4 = int -> string @ local
+
+(* Chained legacy local_ *)
+type t5 = a @ local -> b @ local -> c @ local
+
+(* Mixed with existing @ modes: [local] must be inserted in sorted position.
+   [contended] < [local], [local] < [once], [local] < [unique]. *)
+type t6 = a @ local once -> b @ unique
+
+type t7 = a @ contended local -> b
+
+type t8 = a @ contended local once -> b
+
+(* Inside a [val] signature *)
+module type S = sig
+  val f : int @ local -> int
+
+  val g : a:int @ local -> b:string @ local -> int
+end
+
+(* Inside a let-binding type constraint *)
+let h : int @ local -> int = fun x -> x
+
+(* Inside a nested arrow *)
+type t9 = (int @ local -> int) -> int
+
+(* Local return preserved through a labelled chain *)
+type t10 = a:int @ local -> b:string @ local -> char list @ local

--- a/test/passing/tests/local_to_at_local.ml.why-no-js
+++ b/test/passing/tests/local_to_at_local.ml.why-no-js
@@ -1,0 +1,3 @@
+the legacy [local_]-to-[@ local] rewrite is a parser/printer concern that
+does not depend on the formatting profile; default-profile coverage is
+sufficient

--- a/test/passing/tests/modes-ocaml_version.ml.ref
+++ b/test/passing/tests/modes-ocaml_version.ml.ref
@@ -619,11 +619,11 @@ module Interaction_with_existing_syntax = struct
 
   (* lhs/rhs of arrows *)
 
-  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+  type t = lhs @ local mode1 -> mhs @ local mode2 -> rhs @ local mode3
 
-  let x : (local_ lhs @ mode1 -> local_ rhs @ mode2) @ mode3 = y
+  let x : (lhs @ local mode1 -> rhs @ local mode2) @ mode3 = y
 
-  let x = (expr : (local_ lhs @ mode1 -> local_ rhs @ mode2) @ mode3)
+  let x = (expr : (lhs @ local mode1 -> rhs @ local mode2) @ mode3)
 
   (* modalities on record fields *)
 

--- a/test/passing/tests/modes.ml.js-ref
+++ b/test/passing/tests/modes.ml.js-ref
@@ -681,10 +681,10 @@ module Interaction_with_existing_syntax = struct
 
   (* lhs/rhs of arrows *)
 
-  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+  type t = lhs @ local mode1 -> mhs @ local mode2 -> rhs @ local mode3
 
-  let x : (local_ lhs @ mode1 -> local_ rhs @ mode2) @ mode3 = y
-  let x = (expr : (local_ lhs @ mode1 -> local_ rhs @ mode2) @ mode3)
+  let x : (lhs @ local mode1 -> rhs @ local mode2) @ mode3 = y
+  let x = (expr : (lhs @ local mode1 -> rhs @ local mode2) @ mode3)
 
   (* modalities on record fields *)
 

--- a/test/passing/tests/modes.ml.ref
+++ b/test/passing/tests/modes.ml.ref
@@ -619,11 +619,11 @@ module Interaction_with_existing_syntax = struct
 
   (* lhs/rhs of arrows *)
 
-  type t = local_ lhs @ mode1 -> local_ mhs @ mode2 -> local_ rhs @ mode3
+  type t = lhs @ local mode1 -> mhs @ local mode2 -> rhs @ local mode3
 
-  let x : (local_ lhs @ mode1 -> local_ rhs @ mode2) @ mode3 = y
+  let x : (lhs @ local mode1 -> rhs @ local mode2) @ mode3 = y
 
-  let x = (expr : (local_ lhs @ mode1 -> local_ rhs @ mode2) @ mode3)
+  let x = (expr : (lhs @ local mode1 -> rhs @ local mode2) @ mode3)
 
   (* modalities on record fields *)
 

--- a/test/passing/tests/source.ml.js-ref
+++ b/test/passing/tests/source.ml.js-ref
@@ -10188,8 +10188,8 @@ let _ =
 
 module type For_let_syntax_local =
   For_let_syntax_gen
-  with type ('a, 'b) fn := local_ 'a -> 'b
-   and type ('a, 'b) f_labeled_fn := f:local_ 'a -> 'b
+  with type ('a, 'b) fn := 'a @ local -> 'b
+   and type ('a, 'b) f_labeled_fn := f:'a @ local -> 'b
 
 type fooooooooooooooooooooooooooooooo =
   ( fooooooooooooooooooooooooooooooo

--- a/test/passing/tests/source.ml.ref
+++ b/test/passing/tests/source.ml.ref
@@ -9708,8 +9708,8 @@ let _ =
 
 module type For_let_syntax_local =
   For_let_syntax_gen
-    with type ('a, 'b) fn := local_ 'a -> 'b
-     and type ('a, 'b) f_labeled_fn := f:local_ 'a -> 'b
+    with type ('a, 'b) fn := 'a @ local -> 'b
+     and type ('a, 'b) f_labeled_fn := f:'a @ local -> 'b
 
 type fooooooooooooooooooooooooooooooo =
   ( fooooooooooooooooooooooooooooooo

--- a/test/passing/tests/unboxed_tuples.ml
+++ b/test/passing/tests/unboxed_tuples.ml
@@ -384,11 +384,11 @@ let bar =
 module type S = sig
   val t1 : unit -> #(int * y:bool)
 
-  val t2 : unit -> local_ #(int * y:bool)
+  val t2 : unit -> #(int * y:bool) @ local
 
   val t3 : unit -> #(x:int * y:bool)
 
-  val t4 : unit -> local_ #(x:int * y:bool)
+  val t4 : unit -> #(x:int * y:bool) @ local
 
   val f :
        #(foo:int * very_long_type_name_so_we_get_multiple_lines)

--- a/test/passing/tests/unboxed_tuples.ml.js-ref
+++ b/test/passing/tests/unboxed_tuples.ml.js-ref
@@ -383,9 +383,9 @@ let bar =
    labeled AND the return is `local_` *)
 module type S = sig
   val t1 : unit -> #(int * y:bool)
-  val t2 : unit -> local_ #(int * y:bool)
+  val t2 : unit -> #(int * y:bool) @ local
   val t3 : unit -> #(x:int * y:bool)
-  val t4 : unit -> local_ #(x:int * y:bool)
+  val t4 : unit -> #(x:int * y:bool) @ local
 
   val f
     :  #(foo:int * very_long_type_name_so_we_get_multiple_lines)

--- a/vendor/parser-extended/parser.mly
+++ b/vendor/parser-extended/parser.mly
@@ -248,15 +248,8 @@ let mkpat_stack pat =
   if Erase_jane_syntax.should_erase () then pat else
   {pat with ppat_attributes = local_attr :: pat.ppat_attributes}
 
-let mktyp_stack typ =
-  if Erase_jane_syntax.should_erase () then typ else
-  {typ with ptyp_attributes = local_attr :: typ.ptyp_attributes}
-
 let mkpat_local_if p pat =
   if p then mkpat_stack pat else pat
-
-let mktyp_local_if p typ =
-  if p then mktyp_stack typ else typ
 
 let split_local_from_attrs atrs =
   match
@@ -4472,19 +4465,18 @@ strict_function_or_labeled_tuple_type:
       domain_with_modes = with_optional_mode_expr(extra_rhs(param_type))
       MINUSGREATER
       codomain = strict_function_or_labeled_tuple_type
-        { let local, (domain, _), arg_modes = domain_with_modes in
-          let type_ = mktyp_local_if local domain in
+        { let (domain, _), arg_modes = domain_with_modes in
           let loc = make_loc $sloc in
-          let label, type_ =
+          let label, domain =
             erase_call_pos_type
               ~arg_label:label
-              ~arg_type:type_
+              ~arg_type:domain
               ~loc
           in
           let arrow_type = {
             pap_label = label;
             pap_loc = make_loc $sloc;
-            pap_type = type_;
+            pap_type = domain;
             pap_modes = arg_modes
           }
           in
@@ -4503,8 +4495,8 @@ strict_function_or_labeled_tuple_type:
       MINUSGREATER
       codomain_with_modes = with_optional_mode_expr(tuple_type)
       %prec MINUSGREATER
-         { let arg_local, (domain, _), arg_modes = domain_with_modes in
-           let ret_local, (codomain, _), ret_modes = codomain_with_modes in
+         { let (domain, _), arg_modes = domain_with_modes in
+           let (codomain, _), ret_modes = codomain_with_modes in
            let loc = make_loc $sloc in
            let label, domain =
              erase_call_pos_type
@@ -4515,13 +4507,11 @@ strict_function_or_labeled_tuple_type:
            let arrow_type = {
              pap_label = label;
              pap_loc = make_loc $sloc;
-             pap_type = mktyp_local_if arg_local domain;
+             pap_type = domain;
              pap_modes = arg_modes
            }
            in
-           let codomain =
-             mktyp_local_if ret_local (maybe_curry_typ codomain)
-           in
+           let codomain = maybe_curry_typ codomain in
            Ptyp_arrow([arrow_type], codomain, ret_modes)
          }
       )
@@ -4544,7 +4534,7 @@ strict_function_or_labeled_tuple_type:
       MINUSGREATER
       codomain = strict_function_or_labeled_tuple_type
          {
-           let local, (tuple, tuple_loc), arg_modes = tuple_with_modes in
+           let (tuple, tuple_loc), arg_modes = tuple_with_modes in
            let ty, ltys = tuple in
            let label = mk_labelled label $loc(label) in
            let domain =
@@ -4554,7 +4544,7 @@ strict_function_or_labeled_tuple_type:
            let arrow_type = {
              pap_label = label;
              pap_loc = make_loc $sloc;
-             pap_type = mktyp_local_if local domain;
+             pap_type = domain;
              pap_modes = arg_modes
            }
            in
@@ -4572,8 +4562,8 @@ strict_function_or_labeled_tuple_type:
       MINUSGREATER
       codomain_with_modes = with_optional_mode_expr(tuple_type)
       %prec MINUSGREATER
-         { let arg_local, (tuple, tuple_loc), arg_modes = tuple_with_modes in
-           let ret_local, (codomain, _), ret_modes = codomain_with_modes in
+         { let (tuple, tuple_loc), arg_modes = tuple_with_modes in
+           let (codomain, _), ret_modes = codomain_with_modes in
            let ty, ltys = tuple in
            let label = mk_labelled label $loc(label) in
            let domain =
@@ -4583,12 +4573,12 @@ strict_function_or_labeled_tuple_type:
            let arrow_type = {
              pap_label = label;
              pap_loc = make_loc $sloc;
-             pap_type = mktyp_local_if arg_local domain;
+             pap_type = domain;
              pap_modes = arg_modes
            }
            in
            Ptyp_arrow([arrow_type],
-            mktyp_local_if ret_local (maybe_curry_typ codomain),
+            maybe_curry_typ codomain,
             ret_modes)
          }
     )
@@ -4658,7 +4648,19 @@ at_mode_expr:
 
 %inline with_optional_mode_expr(ty):
   | m0=optional_mode_expr_legacy ty=ty m1=optional_at_mode_expr {
-    m0, (ty, $loc(ty)), m1
+    let m =
+      if m0 && not (Erase_jane_syntax.should_erase ()) then
+        let local_mode =
+          mkloc (Mode "local") (make_loc ($startpos(m0), $endpos(m0)))
+        in
+        List.sort
+          (fun
+            { Location.txt = Mode m1; _ } { Location.txt = Mode m2; _ } ->
+          String.compare m1 m2)
+          (local_mode :: m1)
+      else m1
+    in
+    (ty, $loc(ty)), m
   }
 ;
 


### PR DESCRIPTION
Make ocamlformat print `T @ local` rather than `local_ T`, even if the user wrote the latter.

We insert `local` in sorted order amongst the other modes.

This was 100% written by claude.