### PR TITLE
Convert legacy local_/global_ to new mode/modality syntax

### DIFF
--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4167,16 +4167,11 @@ and fmt_label_declaration c ctx ?(last = false) decl =
           (str ";")
   in
   let global_attr_opt, atrs = split_global_flags_from_attrs atrs in
-  ( match global_attr_opt with
-  | Some attr ->
-      Cmts.relocate_all_to_after c.cmts ~src:attr.attr_loc
-        ~after:pld_type.ptyp_loc
-  | None -> () ) ;
   let pld_modalities =
     match global_attr_opt with
-    | Some _ ->
-        {txt= Modality "global"; loc= Location.none} :: pld_modalities
     | None -> pld_modalities
+    | Some attr ->
+        {txt= Modality "global"; loc= attr.attr_loc} :: pld_modalities
   in
   hovbox 0
     ( Cmts.fmt_before c pld_loc

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -597,7 +597,6 @@ let let_binding_can_be_punned ~binding ~is_ext =
        ; lb_exp
        ; lb_pun= _
        ; lb_attrs= _
-       ; lb_local
        ; lb_modes_binding
        ; lb_loc= _ }
         : Sugar.Let_binding.t ) =
@@ -611,7 +610,6 @@ let let_binding_can_be_punned ~binding ~is_ext =
     , lb_modes
     , lb_args
     , (lb_pat.ast.ppat_attributes, lb_exp.ast.pexp_attributes)
-    , lb_local
     , lb_modes_binding )
   with
   | ( (* Binding must be inside an extension node (we do not pun operators) *)
@@ -628,8 +626,6 @@ let let_binding_can_be_punned ~binding ~is_ext =
       []
     , (* There must be no attrs on either side *)
       ([], [])
-    , (* This must not be a [let local_] binding *)
-      false
     , (* There cannot be any mode annotations *)
       [] )
     when (* LHS and RHS variable names must be the same *)
@@ -5438,7 +5434,6 @@ and fmt_value_binding c ~mutable_flag ~rec_flag ?(punned_in_output = false)
     ; lb_modes
     ; lb_exp
     ; lb_attrs
-    ; lb_local
     ; lb_modes_binding
     ; lb_loc
     ; lb_pun= punned_in_source } =
@@ -5511,7 +5506,6 @@ and fmt_value_binding c ~mutable_flag ~rec_flag ?(punned_in_output = false)
                                   $ fmt_attributes c at_attrs
                                   $ fmt_if mutable_flag " mutable"
                                   $ fmt_if rec_flag " rec"
-                                  $ fmt_if lb_local " local_"
                                   $ fmt_or pat_has_cmt "@ " " "
                                   $ Params.parens_if
                                       (has_args && has_modes_binding)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -988,10 +988,6 @@ and fmt_arrow_param ~return c ctx
     | Optional l -> Some (str "?" $ str l.txt $ fmt ":@,")
   in
   let xtI = sub_typ ~ctx tI in
-  let mI =
-    if localI then {Location.txt= Mode "local"; loc= Location.none} :: mI
-    else mI
-  in
   (* Jane Street: as a special case, labeled tuple types in function returns
      need parens if the return has modes AND the first element has a
      label. *)
@@ -1673,10 +1669,10 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
 and fmt_fun_args c args =
   (* When [islocal] is set on a pattern that already has modes in a
      [Ppat_constraint], merge [Mode "local"] into the existing mode list so
-     the printer emits a single [@ ... ] group instead of an invalid
-     [@ ... @ local] suffix. For patterns without an existing
-     [Ppat_constraint] we keep the simpler prefix-style code path which
-     emits [(pat @ local)] and doesn't disturb comment placement. *)
+     the printer emits a single [@ ... ] group instead of an invalid [@ ... @
+     local] suffix. For patterns without an existing [Ppat_constraint] we
+     keep the simpler prefix-style code path which emits [(pat @ local)] and
+     doesn't disturb comment placement. *)
   let merge_islocal_into_existing_modes pat =
     let local_mode = {Location.txt= Mode "local"; loc= Location.none} in
     match pat.ppat_desc with
@@ -4259,7 +4255,8 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
                      @@ hvbox 0
                           ( fmt_typ
                           $ fmt_modals c
-                              (Modalities (extra_modality @ pca_modalities)) ) ) )
+                              (Modalities (extra_modality @ pca_modalities))
+                          ) ) )
       in
       pre $ vars $ cargs
   | Pcstr_record (loc, lds) ->

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -1671,7 +1671,31 @@ and fmt_pattern ?ext c ?pro ?parens ?(box = false)
             (fmt "@;<0 2>" $ fmt_pattern c (sub_pat ~ctx pat)) )
 
 and fmt_fun_args c args =
+  (* When [islocal] is set on a pattern that already has modes in a
+     [Ppat_constraint], merge [Mode "local"] into the existing mode list so
+     the printer emits a single [@ ... ] group instead of an invalid
+     [@ ... @ local] suffix. For patterns without an existing
+     [Ppat_constraint] we keep the simpler prefix-style code path which
+     emits [(pat @ local)] and doesn't disturb comment placement. *)
+  let merge_islocal_into_existing_modes pat =
+    let local_mode = {Location.txt= Mode "local"; loc= Location.none} in
+    match pat.ppat_desc with
+    | Ppat_constraint (inner, typ, modes) ->
+        Some
+          { pat with
+            ppat_desc= Ppat_constraint (inner, typ, modes @ [local_mode]) }
+    | _ -> None
+  in
   let fmt_fun_arg (a : function_param) =
+    let a =
+      match a.pparam_desc with
+      | Pparam_val (true, lbl, default, pat) -> (
+        match merge_islocal_into_existing_modes pat with
+        | Some pat ->
+            {a with pparam_desc= Pparam_val (false, lbl, default, pat)}
+        | None -> a )
+      | _ -> a
+    in
     let ctx = Fp a in
     Cmts.fmt c a.pparam_loc
     @@

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -4235,7 +4235,7 @@ and fmt_core_type_extract_global c ctx typ =
   let global_attr_opt, _ = split_global_flags_from_attrs ptyp_attributes in
   let extra_modality =
     match global_attr_opt with
-    | Some _ -> [{Location.txt= Modality "global"; loc= Location.none}]
+    | Some attr -> [{Location.txt= Modality "global"; loc= attr.attr_loc}]
     | None -> []
   in
   (fmt_core_type c (sub_typ ~ctx typ), extra_modality)

--- a/lib/Fmt_ast.ml
+++ b/lib/Fmt_ast.ml
@@ -211,11 +211,6 @@ let get_in_local_expr ?eol c ({pexp_desc; pexp_loc; _} : expression) =
   else
     ( match pexp_desc with
     | Pexp_stack e -> Some (fmt "stack_ ", e)
-    | Pexp_apply
-        ( {pexp_desc= Pexp_extension ({txt; loc= _}, PStr []); _}
-        , [(Nolabel, e)] )
-      when Conf.is_jane_street_local_annotation "local" ~test:txt ->
-        Some (fmt "local_ ", e)
     | _ -> None )
     |> Option.map ~f:(fun (expr_pro, e) ->
            Cmts.relocate_all_to_before c.cmts ~src:e.pexp_loc
@@ -997,6 +992,10 @@ and fmt_arrow_param ~return c ctx
     | Optional l -> Some (str "?" $ str l.txt $ fmt ":@,")
   in
   let xtI = sub_typ ~ctx tI in
+  let mI =
+    if localI then {Location.txt= Mode "local"; loc= Location.none} :: mI
+    else mI
+  in
   (* Jane Street: as a special case, labeled tuple types in function returns
      need parens if the return has modes AND the first element has a
      label. *)
@@ -1704,8 +1703,8 @@ and fmt_fun_args c args =
               (Params.parens_if
                  (islocal || parenze_pat xpat)
                  c.conf
-                 (fmt_if islocal "local_ " $ fmt_pattern ~parens:false c xpat) )
-          )
+                 ( fmt_pattern ~parens:false c xpat
+                 $ fmt_if islocal "@ @@ local" ) ) )
     | Pparam_val (islocal, (Optional _ as lbl), None, pat) ->
         let xpat = sub_pat ~ctx pat in
         let has_attr = not (List.is_empty pat.ppat_attributes) in
