### PR TITLE
Short kinds can be adjacent

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -420,6 +420,7 @@ module Structure_item = struct
      |Pstr_primitive {pval_attributes= atrs; _}
      |Pstr_type (_, {ptype_attributes= atrs; _} :: _)
      |Pstr_typext {ptyext_attributes= atrs; _}
+     |Pstr_jkind {pjkind_attributes= atrs; _}
      |Pstr_recmodule ({pmb_expr= {pmod_attributes= atrs; _}; _} :: _)
      |Pstr_open {popen_attributes= atrs; _}
      |Pstr_extension (_, atrs)
@@ -440,7 +441,6 @@ module Structure_item = struct
         || List.exists ~f:Attr.is_doc pmod_attributes
     | Pstr_value {pvbs_bindings= []; _}
      |Pstr_type (_, [])
-     |Pstr_jkind _
      |Pstr_recmodule []
      |Pstr_class_type []
      |Pstr_class [] ->
@@ -477,6 +477,7 @@ module Structure_item = struct
        |Pstr_value _, Pstr_value _
        |Pstr_primitive _, Pstr_primitive _
        |(Pstr_type _ | Pstr_typext _), (Pstr_type _ | Pstr_typext _)
+       |Pstr_jkind _, Pstr_jkind _
        |Pstr_exception _, Pstr_exception _
        |( (Pstr_module _ | Pstr_recmodule _ | Pstr_open _ | Pstr_include _)
         , (Pstr_module _ | Pstr_recmodule _ | Pstr_open _ | Pstr_include _) )
@@ -517,6 +518,7 @@ module Signature_item = struct
      |Psig_type (_, {ptype_attributes= atrs; _} :: _)
      |Psig_typesubst ({ptype_attributes= atrs; _} :: _)
      |Psig_typext {ptyext_attributes= atrs; _}
+     |Psig_jkind {pjkind_attributes= atrs; _}
      |Psig_open {popen_attributes= atrs; _}
      |Psig_extension (_, atrs)
      |Psig_class_type ({pci_attributes= atrs; _} :: _)
@@ -542,7 +544,6 @@ module Signature_item = struct
         Ext_attrs.has_doc ea || (List.exists ~f:Attr.is_doc) atrs
     | Psig_type (_, [])
      |Psig_typesubst []
-     |Psig_jkind _
      |Psig_recmodule []
      |Psig_class_type []
      |Psig_class []
@@ -571,6 +572,7 @@ module Signature_item = struct
       | Psig_value _, Psig_value _
        |( (Psig_type _ | Psig_typesubst _ | Psig_typext _)
         , (Psig_type _ | Psig_typesubst _ | Psig_typext _) )