@@ -1722,14 +1721,14 @@ and fmt_fun_args c args =
           ( fmt_label lbl ":@,"
           $ hovbox 0
             @@ Params.parens_if outer_parens c.conf
-                 ( fmt_if islocal "local_ "
-                 $ fmt_pattern ~parens:inner_parens c xpat ) )
+                 ( fmt_pattern ~parens:inner_parens c xpat
+                 $ fmt_if islocal "@ @@ local" ) )
     | Pparam_val (islocal, ((Labelled _ | Nolabel) as lbl), None, pat) ->
         let xpat = sub_pat ~ctx pat in
         cbox 2
           ( fmt_label lbl ":@,"
           $ Params.parens_if islocal c.conf
-              (fmt_if islocal "local_ " $ fmt_pattern c xpat) )
+              (fmt_pattern c xpat $ fmt_if islocal "@ @@ local") )
     | Pparam_val
         ( islocal
         , Optional l
@@ -1741,8 +1740,8 @@ and fmt_fun_args c args =
         let xpat = sub_pat ~ctx pat in
         cbox 0
           (wrap "?(" ")"
-             ( fmt_if islocal "local_ "
-             $ fmt_pattern c ~box:true xpat
+             ( fmt_pattern c ~box:true xpat
+             $ fmt_if islocal "@ @@ local"
              $ fmt " =@;<1 2>"
              $ hovbox 2 (fmt_expression c xexp) ) )
     | Pparam_val
@@ -1758,8 +1757,8 @@ and fmt_fun_args c args =
         let xpat = sub_pat ~ctx pat in
         cbox 0
           (wrap "?(" ")"
-             ( fmt_if islocal "local_ "
-             $ fmt_pattern c ~parens:false ~box:true xpat
+             ( fmt_pattern c ~parens:false ~box:true xpat
+             $ fmt_if islocal "@ @@ local"
              $ fmt " =@;<1 2>" $ fmt_expression c xexp ) )
     | Pparam_val (islocal, Optional l, Some exp, pat) ->
         let xexp = sub_exp ~ctx exp in
@@ -1772,8 +1771,8 @@ and fmt_fun_args c args =
         cbox 2
           ( str "?" $ str l.txt
           $ wrap_k (fmt ":@,(") (str ")")
-              ( fmt_if islocal "local_ "
-              $ fmt_pattern c ?parens ~box:true xpat
+              ( fmt_pattern c ?parens ~box:true xpat
+              $ fmt_if islocal "@ @@ local"
               $ fmt " =@;<1 2>" $ fmt_expression c xexp ) )
     | Pparam_val (_, (Labelled _ | Nolabel), Some _, _) ->
         impossible "not accepted by parser"
@@ -1806,18 +1805,6 @@ and fmt_body c ?ext ({ast= body; _} as xbody) =
       , update_config_maybe_disabled c pexp_loc pexp_attributes
         @@ fun c ->
         fmt_cases c ctx cs $ fmt_if parens ")" $ Cmts.fmt_after c pexp_loc )
-  | { pexp_desc=
-        Pexp_apply
-          ( { pexp_desc= Pexp_extension ({txt= extension_local; _}, PStr [])
-            ; _ }
-          , [(Nolabel, sbody)] )
-    ; pexp_loc
-    ; _ }
-    when Conf.is_jane_street_local_annotation "local" ~test:extension_local
-         (* Don't wipe away comments before [local_]. *)
-         && not (Cmts.has_before c.cmts pexp_loc) ->
-      ( fmt " local_"
-      , fmt_expression c ~eol:(fmt "@;<1000 0>") (sub_exp ~ctx sbody) )
   | { pexp_desc=
         Pexp_apply
           ( { pexp_desc= Pexp_extension ({txt= extension_exclave; _}, PStr [])
@@ -2508,13 +2495,22 @@ and fmt_expression c ?(box = true) ?(pro = noop) ?eol ?parens
                 ( fmt_infix_op_args ~parens:inner_wrap c xexp infix_op_args
                 $ fmt_atrs ) ) )
   | Pexp_apply
-      ( {pexp_desc= Pexp_extension ({txt= extension_local; _}, PStr []); _}
+      ( { pexp_desc=
+            Pexp_extension ({txt= extension_local; loc= ext_loc}, PStr [])
+        ; _ }
       , [(Nolabel, sbody)] )
     when Conf.is_jane_street_local_annotation "local" ~test:extension_local
     ->
+      let modes = [{txt= Mode "local"; loc= ext_loc}] in
       pro
-      $ Params.parens_if parens c.conf
-          (fmt "local_@ " $ fmt_expression ~box c (sub_exp ~ctx sbody))
+      $ hvbox
+          (Params.Indent.exp_constraint c.conf)
+          (Params.parens_if (parens && has_attr) c.conf
+             ( wrap_fits_breaks ~space:false c.conf "(" ")"
+                 ( fmt_expression c (sub_exp ~ctx sbody)
+                 $ fmt "@ :"
+                 $ fmt_modals c (Modes modes) )
+             $ fmt_atrs ) )
   | Pexp_apply
       ( {pexp_desc= Pexp_extension ({txt= extension_exclave; _}, PStr []); _}
       , [(Nolabel, sbody)] )
@@ -4156,6 +4152,12 @@ and fmt_label_declaration c ctx ?(last = false) decl =
       Cmts.relocate_all_to_after c.cmts ~src:attr.attr_loc
         ~after:pld_type.ptyp_loc
   | None -> () ) ;
+  let pld_modalities =
+    match global_attr_opt with
+    | Some _ ->
+        {txt= Modality "global"; loc= Location.none} :: pld_modalities
+    | None -> pld_modalities
+  in
   hovbox 0
     ( Cmts.fmt_before c pld_loc
     $ hvbox
@@ -4168,9 +4170,6 @@ and fmt_label_declaration c ctx ?(last = false) decl =
                             ( hovbox 2
                                 ( fmt_mutable_flag ~pro:noop ~epi:(fmt "@ ")
                                     c pld_mutable
-                                $ fmt_if
-                                    (Option.is_some global_attr_opt)
-                                    "global_ "
                                 $ fmt_str_loc c pld_name
                                 $ fmt_if field_loose " " $ fmt ":" )
                             $ fmt "@ "
@@ -4216,11 +4215,15 @@ and fmt_constructor_declaration c ctx ~first ~last:_ cstr_decl =
           $ fmt_attributes_and_docstrings c pcd_attributes )
       $ Cmts.fmt_after c pcd_loc )
 
-and fmt_core_type_gf c ctx typ =
+and fmt_core_type_extract_global c ctx typ =
   let {ptyp_attributes; _} = typ in
   let global_attr_opt, _ = split_global_flags_from_attrs ptyp_attributes in
-  fmt_if (Option.is_some global_attr_opt) "global_ "
-  $ fmt_core_type c (sub_typ ~ctx typ)
+  let extra_modality =
+    match global_attr_opt with
+    | Some _ -> [{Location.txt= Modality "global"; loc= Location.none}]
+    | None -> []
+  in
+  (fmt_core_type c (sub_typ ~ctx typ), extra_modality)
 
 and fmt_constructor_arguments ?vars c ctx ~pre = function
   | Pcstr_tuple cargs ->
@@ -4234,10 +4237,14 @@ and fmt_constructor_arguments ?vars c ctx ~pre = function
             $ hvbox 0
                 (list cargs "@ * "
                    (fun {pca_type; pca_loc; pca_modalities} ->
+                     let fmt_typ, extra_modality =
+                       fmt_core_type_extract_global c ctx pca_type
+                     in
                      Cmts.fmt c pca_loc
                      @@ hvbox 0
-                          ( fmt_core_type_gf c ctx pca_type
-                          $ fmt_modals c (Modalities pca_modalities) ) ) )
+                          ( fmt_typ
+                          $ fmt_modals c
+                              (Modalities (extra_modality @ pca_modalities)) ) ) )
       in
       pre $ vars $ cargs
   | Pcstr_record (loc, lds) ->

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -202,21 +202,22 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
           else exp
         in
         Ast_mapper.default_mapper.expr m exp'
-    | Pexp_apply
-        ( {pexp_desc= Pexp_extension ({txt= ext_name; _}, PStr []); _}
-        , [(Nolabel, sbody)] )
-      when Conf.is_jane_street_local_annotation "local" ~test:ext_name ->
-        m.expr m
-          { exp with
-            pexp_desc=
-              Pexp_constraint
-                (sbody, None, [{txt= Mode "local"; loc= Location.none}]) }
     | _ -> Ast_mapper.default_mapper.expr m exp
   in
   (* The old-style [[@local]] attributes can only occur in record label
      declarations, types, and patterns; checking there explicitly ensures we
      don't confuse them with the existing [let[@local always] f x = x]
      attribute, which occurs at a different level. *)
+  let typ (m : Ast_mapper.mapper) typ =
+    (* Types also need their location stack cleared *)
+    let typ = {typ with ptyp_loc_stack= []} in
+    let typ =
+      { typ with
+        ptyp_attributes=
+          normalize_jane_street_local_annotations typ.ptyp_attributes }
+    in
+    Ast_mapper.default_mapper.typ m typ
+  in
   let pat (m : Ast_mapper.mapper) pat =
     let pat =
       { pat with
@@ -225,37 +226,7 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
     in
     Ast_mapper.default_mapper.pat m pat
   in
-  let type_declaration (m : Ast_mapper.mapper) td =
-    let _, td = rewrite_type_declaration_imm_attr_to_jkind_annot td in
-    Ast_mapper.default_mapper.type_declaration m td
-  in
-  let value_binding (m : Ast_mapper.mapper) vb =
-    let vb =
-      if vb.pvb_local then
-        { vb with
-          pvb_local= false
-        ; pvb_modes=
-            {txt= Mode "local"; loc= Location.none} :: vb.pvb_modes }
-      else vb
-    in
-    Ast_mapper.default_mapper.value_binding m vb
-  in
   let label_declaration (m : Ast_mapper.mapper) ld =
-    let global_attr_opt, pld_attributes =
-      List.partition_tf ld.pld_attributes ~f:(fun a ->
-          Conf.is_jane_street_local_annotation "global"
-            ~test:a.attr_name.txt )
-    in
-    let ld =
-      match global_attr_opt with
-      | _ :: _ ->
-          { ld with
-            pld_attributes
-          ; pld_modalities=
-              {txt= Modality "global"; loc= Location.none}
-              :: ld.pld_modalities }
-      | [] -> ld
-    in
     let ld =
       { ld with
         pld_attributes=
@@ -263,71 +234,9 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
     in
     Ast_mapper.default_mapper.label_declaration m ld
   in
-  let constructor_argument ca =
-    let global_attr_opt, ptyp_attributes =
-      List.partition_tf ca.pca_type.ptyp_attributes ~f:(fun a ->
-          Conf.is_jane_street_local_annotation "global"
-            ~test:a.attr_name.txt )
-    in
-    match global_attr_opt with
-    | _ :: _ ->
-        { ca with
-          pca_type= {ca.pca_type with ptyp_attributes}
-        ; pca_modalities=
-            {txt= Modality "global"; loc= Location.none}
-            :: ca.pca_modalities }
-    | [] -> ca
-  in
-  let arrow_param ap =
-    let local_attr_opt, ptyp_attributes =
-      List.partition_tf ap.pap_type.ptyp_attributes ~f:(fun a ->
-          Conf.is_jane_street_local_annotation "local"
-            ~test:a.attr_name.txt )
-    in
-    match local_attr_opt with
-    | _ :: _ ->
-        { ap with
-          pap_type= {ap.pap_type with ptyp_attributes}
-        ; pap_modes=
-            {txt= Mode "local"; loc= Location.none} :: ap.pap_modes }
-    | [] -> ap
-  in
-  let typ_with_normalize =
-    fun m typ ->
-      let typ =
-        match typ.ptyp_desc with
-        | Ptyp_arrow (params, ret, modes) ->
-            let params = List.map ~f:arrow_param params in
-            let ret, modes =
-              let local_attr_opt, ptyp_attributes =
-                List.partition_tf ret.ptyp_attributes ~f:(fun a ->
-                    Conf.is_jane_street_local_annotation "local"
-                      ~test:a.attr_name.txt )
-              in
-              match local_attr_opt with
-              | _ :: _ ->
-                  ( {ret with ptyp_attributes}
-                  , {Location.txt= Mode "local"; loc= Location.none} :: modes )
-              | [] -> (ret, modes)
-            in
-            {typ with ptyp_desc= Ptyp_arrow (params, ret, modes)}
-        | _ -> typ
-      in
-      let typ = {typ with ptyp_loc_stack= []} in
-      let typ =
-        { typ with
-          ptyp_attributes=
-            normalize_jane_street_local_annotations typ.ptyp_attributes }
-      in
-      Ast_mapper.default_mapper.typ m typ
-  in
-  let constructor_declaration (m : Ast_mapper.mapper) cd =
-    let pcd_args =
-      match cd.pcd_args with
-      | Pcstr_tuple args -> Pcstr_tuple (List.map ~f:constructor_argument args)
-      | Pcstr_record _ as r -> r
-    in
-    Ast_mapper.default_mapper.constructor_declaration m {cd with pcd_args}
+  let type_declaration (m : Ast_mapper.mapper) td =
+    let _, td = rewrite_type_declaration_imm_attr_to_jkind_annot td in
+    Ast_mapper.default_mapper.type_declaration m td
   in
   { Ast_mapper.default_mapper with
     location
@@ -336,11 +245,9 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
   ; repl_phrase
   ; expr
   ; pat
-  ; typ= typ_with_normalize
+  ; typ
   ; label_declaration
-  ; type_declaration
-  ; value_binding
-  ; constructor_declaration }
+  ; type_declaration }
 
 let normalize_cmt (conf : Conf.t) =
   let parse_comments_as_doc = conf.fmt_opts.ocp_indent_compat.v in

--- a/lib/Normalize_extended_ast.ml
+++ b/lib/Normalize_extended_ast.ml
@@ -202,22 +202,21 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
           else exp
         in
         Ast_mapper.default_mapper.expr m exp'
+    | Pexp_apply
+        ( {pexp_desc= Pexp_extension ({txt= ext_name; _}, PStr []); _}
+        , [(Nolabel, sbody)] )
+      when Conf.is_jane_street_local_annotation "local" ~test:ext_name ->
+        m.expr m
+          { exp with
+            pexp_desc=
+              Pexp_constraint
+                (sbody, None, [{txt= Mode "local"; loc= Location.none}]) }
     | _ -> Ast_mapper.default_mapper.expr m exp
   in
   (* The old-style [[@local]] attributes can only occur in record label
      declarations, types, and patterns; checking there explicitly ensures we
      don't confuse them with the existing [let[@local always] f x = x]
      attribute, which occurs at a different level. *)
-  let typ (m : Ast_mapper.mapper) typ =
-    (* Types also need their location stack cleared *)
-    let typ = {typ with ptyp_loc_stack= []} in
-    let typ =
-      { typ with
-        ptyp_attributes=
-          normalize_jane_street_local_annotations typ.ptyp_attributes }
-    in
-    Ast_mapper.default_mapper.typ m typ
-  in
   let pat (m : Ast_mapper.mapper) pat =
     let pat =
       { pat with
@@ -226,7 +225,37 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
     in
     Ast_mapper.default_mapper.pat m pat
   in
+  let type_declaration (m : Ast_mapper.mapper) td =
+    let _, td = rewrite_type_declaration_imm_attr_to_jkind_annot td in
+    Ast_mapper.default_mapper.type_declaration m td
+  in
+  let value_binding (m : Ast_mapper.mapper) vb =
+    let vb =
+      if vb.pvb_local then
+        { vb with
+          pvb_local= false
+        ; pvb_modes=
+            {txt= Mode "local"; loc= Location.none} :: vb.pvb_modes }
+      else vb
+    in
+    Ast_mapper.default_mapper.value_binding m vb
+  in
   let label_declaration (m : Ast_mapper.mapper) ld =
+    let global_attr_opt, pld_attributes =
+      List.partition_tf ld.pld_attributes ~f:(fun a ->
+          Conf.is_jane_street_local_annotation "global"
+            ~test:a.attr_name.txt )
+    in
+    let ld =
+      match global_attr_opt with
+      | _ :: _ ->
+          { ld with
+            pld_attributes
+          ; pld_modalities=
+              {txt= Modality "global"; loc= Location.none}
+              :: ld.pld_modalities }
+      | [] -> ld
+    in
     let ld =
       { ld with
         pld_attributes=
@@ -234,9 +263,71 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
     in
     Ast_mapper.default_mapper.label_declaration m ld
   in
-  let type_declaration (m : Ast_mapper.mapper) td =
-    let _, td = rewrite_type_declaration_imm_attr_to_jkind_annot td in
-    Ast_mapper.default_mapper.type_declaration m td
+  let constructor_argument ca =
+    let global_attr_opt, ptyp_attributes =
+      List.partition_tf ca.pca_type.ptyp_attributes ~f:(fun a ->
+          Conf.is_jane_street_local_annotation "global"
+            ~test:a.attr_name.txt )
+    in
+    match global_attr_opt with
+    | _ :: _ ->
+        { ca with
+          pca_type= {ca.pca_type with ptyp_attributes}
+        ; pca_modalities=
+            {txt= Modality "global"; loc= Location.none}
+            :: ca.pca_modalities }
+    | [] -> ca
+  in
+  let arrow_param ap =
+    let local_attr_opt, ptyp_attributes =
+      List.partition_tf ap.pap_type.ptyp_attributes ~f:(fun a ->
+          Conf.is_jane_street_local_annotation "local"
+            ~test:a.attr_name.txt )
+    in
+    match local_attr_opt with
+    | _ :: _ ->
+        { ap with
+          pap_type= {ap.pap_type with ptyp_attributes}
+        ; pap_modes=
+            {txt= Mode "local"; loc= Location.none} :: ap.pap_modes }
+    | [] -> ap
+  in
+  let typ_with_normalize =
+    fun m typ ->
+      let typ =
+        match typ.ptyp_desc with
+        | Ptyp_arrow (params, ret, modes) ->
+            let params = List.map ~f:arrow_param params in
+            let ret, modes =
+              let local_attr_opt, ptyp_attributes =
+                List.partition_tf ret.ptyp_attributes ~f:(fun a ->
+                    Conf.is_jane_street_local_annotation "local"
+                      ~test:a.attr_name.txt )
+              in
+              match local_attr_opt with
+              | _ :: _ ->
+                  ( {ret with ptyp_attributes}
+                  , {Location.txt= Mode "local"; loc= Location.none} :: modes )
+              | [] -> (ret, modes)
+            in
+            {typ with ptyp_desc= Ptyp_arrow (params, ret, modes)}
+        | _ -> typ
+      in
+      let typ = {typ with ptyp_loc_stack= []} in
+      let typ =
+        { typ with
+          ptyp_attributes=
+            normalize_jane_street_local_annotations typ.ptyp_attributes }
+      in
+      Ast_mapper.default_mapper.typ m typ
+  in
+  let constructor_declaration (m : Ast_mapper.mapper) cd =
+    let pcd_args =
+      match cd.pcd_args with
+      | Pcstr_tuple args -> Pcstr_tuple (List.map ~f:constructor_argument args)
+      | Pcstr_record _ as r -> r
+    in
+    Ast_mapper.default_mapper.constructor_declaration m {cd with pcd_args}
   in
   { Ast_mapper.default_mapper with
     location
@@ -245,9 +336,11 @@ let make_mapper ~ignore_doc_comments ~normalize_doc =
   ; repl_phrase
   ; expr
   ; pat
-  ; typ
+  ; typ= typ_with_normalize
   ; label_declaration
-  ; type_declaration }
+  ; type_declaration
+  ; value_binding
+  ; constructor_declaration }
 
 let normalize_cmt (conf : Conf.t) =
   let parse_comments_as_doc = conf.fmt_opts.ocp_indent_compat.v in

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -248,8 +248,8 @@ let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
           ; ret_mode_annotations= []
           ; ret_type_constraint= None }
         , Pfunction_body
-            {pexp_desc= Pexp_constraint (exp1, None, (_ :: _ as modes)); _} )
-      ->
+            {pexp_desc= Pexp_constraint (exp1, None, (_ :: _ as modes)); _}
+        ) ->
         let c =
           { mode_annotations= []
           ; ret_mode_annotations= modes

--- a/lib/Normalize_std_ast.ml
+++ b/lib/Normalize_std_ast.ml
@@ -242,6 +242,21 @@ let make_mapper conf ~ignore_doc_comments ~erase_jane_syntax =
         in
         m.expr m
           {exp with pexp_desc= Pexp_function (ps, c, Pfunction_body exp1)}
+    | Pexp_function
+        ( ps
+        , { mode_annotations= []
+          ; ret_mode_annotations= []
+          ; ret_type_constraint= None }
+        , Pfunction_body
+            {pexp_desc= Pexp_constraint (exp1, None, (_ :: _ as modes)); _} )
+      ->
+        let c =
+          { mode_annotations= []
+          ; ret_mode_annotations= modes
+          ; ret_type_constraint= None }
+        in
+        m.expr m
+          {exp with pexp_desc= Pexp_function (ps, c, Pfunction_body exp1)}
     | Pexp_function (ps, c, b) when erase_jane_syntax ->
         let ps =
           List.map ps ~f:(fun param ->

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -319,8 +319,7 @@ module Let_binding = struct
     and lb_exp = sub_exp ~ctx pvb_expr
     and lb_typ = pvb_constraint in
     let pvb_modes =
-      if pvb_local then
-        {txt= Mode "local"; loc= Location.none} :: pvb_modes
+      if pvb_local then {txt= Mode "local"; loc= Location.none} :: pvb_modes
       else pvb_modes
     in
     let (lb_args, lb_typ, lb_modes, lb_exp), lb_modes_binding =

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -215,7 +215,6 @@ module Let_binding = struct
     ; lb_exp: expression xt
     ; lb_pun: bool
     ; lb_attrs: attribute list
-    ; lb_local: bool
     ; lb_modes_binding: modes
     ; lb_loc: Location.t }
 
@@ -337,7 +336,6 @@ module Let_binding = struct
     ; lb_exp
     ; lb_pun= pvb_is_pun
     ; lb_attrs= pvb_attributes
-    ; lb_local= false
     ; lb_modes_binding
     ; lb_loc= pvb_loc }
 
@@ -357,7 +355,6 @@ module Let_binding = struct
         ; lb_exp
         ; lb_pun= bo.pbop_is_pun
         ; lb_attrs= []
-        ; lb_local= false
         ; lb_modes_binding= []
         ; lb_loc= bo.pbop_loc } )
 end

--- a/lib/Sugar.ml
+++ b/lib/Sugar.ml
@@ -319,6 +319,11 @@ module Let_binding = struct
     let lb_pat = sub_pat ~ctx pvb_pat
     and lb_exp = sub_exp ~ctx pvb_expr
     and lb_typ = pvb_constraint in
+    let pvb_modes =
+      if pvb_local then
+        {txt= Mode "local"; loc= Location.none} :: pvb_modes
+      else pvb_modes
+    in
     let (lb_args, lb_typ, lb_modes, lb_exp), lb_modes_binding =
       if should_desugar_args lb_pat lb_typ then
         (split_fun_args cmts lb_pat lb_exp, pvb_modes)
@@ -332,7 +337,7 @@ module Let_binding = struct
     ; lb_exp
     ; lb_pun= pvb_is_pun
     ; lb_attrs= pvb_attributes
-    ; lb_local= pvb_local
+    ; lb_local= false
     ; lb_modes_binding
     ; lb_loc= pvb_loc }
 

--- a/lib/Sugar.mli
+++ b/lib/Sugar.mli
@@ -71,7 +71,6 @@ module Let_binding : sig
     ; lb_exp: expression Ast.xt
     ; lb_pun: bool
     ; lb_attrs: attribute list
-    ; lb_local: bool  (** the local_ on the bound value (not RHS) *)
     ; lb_modes_binding: modes  (** modes on the bound value (not RHS) *)
     ; lb_loc: Location.t }
 