+       |Psig_jkind _, Psig_jkind _
        |Psig_exception _, Psig_exception _
        |( ( Psig_module _ | Psig_modsubst _ | Psig_recmodule _ | Psig_open _
           | Psig_include _ )

--- a/test/passing/tests/abstract_kinds-erased.ml.ref
+++ b/test/passing/tests/abstract_kinds-erased.ml.ref
@@ -2,6 +2,8 @@
 
 (** Doc comment 1 *)
 
+(* Consecutive short kinds *)
+
 (* a b c d e f g *)
 
 (* A normal comment 1 *)

--- a/test/passing/tests/abstract_kinds.ml
+++ b/test/passing/tests/abstract_kinds.ml
@@ -2,6 +2,13 @@
 
 (** Doc comment 1 *)
 
+(* Consecutive short kinds *)
+
+kind_ k1 = k1
+kind_ k2 = k2
+kind_ k3 = k3
+kind_ k4 = k4
+
 kind_ k =
   (* a b c d e f g *)
   (kind1 & (kind2

--- a/test/passing/tests/abstract_kinds.ml.js-ref
+++ b/test/passing/tests/abstract_kinds.ml.js-ref
@@ -2,6 +2,16 @@
 
 (** Doc comment 1 *)
 
+(* Consecutive short kinds *)
+
+kind_ k1 = k1
+
+kind_ k2 = k2
+
+kind_ k3 = k3
+
+kind_ k4 = k4
+
 kind_ k =
   (* a b c d e f g *)
   (kind1

--- a/test/passing/tests/abstract_kinds.ml.js-ref
+++ b/test/passing/tests/abstract_kinds.ml.js-ref
@@ -5,11 +5,8 @@
 (* Consecutive short kinds *)
 
 kind_ k1 = k1
-
 kind_ k2 = k2
-
 kind_ k3 = k3
-
 kind_ k4 = k4
 
 kind_ k =
@@ -470,13 +467,11 @@ kind_ k =
   (* 209 *)
   (* 210 *)
   ttttttttttttttttttt
+
 (* 208 *)
 (* 207 *)
-
 kind_ k = (* 212 *) kk
-
 kind_ k = (* 215 *) kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk (* 214 *)
-
 kind_ k = _
 (* 224 *)
 (* 223 *)
@@ -577,15 +572,12 @@ kind_ k =
 (* 287 *)
 
 kind_ k = (* 303 *) kk
+
 (* 302 *)
 (* 300 *)
-
 kind_ k = (* 307 *) _ (* 306 *)
-
 kind_ k = (* 310 *) kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk (* 309 *)
-
 kind_ k = (* 319 *) _ (* 318 *)
-
 kind_ k = (* 320 *) kkkkkkkkkkkkkkkkkkkkk
 
 kind_ k =
@@ -643,10 +635,10 @@ kind_ k =
   mod (* 359 *) mmmm (* 349 *)
 
 kind_ k = _
+
 (* 363 *)
 (* 362 *)
 (* 361 *)
-
 kind_ k =
   kind_of_
   (* 372 *)
@@ -715,18 +707,13 @@ kind_ k =
 
 (* Prefix [@foo] attributes on abstract kinds *)
 kind_ k [@@foo]
-
 kind_ k [@@foo] [@@bar]
-
 kind_ k [@@foo]
-
 kind_ k [@@foo "payload"]
 
 (* Prefix [@foo] attributes on kind abbreviations *)
 kind_ k = kkkkkkkkkkkkk [@@foo]
-
 kind_ k = kkkkkkkkkkkkk mod mmmmmm [@@foo] [@@bar]
-
 kind_ k = kind_of_ ttttttt & kkkkkkkkkkkkkkkkkkkkkk [@@foo]
 
 kind_ k = (kkkkkkkkkkkkkkkkkkkk & kind_of_ tttttttt) mod mmmmmmmmmmmmmmmmmmm
@@ -734,23 +721,17 @@ kind_ k = (kkkkkkkkkkkkkkkkkkkk & kind_of_ tttttttt) mod mmmmmmmmmmmmmmmmmmm
 
 (* Post-item [@@foo] attributes on abstract kinds *)
 kind_ k [@@foo]
-
 kind_ k [@@foo] [@@bar]
-
 kind_ k [@@foo "payload"]
-
 kind_ k [@@deprecated "use [k1] instead"]
 
 (* Post-item [@@foo] attributes on kind abbreviations *)
 kind_ k = kkkkkkkkkkkkkkkkkkkkk [@@foo]
-
 kind_ k = kkkkkkkkkkkkkkkkkkkkk mod mmmmmmm [@@foo] [@@bar]
-
 kind_ k = kkkkkkkkkkkkkkkkkkk & kind_of_ ttttttttttttt [@@deprecated "use [k1] instead"]
 
 (* Both prefix and post attributes *)
 kind_ k [@@foo] [@@bar]
-
 kind_ k = kkkkkkkkkkkkkkkkkkkk mod mmmmmm [@@foo] [@@bar]
 
 (* Long kind with attributes that may break *)
@@ -781,22 +762,15 @@ module _ = struct
 
   (* Comment for abstract kind *)
   kind_ kk
-
   kind_ k1
-
   kind_ k2
 
   (* Attributes inside struct *)
   kind_ k [@@foo]
-
   kind_ k [@@foo]
-
   kind_ k [@@foo]
-
   kind_ k = kkkkkkkkkkkkkkkk mod mmmmmm [@@foo]
-
   kind_ k = kkkkkkkkkkkkkkkk mod mmmmmm [@@foo]
-
   kind_ k = kkkkkkkkkkkkk & kind_of_ ttttttt [@@foo] [@@bar]
 
   kind_ k =
@@ -869,7 +843,6 @@ module _ = struct
            mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm)
 
   kind_ k = _
-
   kind_ k = _
 
   kind_ k =
@@ -1038,9 +1011,7 @@ module _ = struct
         mod mmmmmmmmmmmmmmmmmmmmmm mmmmmmmmmmmmmmmmmmmmmmmmmmmmmm)
 
   kind_ k = (* 415 *) _ (* 414 *)
-
   kind_ k = (* 416 *) kkkkkkkkkkkkkkkkkkkkkkkkkkkkkk
-
   kind_ k = (* 418 *) _ (* 417 *)
 
   kind_ k =
@@ -1048,9 +1019,9 @@ module _ = struct
     (* 880 *)
     (* 881 *)
     t
+
   (* 879 *)
   (* 878 *)
-
   kind_ k =
     kind_of_
     (* 884 *)
@@ -1139,7 +1110,6 @@ module _ = struct
        mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
 
   kind_ k = (* 949 *) _ (* 948 *)
-
   kind_ k = (* 950 *) kkkkkkkkkkkkkkkkkkkkkk
 end
 
@@ -1150,22 +1120,15 @@ module type S = sig
 
   (* Comment for abstract kind *)
   kind_ kk
-
   kind_ k1
-
   kind_ k2
 
   (* Attributes inside sig *)
   kind_ k [@@foo]
-
   kind_ k [@@foo]
-
   kind_ k [@@foo]
-
   kind_ k = kkkkkkkkkkkkkkkk mod mmmmmm [@@foo]
-
   kind_ k = kkkkkkkkkkkkkkkk mod mmmmmm [@@foo]
-
   kind_ k = kkkkkkkkkkkkk & kind_of_ ttttttt [@@foo] [@@bar]
 
   kind_ k =
@@ -1298,7 +1261,6 @@ module type S = sig
     mod mmmmmm mmmmmmmmmmmmm mmmmmmmmmmmmm mmmmmmmmmmmmmmm
 
   kind_ k = kkkkkkkkkkkkkkkkkkkkkkkkkkkkk
-
   kind_ k = kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk mod mmmmmmmmmmm
 
   kind_ k =
@@ -1325,7 +1287,6 @@ module type S = sig
        mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm
 
   kind_ k = kkkkkkkkkkkkkkkkkkkkk
-
   kind_ k = (kkkkkkkkkkkkkkkkkkkkkkkkkkkkkk & kkkkkk & _) mod mmmmmm
 
   kind_ k =

--- a/test/passing/tests/abstract_kinds.ml.ref
+++ b/test/passing/tests/abstract_kinds.ml.ref
@@ -2,6 +2,16 @@
 
 (** Doc comment 1 *)
 
+(* Consecutive short kinds *)
+
+kind_ k1 = k1
+
+kind_ k2 = k2
+
+kind_ k3 = k3
+
+kind_ k4 = k4
+
 kind_ k =
   (* a b c d e f g *)
   (kind1


### PR DESCRIPTION
Small styling fix post-#141: short kinds now are formatted on adjacent lines in compact mode, just like types.