--- a/test/passing/tests/implicit_source_position.ml.js-ref
+++ b/test/passing/tests/implicit_source_position.ml.js-ref
@@ -7,7 +7,7 @@ let ignored_pattern ~call_pos:(_ : [%call_pos]) () = 1
 let destructured_pattern ~call_pos:({ pos_fname; _ } : [%call_pos]) () = ()
 let in_a_type : call_pos:[%call_pos] -> unit -> Lexing.position = punned_pattern
 let in_an_expression = [%src_pos]
-let with_locals ~(local_ call_pos : [%call_pos]) () = ()
+let with_locals ~(call_pos : [%call_pos] @ local) () = ()
 
 type 'a t = here:[%call_pos] -> 'a
 

--- a/test/passing/tests/implicit_source_position.ml.ref
+++ b/test/passing/tests/implicit_source_position.ml.ref
@@ -15,7 +15,7 @@ let in_a_type : call_pos:[%call_pos] -> unit -> Lexing.position =
 
 let in_an_expression = [%src_pos]
 
-let with_locals ~(local_ call_pos : [%call_pos]) () = ()
+let with_locals ~(call_pos : [%call_pos] @ local) () = ()
 
 type 'a t = here:[%call_pos] -> 'a
 

--- a/test/passing/tests/layout_annotation.ml.js-ref
+++ b/test/passing/tests/layout_annotation.ml.js-ref
@@ -206,7 +206,7 @@ let o =
 let f : type (a : immediate). a -> a = fun x -> x
 
 let f x =
-  let local_ g (type a : immediate) (x : a) = x in
+  let (g @ local) (type a : immediate) (x : a) = x in
   g x [@nontail]
 ;;
 

--- a/test/passing/tests/layout_annotation.ml.ref
+++ b/test/passing/tests/layout_annotation.ml.ref
@@ -260,7 +260,7 @@ let o =
 let f : type (a : immediate). a -> a = fun x -> x
 
 let f x =
-  let local_ g (type a : immediate) (x : a) = x in
+  let (g @ local) (type a : immediate) (x : a) = x in
   g x [@nontail]
 
 let f x y (type a : immediate) (z : a) = z

--- a/test/passing/tests/layout_annotation_mod.ml.js-ref
+++ b/test/passing/tests/layout_annotation_mod.ml.js-ref
@@ -179,7 +179,7 @@ let o =
 let f : type (a : immediate mod mode). a -> a = fun x -> x
 
 let f x =
-  let local_ g (type a : immediate mod mode) (x : a) = x in
+  let (g @ local) (type a : immediate mod mode) (x : a) = x in
   g x [@nontail]
 ;;
 

--- a/test/passing/tests/layout_annotation_mod.ml.ref
+++ b/test/passing/tests/layout_annotation_mod.ml.ref
@@ -232,7 +232,7 @@ let o =
 let f : type (a : immediate mod mode). a -> a = fun x -> x
 
 let f x =
-  let local_ g (type a : immediate mod mode) (x : a) = x in
+  let (g @ local) (type a : immediate mod mode) (x : a) = x in
   g x [@nontail]
 
 let f x y (type a : immediate mod mode) (z : a) = z

--- a/test/passing/tests/layout_annotation_with.ml.js-ref
+++ b/test/passing/tests/layout_annotation_with.ml.js-ref
@@ -181,7 +181,7 @@ let o =
 let f : type (a : immediate with type_). a -> a = fun x -> x
 
 let f x =
-  let local_ g (type a : immediate with type_) (x : a) = x in
+  let (g @ local) (type a : immediate with type_) (x : a) = x in
   g x [@nontail]
 ;;
 

--- a/test/passing/tests/layout_annotation_with.ml.ref
+++ b/test/passing/tests/layout_annotation_with.ml.ref
@@ -236,7 +236,7 @@ let o =
 let f : type (a : immediate with type_). a -> a = fun x -> x
 
 let f x =
-  let local_ g (type a : immediate with type_) (x : a) = x in
+  let (g @ local) (type a : immediate with type_) (x : a) = x in
   g x [@nontail]
 
 let f x y (type a : immediate with type_) (z : a) = z

--- a/test/passing/tests/let_punning.ml.js-ref
+++ b/test/passing/tests/let_punning.ml.js-ref
@@ -177,7 +177,7 @@ let v =
 ;;
 
 let w =
-  let%foo local_ x = x
-  and local_ y = y in
+  let%foo x @ local = x
+  and y @ local = y in
   ()
 ;;

--- a/test/passing/tests/let_punning.ml.ref
+++ b/test/passing/tests/let_punning.ml.ref
@@ -160,5 +160,5 @@ let v =
   ()
 
 let w =
-  let%foo local_ x = x and local_ y = y in
+  let%foo x @ local = x and y @ local = y in
   ()

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -21,6 +21,15 @@ let f ~(x : int) = x
 
 let f ?(x : int = 1) = x
 
+(* Legacy [local_] applied to an expression that is already a constraint. The
+   local mode should be folded into the existing constraint's modes rather
+   than producing nested constraints. *)
+let _ = (x : int)
+
+let _ = (x : int)
+
+let _ = x
+
 let xs = [(fun a (type b) ~c -> 1)]
 
 let xs = [(fun a (type b) ~c -> 1)]

--- a/test/passing/tests/local-erased.ml.ref
+++ b/test/passing/tests/local-erased.ml.ref
@@ -4,6 +4,23 @@ let f a ~foo:b ?foo:(c = 1) ~d = ()
 
 let f ~x ~(y : string) ?(z : string) = ()
 
+(* Mixed legacy [local_] with new [@ mode] / [@@ mode] modes on patterns. The
+   legacy [local_] should be folded into the existing mode list, producing a
+   single [@ ...]-group. *)
+let f x = x
+
+let f ~x = x
+
+let f ?(x = 1) = x
+
+let f ~foo:x = x
+
+let f (x : int) = x
+
+let f ~(x : int) = x
+
+let f ?(x : int = 1) = x
+
 let xs = [(fun a (type b) ~c -> 1)]
 
 let xs = [(fun a (type b) ~c -> 1)]

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -4,6 +4,17 @@ let f (local_ a) ~foo:(local_ b) ?foo:(local_ c = 1) ~(local_ d) = ()
 
 let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
 
+(* Mixed legacy [local_] with new [@ mode] / [@@ mode] modes on patterns.
+   The legacy [local_] should be folded into the existing mode list, producing
+   a single [@ ...]-group. *)
+let f (local_ x @ mode) = x
+let f ~(local_ x @ mode) = x
+let f ?(local_ x @ mode = 1) = x
+let f ~foo:(local_ x @ mode) = x
+let f (local_ x : int @ mode) = x
+let f ~(local_ x : int @ mode) = x
+let f ?(local_ x : int @ mode = 1) = x
+
 let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
 
 let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]

--- a/test/passing/tests/local.ml
+++ b/test/passing/tests/local.ml
@@ -15,6 +15,13 @@ let f (local_ x : int @ mode) = x
 let f ~(local_ x : int @ mode) = x
 let f ?(local_ x : int @ mode = 1) = x
 
+(* Legacy [local_] applied to an expression that is already a constraint.
+   The local mode should be folded into the existing constraint's modes
+   rather than producing nested constraints. *)
+let _ = local_ (x : int)
+let _ = local_ (x : int @ mode)
+let _ = local_ (x : @ mode)
+
 let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
 
 let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]

--- a/test/passing/tests/local.ml.js-ref
+++ b/test/passing/tests/local.ml.js-ref
@@ -1,23 +1,23 @@
 let f a b c = 1
-let f (local_ a) ~foo:(local_ b) ?foo:(local_ c = 1) ~(local_ d) = ()
-let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
-let xs = [ (fun (local_ a) (type b) ~(local_ c) -> local_ 1) ]
-let xs = [ (fun (local_ a) (type b) ~(local_ c) -> exclave_ 1) ]
+let f (a @ local) ~foo:(b @ local) ?foo:(c @ local = 1) ~(d @ local) = ()
+let f ~(x @ local) ~(y : string @ local) ?(z : string @ local) = ()
+let xs = [ (fun (a @ local) (type b) ~(c @ local) @ local -> 1) ]
+let xs = [ (fun (a @ local) (type b) ~(c @ local) -> exclave_ 1) ]
 
-let f () = local_
-  let a = [ local_ 1 ] in
-  let local_ r = 1 in
-  let local_ f : 'a. 'a -> 'a = fun x -> local_ x in
-  let local_ g a b c : int = 1 in
-  let () = g (local_ fun () -> ()) in
-  local_ "asdfasdfasdfasdfasdfasdfasdf"
+let f () @ local =
+  let a = [ (1 : @ local) ] in
+  let r @ local = 1 in
+  let f : 'a. ('a -> 'a) @ local = fun x @ local -> x in
+  let (g @ local) a b c : int = 1 in
+  let () = g (fun () -> () : @ local) in
+  ("asdfasdfasdfasdfasdfasdfasdf" : @ local)
 ;;
 
 let f () = exclave_
   let a = [ exclave_ 1 ] in
-  let local_ r = 1 in
-  let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
-  let local_ g a b c : int = 1 in
+  let r @ local = 1 in
+  let f : 'a. ('a -> 'a) @ local = fun x -> exclave_ x in
+  let (g @ local) a b c : int = 1 in
   let () = g (exclave_ fun () -> ()) in
   exclave_ "asdfasdfasdfasdfasdfasdfasdf"
 ;;
@@ -25,35 +25,35 @@ let f () = exclave_
 type 'a r =
   { mutable a : 'a
   ; b : 'a
-  ; global_ c : 'a
+  ; c : 'a @@ global
   }
 
 type 'a r =
-  | Foo of global_ 'a
-  | Bar of 'a * global_ 'a
-  | Baz of global_ int * string * global_ 'a
+  | Foo of 'a @@ global
+  | Bar of 'a * 'a @@ global
+  | Baz of int @@ global * string * 'a @@ global
 
 type ('a, 'b) cfn = a:'a @ local -> ?b:b @ local -> 'a @ local -> (int -> 'b @ local)
 
-let _ = local_ ()
+let _ = (() : @ local)
 let _ = exclave_ ()
-let () = local_ x
+let () = (x : @ local)
 let () = exclave_ x
-let { b } = local_ ()
+let { b } = (() : @ local)
 let { b } = exclave_ ()
-let () = local_ r
+let () = (r : @ local)
 let () = exclave_ r
-let local_ x : string = "hi"
-let (x : string) = local_ "hi"
+let x : string @ local = "hi"
+let (x : string) = ("hi" : @ local)
 let (x : string) = exclave_ "hi"
-let x = local_ ("hi" : string)
+let x = (("hi" : string) : @ local)
 let x = exclave_ ("hi" : string)
-let x : 'a. 'a -> 'a = local_ "hi"
+let x : 'a. 'a -> 'a = ("hi" : @ local)
 let x : 'a. 'a -> 'a = exclave_ "hi"
-let local_ f : 'a. 'a -> 'a = "hi"
+let f : 'a. ('a -> 'a) @ local = "hi"
 
 let foo () =
-  if true then (local_ ());
+  if true then (() : @ local);
   ()
 ;;
 
@@ -69,10 +69,9 @@ let[@local never] upstream_local_attr_never_short x = x
 let[@local always] upstream_local_attr_always_short x = x
 let[@local maybe] upstream_local_attr_maybe_short x = x
 
-let f x =
+let f x @ local =
   (* a *)
   (* b *)
-  local_
   (* c *)
   (* d *)
   let y = 1 in
@@ -92,11 +91,12 @@ let f x =
 let x =
   (* a *)
   (* b *)
-  local_
-  (* c *)
-  (* d *)
-  let y = 1 in
-  y
+  ((* c *)
+   (* d *)
+   let y = 1 in
+   y
+   :
+   @ local)
 ;;
 
 let x =
@@ -114,19 +114,19 @@ module type S = functor (_ : S) (_ : S) -> S
    different *)
 
 let f
-  (local_ (* a *)
-          (* b *)
-          (* c *)
-          (* d *)
-    a)
+  (* a *)
+  (* b *)
+  (* c *)
+  (* d *)
+  (a @ local)
   ~foo:
-    (local_ (* e *)
-            (* f *)
-            (* g *)
-            (* h *)
-    b)
-  ?foo:(local_ c = 1)
-  ~(local_ d)
+    (* e *)
+    (* f *)
+    (* g *)
+    (* h *)
+    (b @ local)
+  ?foo:(c @ local = 1)
+  ~(d @ local)
   =
   ()
 ;;
@@ -136,47 +136,46 @@ type 'a r =
   ; b : 'a
   ; (* a *)
     (* b *)
-    global_ (* c *)
-            (* d *) c :
-      'a
+    (* c *)
+    (* d *) c : 'a @@ global
   }
 
 type 'a r =
   | Foo of
       (* a *)
       (* b *)
-      global_ (* c *)
-              (* d *)
-      'a
+      (* c *)
+      (* d *)
+      'a @@ global
   | Bar of
       'a
       * (* e *)
         (* f *)
-      global_ (* g *)
-              (* h *)
-      'a
+        (* g *)
+        (* h *)
+      'a @@ global
   | Baz of
-      global_ int
+      int @@ global
       * string
       * (* i *)
         (* j *)
-      global_ (* k *)
-              (* l *)
-      'a
+        (* k *)
+        (* l *)
+      'a @@ global
 
 let () =
-  let foo (local_ (_ : int)) = 10 in
-  let bar (local_ (Some x : _)) = Some 10 in
-  let baz (local_ (Some x)) = Some 10 in
+  let foo (_ : int @ local) = 10 in
+  let bar (Some x : _ @ local) = Some 10 in
+  let baz (Some x @ local) = Some 10 in
   ()
 ;;
 
 type t : value
 
-let _ = (local_ x) + y
-let _ = (local_ x) |> f
-let _ = local_ x + y
-let _ = local_ x |> f
+let _ = (x : @ local) + y
+let _ = (x : @ local) |> f
+let _ = (x + y : @ local)
+let _ = (x |> f : @ local)
 let _ = (exclave_ x) + y
 let _ = (exclave_ x) |> f
 let _ = exclave_ x + y
@@ -187,83 +186,107 @@ let _ =
   M.x
     (* 2 *) l (* 3 *)
     ~f:
-      ((* 4 *)
-       (* 5 *)
+      (* 4 *)
+      ((* 5 *)
        (* 6 *)
-      local_ fun
-        x (* 7 *) ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-        (* 7 *)
-        (module struct
-          type nonrec t = M.t
-        end))
+       fun x (* 7 *) ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+           (* 7 *)
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
 ;;
 
 let _ =
-  List.iter l ~f:(local_ fun xxxxx ->
-    Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-      (module struct
-        type nonrec t = M.t
-      end))
-;;
-
-let _ =
-  (* 1 *)
-  M.x
-    (* 2 *) l (* 3 *)
-    ~f:((* 4 *)
-        (* 5 *)
-        (* 6 *)
-    local_ function x (* 7 *) ->
-    Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-      (* 8 *)
-      (module struct
-        type nonrec t = M.t
-      end))
-;;
-
-let _ =
-  List.iter l ~f:(local_ function xxxxx ->
-    Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-      (module struct
-        type nonrec t = M.t
-      end))
+  List.iter
+    l
+    ~f:
+      (fun xxxxx ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
 ;;
 
 let _ =
   (* 1 *)
   M.x
     (* 2 *) l (* 3 *)
-    ~f:((* 4 *)
-        (* 5 *)
-        (* 6 *)
-    local_ function
-    | _ ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
-        (* 8 *)
-        (module struct
-          type nonrec t = M.t
-        end)
-    | _ ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
-        (* 9 *)
-        (module struct
-          type nonrec t = M.t
-        end))
+    ~f:
+      (* 4 *)
+      ((* 5 *)
+       (* 6 *)
+       function
+       | x (* 7 *) ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+           (* 8 *)
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
 ;;
 
 let _ =
-  List.iter l ~f:(local_ function
-    | _ ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-        (module struct
-          type nonrec t = M.t
-        end)
-    | _ ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-        (module struct
-          type nonrec t = M.t
-        end))
+  List.iter
+    l
+    ~f:
+      (function
+       | xxxxx ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
+;;
+
+let _ =
+  (* 1 *)
+  M.x
+    (* 2 *) l (* 3 *)
+    ~f:
+      (* 4 *)
+      ((* 5 *)
+       (* 6 *)
+       function
+       | _ ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
+           (* 8 *)
+           (module struct
+             type nonrec t = M.t
+           end)
+       | _ ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
+           (* 9 *)
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
+;;
+
+let _ =
+  List.iter
+    l
+    ~f:
+      (function
+       | _ ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       | _ ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
 ;;
 
 let _ =
@@ -272,71 +295,89 @@ let _ =
     ~f:
       ((* 2 *)
        (* 3 *)
-      local_ fun
-        (* 4 *) xxxxx ->
-      (* 5 *)
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        (module struct
-          type nonrec t = M.t
-        end))
+       fun (* 4 *) xxxxx ->
+         (* 5 *)
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
     ~g:x
 ;;
 
 let _ =
   List.iter
     l
-    ~f:(local_ fun xxxxx ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        (module struct
-          type nonrec t = M.t
-        end))
+    ~f:
+      (fun xxxxx ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
     ~g:x
 ;;
 
 let _ =
   List.iter
     l (* 1 *)
-    ~f:((* 2 *)
-        (* 3 *) local_ function
-      (* 4 *)
-      | xxxxx ->
-        (* 5 *)
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-          (module struct
-            type nonrec t = M.t
-          end))
+    ~f:
+      ((* 2 *)
+       (* 3 *)
+       function
+       (* 4 *)
+       | xxxxx ->
+         (* 5 *)
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
     ~g:x
 ;;
 
 let _ =
   List.iter
     l
-    ~f:(local_ function
-      | xxxxx ->
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-          (module struct
-            type nonrec t = M.t
-          end))
+    ~f:
+      (function
+       | xxxxx ->
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
     ~g:x
 ;;
 
 let _ =
   List.iter
     l (* 1 *)
-    ~f:((* 2 *)
-        (* 3 *) local_ function
-      (* 4 *)
-      | _ (* 5 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
-      | _ (* 6 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x)
+    ~f:
+      ((* 2 *)
+       (* 3 *)
+       function
+       (* 4 *)
+       | _ (* 5 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+       | _ (* 6 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+       :
+       @ local)
     ~g:x
 ;;
 
 let _ =
   List.iter
     l
-    ~f:(local_ function
-      | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
-      | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x)
+    ~f:
+      (function
+       | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+       | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+       :
+       @ local)
     ~g:x
 ;;
 
@@ -344,49 +385,65 @@ let _ =
 let _ =
   List.iter
     l
-    ~f:(local_ function
-      (* x *)
-      | xxxxx (* y *) ->
-        (* z *)
-        exclave_
-        (* w *)
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-          (module struct
-            type nonrec t = M.t
-          end))
+    ~f:
+      (function
+       (* x *)
+       | xxxxx (* y *) ->
+         (* z *)
+         exclave_
+         (* w *)
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
     ~g:x
-;;
-
-let _ =
-  List.iter l ~f:(local_ fun (* x *) xxxxx (* y *) ->
-    (* z *)
-    exclave_
-    (* w *)
-    Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-      (module struct
-        type nonrec t = M.t
-      end))
 ;;
 
 let _ =
   List.iter
     l
-    ~f:(local_ function
-      | xxxxx ->
-        exclave_
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-          (module struct
-            type nonrec t = M.t
-          end))
+    ~f:
+      (fun (* x *) xxxxx (* y *) ->
+         (* z *)
+         exclave_
+         (* w *)
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
+;;
+
+let _ =
+  List.iter
+    l
+    ~f:
+      (function
+       | xxxxx ->
+         exclave_
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
     ~g:x
 ;;
 
 let _ =
-  List.iter l ~f:(local_ fun xxxxx -> exclave_
-    Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-      (module struct
-        type nonrec t = M.t
-      end))
+  List.iter
+    l
+    ~f:
+      (fun xxxxx -> exclave_
+         Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+           (module struct
+             type nonrec t = M.t
+           end)
+       :
+       @ local)
 ;;
 
 (* Two funs breaks comments *)
@@ -427,18 +484,23 @@ let _ =
 (* Two arguments *)
 let xxxxxxxxxxxxxxxxx xxxxxxx ~xxx =
   xxxxxxx
-    (local_ fun () ->
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
-    (local_ fun () ->
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+    (fun () ->
+       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+     :
+     @ local)
+    (fun () ->
+       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
+       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+     :
+     @ local)
 ;;
 
 (* Comment shouldn't split [local_ fun] *)
 let x =
   xxxxxxx
     ~xxxxxxxxxxxxxxxxxxxxxxxxxxx:(fun _ -> x)
-    ~xxxxxxxxxxxxxxxxxxxxxxxxxxx:((* xxxxxxxxxxxxxxxxxxxxxxxxxx *)
-      local_ fun _ _ -> xxxxxxxxxxxxxxxxxxxxxx)
+    ~xxxxxxxxxxxxxxxxxxxxxxxxxxx:
+      (* xxxxxxxxxxxxxxxxxxxxxxxxxx *)
+      (fun _ _ -> xxxxxxxxxxxxxxxxxxxxxx : @ local)
 ;;

--- a/test/passing/tests/local.ml.js-ref
+++ b/test/passing/tests/local.ml.js-ref
@@ -1,6 +1,17 @@
 let f a b c = 1
 let f (a @ local) ~foo:(b @ local) ?foo:(c @ local = 1) ~(d @ local) = ()
 let f ~(x @ local) ~(y : string @ local) ?(z : string @ local) = ()
+
+(* Mixed legacy [local_] with new [@ mode] / [@@ mode] modes on patterns. The legacy
+   [local_] should be folded into the existing mode list, producing a single
+   [@ ...]-group. *)
+let f (x @ local mode) = x
+let f ~(x @ local mode) = x
+let f ?(x @ local mode = 1) = x
+let f ~foo:(x @ local mode) = x
+let f (x : int @ local mode) = x
+let f ~(x : int @ local mode) = x
+let f ?(x : int @ local mode = 1) = x
 let xs = [ (fun (a @ local) (type b) ~(c @ local) @ local -> 1) ]
 let xs = [ (fun (a @ local) (type b) ~(c @ local) -> exclave_ 1) ]
 

--- a/test/passing/tests/local.ml.js-ref
+++ b/test/passing/tests/local.ml.js-ref
@@ -12,6 +12,13 @@ let f ~foo:(x @ local mode) = x
 let f (x : int @ local mode) = x
 let f ~(x : int @ local mode) = x
 let f ?(x : int @ local mode = 1) = x
+
+(* Legacy [local_] applied to an expression that is already a constraint. The local mode
+   should be folded into the existing constraint's modes rather than producing nested
+   constraints. *)
+let _ = ((x : int) : @ local)
+let _ = ((x : int @ mode) : @ local)
+let _ = ((x : @ mode) : @ local)
 let xs = [ (fun (a @ local) (type b) ~(c @ local) @ local -> 1) ]
 let xs = [ (fun (a @ local) (type b) ~(c @ local) -> exclave_ 1) ]
 

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -4,6 +4,32 @@ let f (a @ local) ~foo:(b @ local) ?foo:(c @ local = 1) ~(d @ local) = ()
 
 let f ~(x @ local) ~(y : string @ local) ?(z : string @ local) = ()
 
+(* Mixed legacy [local_] with new [@ mode] / [@@ mode] modes on patterns. The
+   legacy [local_] should be folded into the existing mode list, producing a
+   single [@ ...]-group. *)
+let f (x @ local mode) = x
+
+let f ~(x @ local mode) = x
+
+let f ?(x @ local mode = 1) = x
+
+let f ~foo:(x @ local mode) = x
+
+let f (x : int @ local mode) = x
+
+let f ~(x : int @ local mode) = x
+
+let f ?(x : int @ local mode = 1) = x
+
+(* Legacy [local_] applied to an expression that is already a constraint. The
+   local mode should be folded into the existing constraint's modes rather
+   than producing nested constraints. *)
+let _ = ((x : int) : @ local)
+
+let _ = ((x : int @ mode) : @ local)
+
+let _ = ((x : @ mode) : @ local)
+
 let xs = [(fun (a @ local) (type b) ~(c @ local) @ local -> 1)]
 
 let xs = [(fun (a @ local) (type b) ~(c @ local) -> exclave_ 1)]

--- a/test/passing/tests/local.ml.ref
+++ b/test/passing/tests/local.ml.ref
@@ -1,73 +1,73 @@
 let f a b c = 1
 
-let f (local_ a) ~foo:(local_ b) ?foo:(local_ c = 1) ~(local_ d) = ()
+let f (a @ local) ~foo:(b @ local) ?foo:(c @ local = 1) ~(d @ local) = ()
 
-let f ~(local_ x) ~(local_ y : string) ?(local_ z : string) = ()
+let f ~(x @ local) ~(y : string @ local) ?(z : string @ local) = ()
 
-let xs = [(fun (local_ a) (type b) ~(local_ c) -> local_ 1)]
+let xs = [(fun (a @ local) (type b) ~(c @ local) @ local -> 1)]
 
-let xs = [(fun (local_ a) (type b) ~(local_ c) -> exclave_ 1)]
+let xs = [(fun (a @ local) (type b) ~(c @ local) -> exclave_ 1)]
 
-let f () = local_
-  let a = [local_ 1] in
-  let local_ r = 1 in
-  let local_ f : 'a. 'a -> 'a = fun x -> local_ x in
-  let local_ g a b c : int = 1 in
-  let () = g (local_ fun () -> ()) in
-  local_ "asdfasdfasdfasdfasdfasdfasdf"
+let f () @ local =
+  let a = [(1 : @ local)] in
+  let r @ local = 1 in
+  let f : 'a. ('a -> 'a) @ local = fun x @ local -> x in
+  let (g @ local) a b c : int = 1 in
+  let () = g (fun () -> () : @ local) in
+  ("asdfasdfasdfasdfasdfasdfasdf" : @ local)
 
 let f () = exclave_
   let a = [exclave_ 1] in
-  let local_ r = 1 in
-  let local_ f : 'a. 'a -> 'a = fun x -> exclave_ x in
-  let local_ g a b c : int = 1 in
+  let r @ local = 1 in
+  let f : 'a. ('a -> 'a) @ local = fun x -> exclave_ x in
+  let (g @ local) a b c : int = 1 in
   let () = g (exclave_ fun () -> ()) in
   exclave_ "asdfasdfasdfasdfasdfasdfasdf"
 
-type 'a r = {mutable a: 'a; b: 'a; global_ c: 'a}
+type 'a r = {mutable a: 'a; b: 'a; c: 'a @@ global}
 
 type 'a r =
-  | Foo of global_ 'a
-  | Bar of 'a * global_ 'a
-  | Baz of global_ int * string * global_ 'a
+  | Foo of 'a @@ global
+  | Bar of 'a * 'a @@ global
+  | Baz of int @@ global * string * 'a @@ global
 
 type ('a, 'b) cfn =
   a:'a @ local -> ?b:b @ local -> 'a @ local -> (int -> 'b @ local)
 
-let _ = local_ ()
+let _ = (() : @ local)
 
 let _ = exclave_ ()
 
-let () = local_ x
+let () = (x : @ local)
 
 let () = exclave_ x
 
-let {b} = local_ ()
+let {b} = (() : @ local)
 
 let {b} = exclave_ ()
 
-let () = local_ r
+let () = (r : @ local)
 
 let () = exclave_ r
 
-let local_ x : string = "hi"
+let x : string @ local = "hi"
 
-let (x : string) = local_ "hi"
+let (x : string) = ("hi" : @ local)
 
 let (x : string) = exclave_ "hi"
 
-let x = local_ ("hi" : string)
+let x = (("hi" : string) : @ local)
 
 let x = exclave_ ("hi" : string)
 
-let x : 'a. 'a -> 'a = local_ "hi"
+let x : 'a. 'a -> 'a = ("hi" : @ local)
 
 let x : 'a. 'a -> 'a = exclave_ "hi"
 
-let local_ f : 'a. 'a -> 'a = "hi"
+let f : 'a. ('a -> 'a) @ local = "hi"
 
 let foo () =
-  if true then (local_ ()) ;
+  if true then (() : @ local) ;
   ()
 
 let[@ocaml.local] upstream_local_attr_long x = x
@@ -88,10 +88,9 @@ let[@local always] upstream_local_attr_always_short x = x
 
 let[@local maybe] upstream_local_attr_maybe_short x = x
 
-let f x =
+let f x @ local =
   (* a *)
   (* b *)
-  local_
   (* c *)
   (* d *)
   let y = 1 in
@@ -109,11 +108,12 @@ let f x =
 let x =
   (* a *)
   (* b *)
-  local_
-  (* c *)
-  (* d *)
-  let y = 1 in
-  y
+  ( (* c *)
+    (* d *)
+    let y = 1 in
+    y
+    :
+    @ local )
 
 let x =
   (* a *)
@@ -129,16 +129,16 @@ module type S = functor (_ : S) (_ : S) -> S
    extended AST is different *)
 
 let f
-    (local_ (* a *)
-            (* b *)
-            (* c *)
-            (* d *)
-      a )
-    ~foo:(local_ (* e *)
-                 (* f *)
-                 (* g *)
-                 (* h *)
-      b ) ?foo:(local_ c = 1) ~(local_ d) =
+    (* a *)
+    (* b *)
+    (* c *)
+    (* d *) (a @ local)
+    ~foo:
+      (* e *)
+      (* f *)
+      (* g *)
+      (* h *)
+      (b @ local) ?foo:(c @ local = 1) ~(d @ local) =
   ()
 
 type 'a r =
@@ -146,48 +146,47 @@ type 'a r =
   ; b: 'a
   ; (* a *)
     (* b *)
-    global_ (* c *)
-            (* d *) c:
-      'a }
+    (* c *)
+    (* d *) c: 'a @@ global }
 
 type 'a r =
   | Foo of
       (* a *)
       (* b *)
-      global_ (* c *)
-              (* d *)
-      'a
+      (* c *)
+      (* d *)
+      'a @@ global
   | Bar of
       'a
       * (* e *)
         (* f *)
-      global_ (* g *)
-              (* h *)
-      'a
+        (* g *)
+        (* h *)
+      'a @@ global
   | Baz of
-      global_ int
+      int @@ global
       * string
       * (* i *)
         (* j *)
-      global_ (* k *)
-              (* l *)
-      'a
+        (* k *)
+        (* l *)
+      'a @@ global
 
 let () =
-  let foo (local_ (_ : int)) = 10 in
-  let bar (local_ (Some x : _)) = Some 10 in
-  let baz (local_ (Some x)) = Some 10 in
+  let foo (_ : int @ local) = 10 in
+  let bar (Some x : _ @ local) = Some 10 in
+  let baz (Some x @ local) = Some 10 in
   ()
 
 type t : value
 
-let _ = (local_ x) + y
+let _ = (x : @ local) + y
 
-let _ = (local_ x) |> f
+let _ = (x : @ local) |> f
 
-let _ = local_ x + y
+let _ = (x + y : @ local)
 
-let _ = local_ x |> f
+let _ = (x |> f : @ local)
 
 let _ = (exclave_ x) + y
 
@@ -200,179 +199,235 @@ let _ = exclave_ x |> f
 let _ =
   (* 1 *)
   M.x (* 2 *) l (* 3 *)
-    ~f:((* 4 *)
-        (* 5 *)
+    ~f:
+      (* 4 *)
+      ( (* 5 *)
         (* 6 *)
-      local_ fun
-        x (* 7 *) ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-        (* 7 *)
-        ( module struct
-          type nonrec t = M.t
-        end ) )
+        fun x (* 7 *) ->
+          Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+            (* 7 *)
+            ( module struct
+              type nonrec t = M.t
+            end )
+        :
+        @ local )
 
 let _ =
-  List.iter l ~f:(local_ fun xxxxx ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        ( module struct
-          type nonrec t = M.t
-        end ) )
-
-let _ =
-  (* 1 *)
-  M.x (* 2 *) l (* 3 *)
-      ~f:((* 4 *)
-          (* 5 *)
-          (* 6 *) local_ function x (* 7 *) ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-        (* 8 *)
-        ( module struct
-          type nonrec t = M.t
-        end ) )
-
-let _ =
-  List.iter l ~f:(local_ function xxxxx ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        ( module struct
-          type nonrec t = M.t
-        end ) )
+  List.iter l
+    ~f:
+      ( fun xxxxx ->
+          Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+            ( module struct
+              type nonrec t = M.t
+            end )
+        :
+        @ local )
 
 let _ =
   (* 1 *)
   M.x (* 2 *) l (* 3 *)
-    ~f:((* 4 *)
-        (* 5 *)
-        (* 6 *) local_ function
-    | _ ->
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
-          (* 8 *)
-          ( module struct
-            type nonrec t = M.t
-          end )
-    | _ ->
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
-          (* 9 *)
-          ( module struct
-            type nonrec t = M.t
-          end ) )
+    ~f:
+      (* 4 *)
+      ( (* 5 *)
+        (* 6 *)
+        function
+        | x (* 7 *) ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+              (* 8 *)
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
 
 let _ =
-  List.iter l ~f:(local_ function
-    | _ ->
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-          ( module struct
-            type nonrec t = M.t
-          end )
-    | _ ->
-        Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
-          ( module struct
-            type nonrec t = M.t
-          end ) )
+  List.iter l
+    ~f:
+      ( function
+        | xxxxx ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
+
+let _ =
+  (* 1 *)
+  M.x (* 2 *) l (* 3 *)
+    ~f:
+      (* 4 *)
+      ( (* 5 *)
+        (* 6 *)
+        function
+        | _ ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
+              (* 8 *)
+              ( module struct
+                type nonrec t = M.t
+              end )
+        | _ ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxx
+              (* 9 *)
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
+
+let _ =
+  List.iter l
+    ~f:
+      ( function
+        | _ ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        | _ ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
 
 let _ =
   List.iter l (* 1 *)
-    ~f:((* 2 *)
+    ~f:
+      ( (* 2 *)
         (* 3 *)
-      local_ fun
-        (* 4 *) xxxxx ->
-      (* 5 *)
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        ( module struct
-          type nonrec t = M.t
-        end ) )
-    ~g:x
-
-let _ =
-  List.iter l
-    ~f:(local_ fun xxxxx ->
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        ( module struct
-          type nonrec t = M.t
-        end ) )
-    ~g:x
-
-let _ =
-  List.iter l (* 1 *)
-    ~f:((* 2 *)
-        (* 3 *) local_ function
-      (* 4 *)
-      | xxxxx ->
+        fun (* 4 *) xxxxx ->
           (* 5 *)
           Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
             ( module struct
               type nonrec t = M.t
-            end ) )
+            end )
+        :
+        @ local )
     ~g:x
 
 let _ =
   List.iter l
-    ~f:(local_ function
-      | xxxxx ->
+    ~f:
+      ( fun xxxxx ->
           Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
             ( module struct
               type nonrec t = M.t
-            end ) )
+            end )
+        :
+        @ local )
     ~g:x
 
 let _ =
   List.iter l (* 1 *)
-    ~f:((* 2 *)
-        (* 3 *) local_ function
-      (* 4 *)
-      | _ (* 5 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
-      | _ (* 6 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x )
+    ~f:
+      ( (* 2 *)
+        (* 3 *)
+        function
+        (* 4 *)
+        | xxxxx ->
+            (* 5 *)
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
     ~g:x
 
 let _ =
   List.iter l
-    ~f:(local_ function
-      | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
-      | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x )
+    ~f:
+      ( function
+        | xxxxx ->
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
+    ~g:x
+
+let _ =
+  List.iter l (* 1 *)
+    ~f:
+      ( (* 2 *)
+        (* 3 *)
+        function
+        (* 4 *)
+        | _ (* 5 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+        | _ (* 6 *) -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+        :
+        @ local )
+    ~g:x
+
+let _ =
+  List.iter l
+    ~f:
+      ( function
+        | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+        | _ -> Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx x
+        :
+        @ local )
     ~g:x
 
 (* [exclave_] *)
 let _ =
   List.iter l
-    ~f:(local_ function
-      (* x *)
-      | xxxxx (* y *) ->
+    ~f:
+      ( function
+        (* x *)
+        | xxxxx (* y *) ->
+            (* z *)
+            exclave_
+            (* w *)
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
+    ~g:x
+
+let _ =
+  List.iter l
+    ~f:
+      ( fun (* x *) xxxxx (* y *) ->
           (* z *)
           exclave_
           (* w *)
           Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
             ( module struct
               type nonrec t = M.t
-            end ) )
-    ~g:x
-
-let _ =
-  List.iter l ~f:(local_ fun (* x *) xxxxx (* y *) ->
-      (* z *)
-      exclave_
-      (* w *)
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        ( module struct
-          type nonrec t = M.t
-        end ) )
+            end )
+        :
+        @ local )
 
 let _ =
   List.iter l
-    ~f:(local_ function
-      | xxxxx ->
-          exclave_
-          Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-            ( module struct
-              type nonrec t = M.t
-            end ) )
+    ~f:
+      ( function
+        | xxxxx ->
+            exclave_
+            Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+              ( module struct
+                type nonrec t = M.t
+              end )
+        :
+        @ local )
     ~g:x
 
 let _ =
-  List.iter l ~f:(local_ fun xxxxx ->
-      exclave_
-      Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
-        ( module struct
-          type nonrec t = M.t
-        end ) )
+  List.iter l
+    ~f:
+      ( fun xxxxx -> exclave_
+          Xxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxx
+            ( module struct
+              type nonrec t = M.t
+            end )
+        :
+        @ local )
 
 (* Two funs breaks comments *)
 let _ = M.f ~x:(fun _ -> x) ~y:((* c *) stack_ fun _ -> y)
@@ -407,17 +462,21 @@ let _ =
 (* Two arguments *)
 let xxxxxxxxxxxxxxxxx xxxxxxx ~xxx =
   xxxxxxx
-    (local_ fun () ->
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx ;
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx )
-    (local_ fun () ->
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx ;
-      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx )
+    ( fun () ->
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx ;
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      :
+      @ local )
+    ( fun () ->
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx ;
+        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      :
+      @ local )
 
 (* Comment shouldn't split [local_ fun] *)
 let x =
   xxxxxxx
     ~xxxxxxxxxxxxxxxxxxxxxxxxxxx:(fun _ -> x)
-    ~xxxxxxxxxxxxxxxxxxxxxxxxxxx:((* xxxxxxxxxxxxxxxxxxxxxxxxxx *)
-      local_ fun
-        _ _ -> xxxxxxxxxxxxxxxxxxxxxx )
+    ~xxxxxxxxxxxxxxxxxxxxxxxxxxx:
+      (* xxxxxxxxxxxxxxxxxxxxxxxxxx *)
+      (fun _ _ -> xxxxxxxxxxxxxxxxxxxxxx : @ local)

--- a/test/passing/tests/modes-ocaml_version.ml.ref
+++ b/test/passing/tests/modes-ocaml_version.ml.ref
@@ -613,9 +613,9 @@ end
 module Interaction_with_existing_syntax = struct
   (* let bindings *)
 
-  let local_ x @ mode1 mode2 = y
+  let x @ local mode1 mode2 = y
 
-  let local_ x : typ1 typ2 @ mode1 mode2 = y
+  let x : typ1 typ2 @ local mode1 mode2 = y
 
   (* lhs/rhs of arrows *)
 
@@ -627,19 +627,19 @@ module Interaction_with_existing_syntax = struct
 
   (* modalities on record fields *)
 
-  type t = {global_ x: t @@ mode1 mode2}
+  type t = {x: t @@ global mode1 mode2}
 
-  type t = A of {global_ x: t @@ mode1 mode2}
+  type t = A of {x: t @@ global mode1 mode2}
 
   (* modalities on constructor arguments *)
 
   type t =
-    | A of global_ typ @@ mode1 mode2
-    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+    | A of typ @@ global mode1 mode2
+    | B of typ1 @@ global mode1 * typ2 @@ global mode2
 
   type t =
-    | A : global_ typ @@ mode1 mode2 -> t
-    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+    | A : typ @@ global mode1 mode2 -> t
+    | B : typ1 @@ global mode1 * typ2 @@ global mode2 -> t
 end
 
 module Regressions = struct
@@ -652,13 +652,17 @@ module Regressions = struct
     let (x, y) @ mode = (x, y) in
     (x, y)
 
-  let (t as t) @ mode = local_
-    let (t as t) @ mode = local_ t in
-    t
+  let (t as t) @ mode =
+    ( let (t as t) @ mode = (t : @ local) in
+      t
+      :
+      @ local )
 
-  let (x, y) @ mode = local_
-    let (x, y) @ mode = local_ t in
-    t
+  let (x, y) @ mode =
+    ( let (x, y) @ mode = (t : @ local) in
+      t
+      :
+      @ local )
 
   class t =
     let (x, y) @ mode = x in

--- a/test/passing/tests/modes.ml.js-ref
+++ b/test/passing/tests/modes.ml.js-ref
@@ -676,8 +676,8 @@ end
 module Interaction_with_existing_syntax = struct
   (* let bindings *)
 
-  let local_ x @ mode1 mode2 = y
-  let local_ x : typ1 typ2 @ mode1 mode2 = y
+  let x @ local mode1 mode2 = y
+  let x : typ1 typ2 @ local mode1 mode2 = y
 
   (* lhs/rhs of arrows *)
 
@@ -688,18 +688,18 @@ module Interaction_with_existing_syntax = struct
 
   (* modalities on record fields *)
 
-  type t = { global_ x : t @@ mode1 mode2 }
-  type t = A of { global_ x : t @@ mode1 mode2 }
+  type t = { x : t @@ global mode1 mode2 }
+  type t = A of { x : t @@ global mode1 mode2 }
 
   (* modalities on constructor arguments *)
 
   type t =
-    | A of global_ typ @@ mode1 mode2
-    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+    | A of typ @@ global mode1 mode2
+    | B of typ1 @@ global mode1 * typ2 @@ global mode2
 
   type t =
-    | A : global_ typ @@ mode1 mode2 -> t
-    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+    | A : typ @@ global mode1 mode2 -> t
+    | B : typ1 @@ global mode1 * typ2 @@ global mode2 -> t
 end
 
 module Regressions = struct
@@ -714,14 +714,18 @@ module Regressions = struct
     x, y
   ;;
 
-  let (t as t) @ mode = local_
-    let (t as t) @ mode = local_ t in
-    t
+  let (t as t) @ mode =
+    (let (t as t) @ mode = (t : @ local) in
+     t
+     :
+     @ local)
   ;;
 
-  let (x, y) @ mode = local_
-    let (x, y) @ mode = local_ t in
-    t
+  let (x, y) @ mode =
+    (let (x, y) @ mode = (t : @ local) in
+     t
+     :
+     @ local)
   ;;
 
   class t =

--- a/test/passing/tests/modes.ml.ref
+++ b/test/passing/tests/modes.ml.ref
@@ -613,9 +613,9 @@ end
 module Interaction_with_existing_syntax = struct
   (* let bindings *)
 
-  let local_ x @ mode1 mode2 = y
+  let x @ local mode1 mode2 = y
 
-  let local_ x : typ1 typ2 @ mode1 mode2 = y
+  let x : typ1 typ2 @ local mode1 mode2 = y
 
   (* lhs/rhs of arrows *)
 
@@ -627,19 +627,19 @@ module Interaction_with_existing_syntax = struct
 
   (* modalities on record fields *)
 
-  type t = {global_ x: t @@ mode1 mode2}
+  type t = {x: t @@ global mode1 mode2}
 
-  type t = A of {global_ x: t @@ mode1 mode2}
+  type t = A of {x: t @@ global mode1 mode2}
 
   (* modalities on constructor arguments *)
 
   type t =
-    | A of global_ typ @@ mode1 mode2
-    | B of global_ typ1 @@ mode1 * global_ typ2 @@ mode2
+    | A of typ @@ global mode1 mode2
+    | B of typ1 @@ global mode1 * typ2 @@ global mode2
 
   type t =
-    | A : global_ typ @@ mode1 mode2 -> t
-    | B : global_ typ1 @@ mode1 * global_ typ2 @@ mode2 -> t
+    | A : typ @@ global mode1 mode2 -> t
+    | B : typ1 @@ global mode1 * typ2 @@ global mode2 -> t
 end
 
 module Regressions = struct
@@ -652,13 +652,17 @@ module Regressions = struct
     let (x, y) @ mode = (x, y) in
     (x, y)
 
-  let (t as t) @ mode = local_
-    let (t as t) @ mode = local_ t in
-    t
+  let (t as t) @ mode =
+    ( let (t as t) @ mode = (t : @ local) in
+      t
+      :
+      @ local )
 
-  let (x, y) @ mode = local_
-    let (x, y) @ mode = local_ t in
-    t
+  let (x, y) @ mode =
+    ( let (x, y) @ mode = (t : @ local) in
+      t
+      :
+      @ local )
 
   class t =
     let (x, y) @ mode = x in


### PR DESCRIPTION
Format Jane Street legacy `local_` / `global_` annotations using the new mode / modality syntax. Conversions:

- `local_ exp` → `(exp : @ local)`
- `(local_ pat)`, `~(local_ pat)`, `?(local_ pat = e)` etc. → `(pat @ local)` (6 sites in `fmt_fun_args`)
- `let local_ x = e` → `let x @ local = e`
- `{ global_ c : t }` → `{ c : t @@ global }` (record fields)
- `C of global_ T` → `C of T @@ global` (constructor args)

Arrow types (`local_ T -> U` → `T @ local -> U`) are handled by #142 (now in `oxcaml/jane`), so this PR's scope is just expressions, patterns, let-bindings, record fields, and constructor arguments.

The standard parser canonicalizes the legacy and new forms to the same AST in most places (via `with_optional_mode_expr` etc.), so the round-trip AST equality check passes naturally for the conversions above. One case needed extra help: the formatter's pre-existing `type_constr_and_body` transformation hoists modes from a function body `(y : @ mode)` into the function's `ret_mode_annotations`. The std parser distinguishes these two shapes and existing normalization only handled the `Pexp_constraint(_, Some ty, [])` case; this PR adds the symmetric rule for `Pexp_constraint(_, None, modes)`.

The `lb_local` field on `Sugar.Let_binding.t` is removed; `Sugar.of_let_binding` now folds `pvb_local=true` into `pvb_modes` so the regular new-syntax printing path takes over.

Mixed legacy + new syntax (e.g. `(local_ x @ mode)`) merges the `local` mode into the existing modes list, so the output is a single `@ ...` group `(x @ local mode)` instead of an invalid `((x @ mode) @ local)` re-extension.

Other legacy AST shapes (`Pparam_val (true, ...)` for plain `Ppat_var`, `global_` attribute on record/constructor fields, `Pexp_apply (extension_local, ...)`) remain in the AST as the parser produced them; the formatter simply prints them in the new syntax.

Tests in `local.ml` exercise the six mixed-syntax pattern shapes and the three `local_ (e : ...)` expression shapes.